### PR TITLE
Support multiple projects (breaking change)

### DIFF
--- a/rootfs/etc/profile.d/defaults.sh
+++ b/rootfs/etc/profile.d/defaults.sh
@@ -72,7 +72,7 @@ export TF_STATE_FILE=${TF_STATE_DIR}/terraform.tfstate
 export TF_LOG=ERROR
 export TF_LOG_PATH=${TF_STATE_DIR}/terraform.log
 export TF_BUCKET=${CLUSTER_STATE_BUCKET}
-export TF_BUCKET_PREFIX=geodesic/terraform
+export TF_BUCKET_PREFIX=geodesic/terraform/$(basename `pwd`)
 
 #
 # Geodesic

--- a/rootfs/etc/profile.d/defaults.sh
+++ b/rootfs/etc/profile.d/defaults.sh
@@ -67,7 +67,7 @@ export KUBECONFIG=${REMOTE_STATE}/kubernetes/kubeconfig
 #
 # Terraform
 #
-export TF_STATE_DIR=${LOCAL_STATE}/terraform/${CLUSTER_NAME}
+export TF_STATE_DIR=${LOCAL_STATE}/terraform/${CLUSTER_NAME}/$(basename `pwd`)
 export TF_STATE_FILE=${TF_STATE_DIR}/terraform.tfstate
 export TF_LOG=ERROR
 export TF_LOG_PATH=${TF_STATE_DIR}/terraform.log


### PR DESCRIPTION
## what
 * namespace terraform remote state based on your current working directory

## why
* Support multiple terraform projects with state separated by directory (`pwd`)

## upgrading

State has moved to `s3://$bucket/geodesic/terraform/$project` where `project` is your current working directory
Rough upgrade steps:
```
# change to your terraform project directory
cd /conf/tf

# mount s3 state bucket
cloud config mount

# create new project state folder
mkdir -p /mnt/remote/geodesic/terraform/$(basename `pwd`)

# move your terraform state files
mv /mnt/remote/geodesic/terraform/*.tfstate /mnt/remote/geodesic/terraform/$(basename `pwd`)
```
