### PR TITLE
Install aws-assumed-role with curl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "aws-assumed-role"]
-	path = aws-assumed-role
-	url = https://github.com/cloudposse/aws-assumed-role.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,12 @@ ENV GOMPLATE_VERSION 2.2.0
 RUN curl --fail -sSL -o /usr/local/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim \
     && chmod +x /usr/local/bin/gomplate
 
+# Install AWS Assumed Role
+ENV AWS_ASSUMED_ROLE_VERSION 0.1.0
+RUN mkdir -p /etc/profile.d \
+    && curl --fail -sSL -o /etc/profile.d/aws-assume-role.sh https://raw.githubusercontent.com/cloudposse/aws-assumed-role/0.1.0/profile \
+    && chmod +x /etc/profile.d/aws-assume-role.sh
+
 ENV BOOTSTRAP=true
 
 # Where to store state
@@ -142,7 +148,6 @@ ENV HOME=/mnt/local
 
 VOLUME ["/mnt/local"]
 
-ADD aws-assumed-role/profile /etc/profile.d/aws-assume-role.sh
 ADD rootfs/ /
 
 WORKDIR /mnt/local

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	@make bash:lint
 
 deps:
-	@make --no-print-directory git:submodules-update
+	@exit 0
 
 build:
 	@make --no-print-directory docker:build


### PR DESCRIPTION
## what
* Drop the git submodule for `aws-assumed-role`
* Install script the way we do all of our other dependencies

## why
* Consistency
* Submodules add undo complexity
 