### PR TITLE
Fix ENV vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Docker can be easily installed by following the instructions for your OS:
    ```
 
 
-4. Run `geodesic use aws.example.com` to start the geodesic shell for that cluster
+4. Run `geodesic use --name aws.example.com` to start the geodesic shell for that cluster
 5. Run `cloud create` to run through configuration steps
 6. Run `cloud up` to provision the cluster
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Docker can be easily installed by following the instructions for your OS:
    ```
 
 
-4. Run `geodesic use --name aws.example.com` to start the geodesic shell for that cluster
+4. Run `geodesic use --name=aws.example.com` to start the geodesic shell for that cluster
 5. Run `cloud create` to run through configuration steps
 6. Run `cloud up` to provision the cluster
 

--- a/rootfs/usr/local/include/toolbox/kops/Makefile.defaults
+++ b/rootfs/usr/local/include/toolbox/kops/Makefile.defaults
@@ -1,7 +1,6 @@
 export KOPS_BIN ?= kops
 
 export KOPS_REGION ?= $(AWS_REGION)
-
 export KOPS_DNS_ZONE ?= $(CLUSTER_DNS_ZONE)
 export KOPS_NAME ?= $(CLUSTER_NAME)
 
@@ -10,12 +9,7 @@ export KOPS_STATE_STORE ?= s3://$(CLUSTER_STATE_BUCKET)
 
 export KOPS_CLOUD ?= aws
 export KOPS_ZONES ?= $(AWS_REGION)a
-
-export KOPS_MASTER_SIZE ?= t2.medium
 export KOPS_MASTER_ZONES ?= $(KOPS_ZONES)
-
-export KOPS_NODE_SIZE ?= t2.medium
-export KOPS_NODE_COUNT ?= 3
 
 export KOPS_ASSOCIATE_PUBLIC_IP ?= true
 


### PR DESCRIPTION
## What
* Removed ```KOPS_MASTER_SIZE, KOPS_NODE_SIZE, KOPS_NODE_COUNT``` from toolbox/kops/Makefile.defaults.
* Fixed ```geodesic use --name``` in README.md

## Why
* The vars ```KOPS_MASTER_SIZE, KOPS_NODE_SIZE, KOPS_NODE_COUNT``` are cluster-specific (user-configurable) and should not be declared in the generic geodesic Docker image.
* ```geodesic use``` requires the name of the cluster specified via the ```name``` parameter
