### PR TITLE
README: Modify docker command to inline variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Docker can be easily installed by following the instructions for your OS:
    This will create a new project in your current working directory, complete with `Dockerfile` and `Makefile`.
 
    ```
-   docker run -e CLUSTER_NAME \
+   docker CLUSTER_NAME=$CLUSTER_NAME run -e CLUSTER_NAME \
               -e DOCKER_IMAGE=cloudposse/${CLUSTER_NAME} \
               -e DOCKER_TAG=dev \
               cloudposse/geodesic:latest -c new-project | tar -xv -C .


### PR DESCRIPTION
## what
* Inline the `CLUSTER_NAME` variable

## why
* Users utilizing sudo to run Docker need to inline the variable as this is not inherited by sudo
* Running docker with sudo is generally considered best practice since the "docker" group sometimes suggested to run docker as a non-root user is equivalent to root privileges. 

https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface
  