### PR TITLE
Fix Argument Parsing

### DIFF
--- a/bin/cloud
+++ b/bin/cloud
@@ -19,7 +19,7 @@ function options_to_env() {
     k=${k^^}      # Convert to uppercase
 
     v=${kv[1]}    # Treat second element as value
-    v=${kv:-true} # Set it to true for boolean flags
+    v=${v:-true}  # Set it to true for boolean flags
 
     env="$k=$v"
     envs+=("$env")


### PR DESCRIPTION
## what
* default value of `true` was incorrectly being set to `v`

## why
* `kv` is an array, not a scalar; meant to use `v`

## who
@goruha 