### PR TITLE
Add default ansible.cfg

### DIFF
--- a/rootfs/etc/ansible/ansible.cfg
+++ b/rootfs/etc/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+roles_path = ./roles
+inventory = ./inventory
+host_key_checking = False
+hash_behaviour = merge
+timeout = 60


### PR DESCRIPTION
## What

* Add default ansible.cfg

## Why

* ansible.cfg can be absent in playbook directory  
