### PR TITLE
avoid travis run tasks related to secured data on PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 - docker
 install:
 - make init
-- make docker:login
+- 'if [ "$TRAVIS_PULL_REQUEST" != "true" ]; then make docker:login; fi'
 
 script:
 - make deps
@@ -22,7 +22,7 @@ script:
 - make docker:build
 
 after_success:
-- make travis:docker-tag-and-push
+- 'if [ "$TRAVIS_PULL_REQUEST" != "true" ]; then make travis:docker-tag-and-push; fi'
 
 deploy:
   # Deploy to dev (branch)


### PR DESCRIPTION
# What:

- added conditions to steps related to secured data

# Why:

- travis do not send encrypted variables to untrusted PR's (from forked repo's)