### PR TITLE
Only use-profile if AWS configured

### DIFF
--- a/rootfs/etc/profile.d/use-profile.sh
+++ b/rootfs/etc/profile.d/use-profile.sh
@@ -1,3 +1,3 @@
-if [ -n "${AWS_PROFILE}" ]; then
+if [ -n "${AWS_PROFILE}" ] && [ -f "${AWS_CONFIG_FILE}" ] &&  [ -f "${AWS_SHARED_CREDENTIALS_FILE}" ]; then
   use-profile
 fi


### PR DESCRIPTION
## what
* Check if AWS configs exist before attempting to call `use-profile`

## why
* See: https://github.com/cloudposse/geodesic/issues/73
* Without this fix, if AWS cli was not configured, the shell would immediately exit
* Bug affected new users (cold-start problem)