### PR TITLE
Fix timedrift

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -30,6 +30,13 @@ function assume-role() {
     echo "Usage: $0 [role]"
     return 1
   fi
+  # Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift
+  # (Only works in privileged mode)
+  hwclock -s >/dev/null 2>&1 
+  if [ $? -ne 0 ]; then
+    echo "* Failed to sync system time from hardware clock"
+  fi
+
   shift
   if [ $# -eq 0 ]; then
     aws-vault exec --assume-role-ttl=${AWS_VAULT_ASSUME_ROLE_TTL} $role -- bash -l

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -42,6 +42,8 @@ function geodesic_prompt() {
 
   if [ -n "${AWS_VAULT}" ]; then
     ROLE_PROMPT="(${AWS_VAULT})"
+  else
+    ROLE_PROMPT="(none)"
   fi
 
   if [ -n "${CLUSTER_NAME}" ]; then


### PR DESCRIPTION
## what
* Call `hwclock` to sync system time from hardware clock

## why
* Docker VM time drifts when laptop goes to sleep (known issue)
