### PR TITLE
typo fix in 'cloud config reset' command

### DIFF
--- a/rootfs/usr/local/include/toolbox/config/Makefile
+++ b/rootfs/usr/local/include/toolbox/config/Makefile
@@ -37,7 +37,7 @@ edit: init require-cluster-mounted
 
 ## Reset local state
 reset: require-cluster-mounted
-	@rf -rf $(REMOTE_STATE)/* $(REMOTE_STATE)/.bootstrapped
+	@rm -rf $(REMOTE_STATE)/* $(REMOTE_STATE)/.bootstrapped
 	@rm -f $(LOCAL_STATE)/history
 	@cloud config init
 	@echo "Reset local state"


### PR DESCRIPTION
# What

- fix typo in `toolbox/config` Makefile

# Why 

- fix command `cloud config reset`