### PR TITLE
Make incluedes optional for helm

### DIFF
--- a/dist/helm/Makefile
+++ b/dist/helm/Makefile
@@ -1,5 +1,5 @@
 include ../Makefile.helpers
-include Makefile.*
+-include Makefile.*
 
 ## Init the client & server
 init:


### PR DESCRIPTION
## what
* make `include` optional

## why
* currently no additional includes in helm dir

## who
@cloudposse/engineering 