### PR TITLE
Add a method to update geodesic

### DIFF
--- a/dist/contrib/geodesic
+++ b/dist/contrib/geodesic
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Please run the following commands to start the geodesic shell (modify as necessary)
-DOCKER_IMAGE=${DOCKER_IMAGE:-cloudposse/geodesic}
-DOCKER_TAG=${DOCKER_TAG:-latest}
-DOCKER_NAME=${DOCKER_NAME:-geodesic}
+export DOCKER_IMAGE=${DOCKER_IMAGE:-cloudposse/geodesic}
+export DOCKER_TAG=${DOCKER_TAG:-latest}
+export DOCKER_NAME=${DOCKER_NAME:-geodesic}
+
 STATE_DIR=${STATE_DIR:-${HOME}/.geodesic}
 OS=$(uname -s)
 mkdir -p ${STATE_DIR}
@@ -10,6 +11,17 @@ mkdir -p ${STATE_DIR}
 if ! which docker > /dev/null; then
   echo "Cannot find docker installed on this system. Please install and try again."
   exit 1
+fi
+
+if [ "$1" == "update" ]; then
+  curl --silent --fail https://geodesic.sh | bash
+  if [ $? -eq 0 ]; then
+    echo "# ${DOCKER_NAME}:${DOCKER_TAG} has been updated."
+    exit 0
+  else
+    echo "Failed to update geodesic"
+    exit 1
+  fi
 fi
 
 if [ -t 1 ]; then

--- a/public/install.sh
+++ b/public/install.sh
@@ -26,6 +26,10 @@ fi
 echo "# Installing ${APP_NAME} from ${DOCKER_IMAGE}:${DOCKER_TAG}..."
 if [ "${REQUIRE_PULL}" == "true" ]; then
   docker pull "${DOCKER_IMAGE}:${DOCKER_TAG}"
+  if [ $? -ne 0 ]; then
+    echo "Failed to pull down ${DOCKER_IMAGE}:${DOCKER_TAG}"
+    exit 1
+  fi
 fi 
 
 # Sometimes docker might not exit cleanly 


### PR DESCRIPTION
## what
* add support for `geodesic update` which pulls down the latest version from https://geodesic.sh

## why
* make upgrades easier

## testing
* `make build install`
* `geodesic update`
* after you run the above command, it will install the latest version on `geodesic.sh` which is older than the version you installed (since this is not on master yet)

## who
@goruha 