### PR TITLE
Fix HELM HOME

### DIFF
--- a/rootfs/etc/profile.d/defaults.sh
+++ b/rootfs/etc/profile.d/defaults.sh
@@ -31,7 +31,6 @@ fi
 #
 # Helm
 #
-export HELM_HOME=${REMOTE_STATE}/helm/
 export HELM_VALUES_PATH=${REMOTE_STATE}/helm/values
 
 #


### PR DESCRIPTION
## What
* Fix `HELM_HOME` env var

## Why
* On docker build helm plugins installed into directory that are not used later