### PR TITLE
iTerm Integration

### DIFF
--- a/rootfs/etc/profile.d/defaults.sh
+++ b/rootfs/etc/profile.d/defaults.sh
@@ -77,4 +77,5 @@ export TF_BUCKET_PREFIX=geodesic/terraform
 #
 export CLOUD_CONFIG=${REMOTE_STATE}/env
 export CLOUD_CONFIG_SAMPLE=${GEODESIC_PATH}/modules/config/env.sample
+export SHELL_NAME=Geodesic
 

--- a/rootfs/etc/profile.d/iterm.sh
+++ b/rootfs/etc/profile.d/iterm.sh
@@ -1,0 +1,15 @@
+set_badge() {
+  if [ "${TERM_PROGRAM}" == "iTerm.app" ]; then
+    printf "\e]1337;SetBadgeFormat=%s\a" $(echo "$1" | base64)
+  fi
+}
+
+## Display an exit greeting
+function _exit() {
+  set_badge ""
+  echo 'Goodbye'
+  exit 0
+}
+trap _exit EXIT
+
+set_badge "${SHELL_NAME}"

--- a/rootfs/opt/geodesic
+++ b/rootfs/opt/geodesic
@@ -48,7 +48,7 @@ fi
 
 if [ -t 1 ]; then
   # Running in terminal 
-  DOCKER_ARGS=(-it --rm --name="${DOCKER_NAME}-bootstrap" --env LS_COLORS --env TERM --env TERM_COLOR)
+  DOCKER_ARGS=(-it --rm --name="${DOCKER_NAME}-bootstrap" --env LS_COLORS --env TERM --env TERM_COLOR --env TERM_PROGRAM)
 
   if [ -n "$SSH_AUTH_SOCK" ]; then
     if [ `uname -s` == 'Darwin' ]; then


### PR DESCRIPTION
## what
* Display brand-able terminal description that defaults to "Geodesic"
   ![image](https://cloud.githubusercontent.com/assets/52489/23437266/4ddcbb08-fdc2-11e6-828f-99a424ff485d.png)

## why
* Make it more clear that you're in a Geodesic shell

## caveats
* Only works in `iTerm.app` (which is the most common 3rd party terminal app for OSX; typically used by power users)

## who
@goruha  