### PR TITLE
Removed all references to CLOUD_CONFIG and CLOUD_CONFIG_SAMPLE vars

### DIFF
--- a/rootfs/etc/profile.d/defaults.sh
+++ b/rootfs/etc/profile.d/defaults.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Setup some default envs
 export LESS=-Xr
 
@@ -75,7 +77,5 @@ export TF_BUCKET_PREFIX=geodesic/terraform
 #
 # Geodesic
 #
-export CLOUD_CONFIG=${REMOTE_STATE}/env
-export CLOUD_CONFIG_SAMPLE=${GEODESIC_PATH}/config/env.sample
 export SHELL_NAME=Geodesic
 

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -1,14 +1,8 @@
+#!/usr/bin/env bash
 # Allow bash to check the window size to keep prompt with relative to window size
 shopt -s checkwinsize
 
 function reload() {
-# Load cluster env
-  if [ -f "${CLOUD_CONFIG}" ]; then
-    set -o allexport
-    . "${CLOUD_CONFIG}"
-    set +o allexport
-  fi
-
   # Reprocess defaults
   if [ -f "/etc/profile.d/defaults.sh" ]; then
     . "/etc/profile.d/defaults.sh"
@@ -24,13 +18,13 @@ function reload() {
   eval $(resize)
 }
 
+
 # Define our own prompt
 function geodesic-prompt() {
   reload
 
   # Run the aws-assume-role prompt
   console-prompt
-
 
   # Augment prompt (PS1) with some geodesic state information
   if [ -d "${CLUSTER_REPO_PATH}/.git" ]; then
@@ -47,5 +41,3 @@ function geodesic-prompt() {
 }
 
 export PROMPT_COMMAND=geodesic-prompt
-
-


### PR DESCRIPTION
## What
* Removed all references to CLOUD_CONFIG and CLOUD_CONFIG_SAMPLE vars.

## Why
* These vars are not used anymore in the new geodesic version with Docker inheritance.
