### PR TITLE
Add `additionalPolicies` to `kops` template

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -3,6 +3,18 @@ kind: Cluster
 metadata:
   name: {{getenv "CLUSTER_NAME"}}
 spec:
+  additionalPolicies:
+      nodes: |
+        [
+          {
+            "Sid": "assumeClusterRole",
+            "Action": [
+              "sts:AssumeRole"
+            ],
+            "Effect": "Allow",
+            "Resource": ["*"]
+          }
+        ]
   api:
     loadBalancer:
       type: Public


### PR DESCRIPTION
## what
* Add `additionalPolicies` with `sts:AssumeRole` to `kops` template

## why
* Allow `kops` clusters created from the template to assume IAM roles
* Use with `kube2iam`
