### PR TITLE
Block Until Filesystem Mounted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,6 @@ ENV MOTD_URL=http://geodesic.sh/motd
 ENV HOME=/mnt/local
 
 VOLUME ["/mnt/local"]
-VOLUME ["/mnt/remote"]
 
 ADD rootfs/ /
 

--- a/rootfs/usr/local/include/toolbox/config/Makefile
+++ b/rootfs/usr/local/include/toolbox/config/Makefile
@@ -71,6 +71,7 @@ destroy-bucket: validate
 mount: validate
 	@mkdir -p $(REMOTE_MOUNT_POINT)
 	@(nohup goofys -f --file-mode=0600 --region ${CLUSTER_STATE_BUCKET_REGION} --sse $(CLUSTER_STATE_BUCKET) ${REMOTE_MOUNT_POINT}) 2>&1 >>/var/log/goofys.log 2>&1 &
+	@until mountpoint -q ${REMOTE_MOUNT_POINT}; do sleep 0.250; done
 	@echo "Mounted $(CLUSTER_STATE_BUCKET) to $(REMOTE_MOUNT_POINT)"
 	@mkdir -p $(REMOTE_STATE)
 	@mkdir -p $(dir $(KUBECONFIG))


### PR DESCRIPTION
## what
* Sleep until `/mnt/remote` is mounted
* Remove the `VOLUME` for `/mnt/remote`

## why
* Previous command is run in the background 
* Need to operate asynchronously as we don't know when the filesystem will be mounted
* The `VOLUME` statement caused `/mnt/remote` to always report as `mountpoint` even if it was not mounted
