### PR TITLE
Fix utf-8 prompt

### DIFF
--- a/rootfs/etc/profile.d/locale.sh
+++ b/rootfs/etc/profile.d/locale.sh
@@ -1,0 +1,3 @@
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -29,12 +29,13 @@ function geodesic-prompt() {
   BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 '
   TWO_JOINED_SQUARES=$'\u29C9 '
   CROSS_MARK=$'\u274C '
-  STATUS=${CROSS_MARK}
 
   if [ -z "$AWS_IAM_ROLE_ARN" ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}
   elif [ $AWS_SESSION_TTL -gt 0 ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}
+  else
+    STATUS=${CROSS_MARK}
   fi
 
   if [ -n "${CLUSTER_NAME}" ]; then

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -32,7 +32,7 @@ function geodesic-prompt() {
 
   if [ -n "$AWS_IAM_ROLE_ARN" ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}
-  elif [ $AWS_SESSION_TTL -gt 0 ]; then
+  elif [ $AWS_SESSION_TTL -gt 0 ] && [ -n $AWS_SESSION_TOKEN ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}
   else
     STATUS=${CROSS_MARK}

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -31,11 +31,11 @@ function geodesic-prompt() {
   CROSS_MARK=$'\u274C '
 
   if [ -n "$AWS_IAM_ROLE_ARN" ]; then
-    STATUS=${WHITE_HEAVY_CHECK_MARK}
-  elif [ $AWS_SESSION_TTL -gt 0 ] && [ -n $AWS_SESSION_TOKEN ]; then
-    STATUS=${WHITE_HEAVY_CHECK_MARK}
+    export STATUS=${WHITE_HEAVY_CHECK_MARK}
+  elif [ $AWS_SESSION_TTL -gt 0 ] && [ -n "$AWS_SESSION_TOKEN" ]; then
+    export STATUS=${WHITE_HEAVY_CHECK_MARK}
   else
-    STATUS=${CROSS_MARK}
+    export STATUS=${CROSS_MARK}
   fi
 
   if [ -n "${CLUSTER_NAME}" ]; then

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -25,18 +25,18 @@ function geodesic-prompt() {
 
   # Run the aws-assume-role prompt
   console-prompt
-
-  # Augment prompt (PS1) with some geodesic state information
-  if [ -d "${CLUSTER_REPO_PATH}/.git" ]; then
-    GIT_STATE=$(git -C ${CLUSTER_REPO_PATH} diff-files --no-ext-diff)
-    STATUS="\[✅\]";
-    if [ -n "${GIT_STATE}" ]; then
-      STATUS="\[❌\]"
-    fi
-  fi
+  WHITE_HEAVY_CHECK_MARK=$'\u2705 '
+  BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 '
+  TWO_JOINED_SQUARES=$'\u29C9 '
+  CROSS_MARK=$'\u274C '
 
   if [ -n "${CLUSTER_NAME}" ]; then
-    PS1=" \[⧉\] ${CLUSTER_NAME}\n$STATUS  $ROLE_PROMPT \W \[➤\] "
+    if [ $AWS_SESSION_TTL -le 0 ]; then
+      STATUS=${CROSS_MARK}
+    else
+      STATUS=${WHITE_HEAVY_CHECK_MARK}
+    fi
+    PS1=$' ${TWO_JOINED_SQUARES}'" ${CLUSTER_NAME}\n"$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
   fi
 }
 

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -25,13 +25,15 @@ function geodesic-prompt() {
 
   # Run the aws-assume-role prompt
   console-prompt
-  local WHITE_HEAVY_CHECK_MARK=$'\u2705 '
-  local BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 '
-  local TWO_JOINED_SQUARES=$'\u29C9 '
-  local CROSS_MARK=$'\u274C '
-  local STATUS=${CROSS_MARK}
+  WHITE_HEAVY_CHECK_MARK=$'\u2705 '
+  BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 '
+  TWO_JOINED_SQUARES=$'\u29C9 '
+  CROSS_MARK=$'\u274C '
+  STATUS=${CROSS_MARK}
 
-  if [ $AWS_SESSION_TTL -gt 0 ]; then
+  if [ -z "$AWS_IAM_ROLE_ARN" ]; then
+    STATUS=${WHITE_HEAVY_CHECK_MARK}
+  elif [ $AWS_SESSION_TTL -gt 0 ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}
   fi
 

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -25,19 +25,22 @@ function geodesic-prompt() {
 
   # Run the aws-assume-role prompt
   console-prompt
-  WHITE_HEAVY_CHECK_MARK=$'\u2705 '
-  BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 '
-  TWO_JOINED_SQUARES=$'\u29C9 '
-  CROSS_MARK=$'\u274C '
+  local WHITE_HEAVY_CHECK_MARK=$'\u2705 '
+  local BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 '
+  local TWO_JOINED_SQUARES=$'\u29C9 '
+  local CROSS_MARK=$'\u274C '
+  local STATUS=${CROSS_MARK}
+
+  if [ $AWS_SESSION_TTL -gt 0 ]; then
+    STATUS=${WHITE_HEAVY_CHECK_MARK}
+  fi
 
   if [ -n "${CLUSTER_NAME}" ]; then
-    if [ $AWS_SESSION_TTL -le 0 ]; then
-      STATUS=${CROSS_MARK}
-    else
-      STATUS=${WHITE_HEAVY_CHECK_MARK}
-    fi
     PS1=$' ${TWO_JOINED_SQUARES}'" ${CLUSTER_NAME}\n"$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
+  else
+    PS1=$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
   fi
+  export PS1
 }
 
 export PROMPT_COMMAND=geodesic-prompt

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -30,7 +30,7 @@ function geodesic-prompt() {
   TWO_JOINED_SQUARES=$'\u29C9 '
   CROSS_MARK=$'\u274C '
 
-  if [ -z "$AWS_IAM_ROLE_ARN" ]; then
+  if [ -n "$AWS_IAM_ROLE_ARN" ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}
   elif [ $AWS_SESSION_TTL -gt 0 ]; then
     STATUS=${WHITE_HEAVY_CHECK_MARK}

--- a/rootfs/usr/local/include/terraform/apply
+++ b/rootfs/usr/local/include/terraform/apply
@@ -1,6 +1,8 @@
 include terraform/plan
 
+TF_PARALLELISM ?= 10
+
 ## Apply pending changes
 apply: plan
 	@confirm CLUSTER_NAME
-	@terraform apply -input=false $(TF_STATE_DIR)/terraform.out
+	@terraform apply -parallelism=$(TF_PARALLELISM) -input=false $(TF_STATE_DIR)/terraform.out


### PR DESCRIPTION
## what
* Use special `bash` 3.2+ feature for outputting `utf8` characters (`$'\uXXXX'`)
* Explicitly set locale (sorry, hardcoded to `en_US.utf8`)

## why
* This seems to fix the prompt line wrapping problems
* `\[....\]` does not help with `utf8` characters (only `ansi`)

![image](https://user-images.githubusercontent.com/52489/31008215-1e94f8e0-a4b8-11e7-9137-709c252b7727.png)
