### PR TITLE
Use travis-ci.org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "aws-assumed-role"]
-	path = aws-assumed-role
-	url = git@github.com:cloudposse/aws-assumed-role.git
 [submodule "dist/charts"]
 	path = dist/charts
 	url = git@github.com:cloudposse/charts.git
+[submodule "aws-assumed-role"]
+	path = aws-assumed-role
+	url = https://github.com/cloudposse/aws-assumed-role.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "dist/charts"]
-	path = dist/charts
-	url = git@github.com:cloudposse/charts.git
 [submodule "aws-assumed-role"]
 	path = aws-assumed-role
 	url = https://github.com/cloudposse/aws-assumed-role.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+#
+# CI/CD configuration for https://travis-ci.org/cloudposse/geodesic/
+#
 sudo: required
 addons:
   apt:


### PR DESCRIPTION
## what
* Update submodules to use `https://` instead of `git://`
* Describe `.travis.yaml`

## why
* Greater transparency (previously used privately hosted travis-ci.com)

## who
@goruha 
