### PR TITLE
Fix `cloud config mount` with Assumed Roles

### DIFF
--- a/rootfs/usr/local/include/toolbox/config/Makefile
+++ b/rootfs/usr/local/include/toolbox/config/Makefile
@@ -84,7 +84,7 @@ destroy-bucket: validate
 ## Mount remote cluster state bucket
 mount: validate 
 	@mkdir -p $(REMOTE_MOUNT_POINT)
-ifeq ($(AWS_ASSUME_ROLE_ARN),)
+ifeq ($(AWS_IAM_ROLE_ARN),)
 # Support standard AWS credentials
 	@echo "$(AWS_ACCESS_KEY_ID):$(AWS_SECRET_ACCESS_KEY)" > /dev/shm/passwd-s3fs
 	@chmod 600 /dev/shm/passwd-s3fs


### PR DESCRIPTION
## what
* Use AWS_IAM_ROLE_ARN variable

## why
* Wrong variable name was used and it broke mounting of buckets when assumed roles were used