### PR TITLE
Add User for Each Cluster Repo

### DIFF
--- a/etc/profile.d/prompt.sh
+++ b/etc/profile.d/prompt.sh
@@ -22,7 +22,7 @@ function geodesic-prompt() {
 
   # Augment prompt (PS1) with some geodesic state information
   if [ -d "${CLUSTER_REPO_PATH}/.git" ]; then
-    GIT_STATE=$(git -C ${CLUSTER_REPO_PATH} diff-files --no-ext-diff --quiet)
+    GIT_STATE=$(git -C ${CLUSTER_REPO_PATH} diff-files --no-ext-diff)
     STATUS="\[✅\]";
     if [ -n "${GIT_STATE}" ]; then
       STATUS="\[❌\]"

--- a/modules/config/Makefile
+++ b/modules/config/Makefile
@@ -92,6 +92,7 @@ mount: validate
 	@mkdir -p $(dir $(KUBECONFIG))
 	@mkdir -p $(KOPS_STATE_PATH)
 	@[ ! -f "${KOPS_STATE_PATH}/id_rsa" ] || cloud kops add-ssh-key
+	@source $(CLOUD_CONFIG) && cloud hub deps
 
 ## Unmount remote cluster state bucket
 unmount:

--- a/modules/hub/Makefile
+++ b/modules/hub/Makefile
@@ -6,18 +6,21 @@ MESSAGE ?= Automatic commit
 REMOTE ?= origin
 BRANCH ?= master
 
+deps: 
+	@ls -1 $(LOCAL_STATE)/clusters/ | xargs -I '{}' adduser -h $(LOCAL_STATE)/clusters/{} -s /sbin/nologin -g 'Cluster Repo' -D -H {} >/dev/null 2>&1 || true
+
 validate:
 	$(call assert-set,CLUSTER_NAME)
 
 ## Create a new private cluster repo
-create: validate test
+create: validate test deps
 	@[ -d $(CLUSTER_REPO_PATH) ] || mkdir -p $(CLUSTER_REPO_PATH)
 	@[ -d $(CLUSTER_REPO_PATH)/.git ] || git -C $(CLUSTER_REPO_PATH) init
 	@cd $(CLUSTER_REPO_PATH) && \
 		hub create -p -d "Geodesic cluster configuration for $(CLUSTER_NAME)" $(GITHUB_ORG)/$(CLUSTER_NAME) 
 
 ## Clone an existing cluster repo
-clone: validate test
+clone: validate test deps
 	$(call assert-set,GITHUB_ORG)
 	@git clone -b $(BRANCH) git@github.com:$(GITHUB_ORG)/$(CLUSTER_NAME) $(CLUSTER_REPO_PATH)
 	@cloud hub pull
@@ -31,12 +34,12 @@ update:
 	fi
 
 ## Pull down updates
-pull: validate test
+pull: validate test deps
 	@git -C $(CLUSTER_REPO_PATH) pull $(REMOTE) $(BRANCH)
 	@git -C $(CLUSTER_REPO_PATH) submodule update --init --remote
 
 ## Push changes to github
-push: validate test
+push: validate test deps
 	@git -C $(CLUSTER_REPO_PATH) push $(REMOTE) $(BRANCH)
 
 ## Commit changes 


### PR DESCRIPTION
## what
* create a user for each cluster in `/etc/passwd`

## why
* support `cd ~cluster` (e.g. `cd ~demo<tab>`)
* fewer key strokes to get into a cluster config

## who
@goruha 