### PR TITLE
Add support for aws-vault server mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,7 +211,6 @@ RUN curl --fail -sSL -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloa
 # AWS
 #
 ENV AWS_DATA_PATH=/localhost/.aws/
-ENV AWS_SHARED_CREDENTIALS_FILE=/localhost/.aws/credentials
 ENV AWS_CONFIG_FILE=/localhost/.aws/config
 
 #

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -34,7 +34,7 @@ function geodesic_prompt() {
   TWO_JOINED_SQUARES=$'\u29C9 '
   CROSS_MARK=$'\u274C '
 
-  if [ -n "$AWS_SESSION_TOKEN" ]; then
+  if [ -n "$AWS_VAULT" ]; then
     export STATUS=${WHITE_HEAVY_CHECK_MARK}
   else
     export STATUS=${CROSS_MARK}


### PR DESCRIPTION
## what
* Add support for `aws-vault server` mode

## why
* Support endless sessions for local development by mocking EC2 metadata api