### PR TITLE
Disable IPv6 for Helm Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk update \
           openssl openssh-client iputils drill \
           git coreutils less groff bash-completion hub hub-bash-completion && \
           mkdir /etc/bash_completion.d/
+	  
+RUN echo "0" > /proc/sys/net/ipv6/conf/all/disable_ipv6
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update \
           git coreutils less groff bash-completion hub hub-bash-completion && \
           mkdir /etc/bash_completion.d/
 	  
-RUN echo "0" > /proc/sys/net/ipv6/conf/all/disable_ipv6
+RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf
 
 USER root
 


### PR DESCRIPTION
## What
* Disable IPv6 

## Why
* Fix helm error `E0702 16:53:48.804933     363 portforward.go:209] Unable to create listener: Error listen tcp6 [::1]:37117: bind: cannot assign requested address`