### PR TITLE
Load a cluster-specific .bashrc file if one exists

### DIFF
--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -10,6 +10,14 @@ function reload() {
   if [ -f "/etc/profile.d/defaults.sh" ]; then
     . "/etc/profile.d/defaults.sh"
   fi
+
+  # Load a Cluster .bashrc (if one exists & not already loaded)
+  if [ -f "${CLUSTER_REPO_PATH}/.bashrc" ]; then
+    if [ "${CLUSTER_REPO_PATH_BASHRC}" != "${CLUSTER_REPO_PATH}/.bashrc" ]; then
+      CLUSTER_REPO_PATH_BASHRC="${CLUSTER_REPO_PATH}/.bashrc"
+      . "${CLUSTER_REPO_PATH_BASHRC}"
+    fi
+  fi
 }
 
 # Define our own prompt


### PR DESCRIPTION
## what
* `source` a cluster-specific `.bashrc` file if one exists had hasn't already been loaded

## why
* make it easier to define cluster-specific shortcuts or aliases (E.g. `alias cloudposse=kubectl --namespace=cloudposse`)

## who
@goruha 