### PR TITLE
Change ENV var name from `CLUSTER_NAME` to `KOPS_CLUSTER_NAME`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV CACHE_PATH=/localhost/.geodesic
 ENV GEODESIC_PATH=/usr/local/include/toolbox
 ENV MOTD_URL=http://geodesic.sh/motd
 ENV HOME=/conf
-ENV CLUSTER_NAME=example.foo.bar
+ENV KOPS_CLUSTER_NAME=example.foo.bar
 
 # Install all packages as root
 USER root

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -46,8 +46,8 @@ function geodesic_prompt() {
     ROLE_PROMPT="(none)"
   fi
 
-  if [ -n "${CLUSTER_NAME}" ]; then
-    PS1=$' ${TWO_JOINED_SQUARES}'" ${CLUSTER_NAME}\n"$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
+  if [ -n "${KOPS_CLUSTER_NAME}" ]; then
+    PS1=$' ${TWO_JOINED_SQUARES}'" ${KOPS_CLUSTER_NAME}\n"$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
   else
     PS1=$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
   fi

--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: kops/v1alpha2
 kind: Cluster
 metadata:
-  name: {{getenv "CLUSTER_NAME"}}
+  name: {{getenv "KOPS_CLUSTER_NAME"}}
 spec:
   additionalPolicies:
       nodes: |
@@ -22,13 +22,13 @@ spec:
     alwaysAllow: {}
   channel: stable
   cloudLabels:
-    Cluster: {{getenv "CLUSTER_NAME"}}
+    Cluster: {{getenv "KOPS_CLUSTER_NAME"}}
   cloudProvider: aws
-  configBase: {{getenv "KOPS_STATE_STORE" }}/{{getenv "CLUSTER_NAME"}}
+  configBase: {{getenv "KOPS_STATE_STORE" }}/{{getenv "KOPS_CLUSTER_NAME"}}
   {{if getenv "KOPS_DNS_ZONE" }}
   dnsZone: {{getenv "KOPS_DNS_ZONE"}}
   {{else}}
-  dnsZone: {{getenv "CLUSTER_NAME" | regexp.Replace "^[^.]+\\." ""}}
+  dnsZone: {{getenv "KOPS_CLUSTER_NAME" | regexp.Replace "^[^.]+\\." ""}}
   {{end}}
   etcdClusters:
   - etcdMembers:
@@ -48,7 +48,7 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: {{getenv "KUBERNETES_VERSION"}}
-  masterPublicName: api.{{getenv "CLUSTER_NAME"}}
+  masterPublicName: api.{{getenv "KOPS_CLUSTER_NAME"}}
   networkCIDR: 172.20.0.0/16
   networking:
     calico: {}
@@ -74,7 +74,7 @@ spec:
   {{- end }}
   topology:
     bastion:
-      bastionPublicName: {{ getenv "KOPS_BASTION_PUBLIC_NAME"}}.{{getenv "CLUSTER_NAME"}}
+      bastionPublicName: {{ getenv "KOPS_BASTION_PUBLIC_NAME"}}.{{getenv "KOPS_CLUSTER_NAME"}}
     dns:
       type: Public
     masters: private
@@ -85,7 +85,7 @@ apiVersion: kops/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
-    kops.k8s.io/cluster: {{getenv "CLUSTER_NAME"}}
+    kops.k8s.io/cluster: {{getenv "KOPS_CLUSTER_NAME"}}
   name: bastions
 spec:
   image: {{getenv "KOPS_BASE_IMAGE"}}
@@ -105,7 +105,7 @@ apiVersion: kops/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
-    kops.k8s.io/cluster: {{getenv "CLUSTER_NAME"}}
+    kops.k8s.io/cluster: {{getenv "KOPS_CLUSTER_NAME"}}
   name: master-{{.}}
 spec:
   associatePublicIp: false
@@ -123,7 +123,7 @@ apiVersion: kops/v1alpha2
 kind: InstanceGroup
 metadata:
   labels:
-    kops.k8s.io/cluster: {{getenv "CLUSTER_NAME"}}
+    kops.k8s.io/cluster: {{getenv "KOPS_CLUSTER_NAME"}}
   name: nodes
 spec:
   associatePublicIp: false

--- a/rootfs/templates/scaffolding/Makefile
+++ b/rootfs/templates/scaffolding/Makefile
@@ -1,6 +1,6 @@
-export CLUSTER_NAME ?= $(shell basename `pwd`)
+export KOPS_CLUSTER_NAME ?= $(shell basename `pwd`)
 export DOCKER_ORG ?= {{ getenv "DOCKER_ORG" "cloudposse" }}
-export DOCKER_IMAGE ?= $(DOCKER_ORG)/$(CLUSTER_NAME)
+export DOCKER_IMAGE ?= $(DOCKER_ORG)/$(KOPS_CLUSTER_NAME)
 export DOCKER_TAG ?= dev
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_BUILD_FLAGS = 
@@ -22,4 +22,4 @@ install:
 	@docker run --rm -e DOCKER_IMAGE -e DOCKER_TAG $(DOCKER_IMAGE_NAME) | sudo bash -s $(DOCKER_TAG)
 
 run:
-	$(CLUSTER_NAME)
+	$(KOPS_CLUSTER_NAME)

--- a/rootfs/usr/local/bin/new-project
+++ b/rootfs/usr/local/bin/new-project
@@ -1,5 +1,5 @@
 #!/bin/bash
-CLUSTER_NAME=${CLUSTER_NAME:-geodesic.example.org}
+KOPS_CLUSTER_NAME=${KOPS_CLUSTER_NAME:-geodesic.example.org}
 SCAFFOLDING=/templates/scaffolding/
 OUTPUT=/tmp/scaffolding
 
@@ -7,9 +7,9 @@ rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}
 
 # Render templates
-echo "Building project for ${CLUSTER_NAME}..." 1>&2
+echo "Building project for ${KOPS_CLUSTER_NAME}..." 1>&2
 gomplate --input-dir ${SCAFFOLDING} --output-dir ${OUTPUT}
 
 # Compress into a tarball
 cd ${OUTPUT}
-tar --transform="s|^./|${CLUSTER_NAME}/|" -c .
+tar --transform="s|^./|${KOPS_CLUSTER_NAME}/|" -c .

--- a/rootfs/usr/local/include/helpers
+++ b/rootfs/usr/local/include/helpers
@@ -46,7 +46,7 @@ module:
 
 .PHONY : confirm
 confirm:
-	@confirm CLUSTER_NAME
+	@confirm KOPS_CLUSTER_NAME
 
 .PHONY : help
 ## This help screen


### PR DESCRIPTION
## what
* Change ENV var name from `CLUSTER_NAME` to `KOPS_CLUSTER_NAME`

## why
* To standardize on the ENV var name for `kops` clusters
*  `KOPS_CLUSTER_NAME` is used in the `kops` sources and official docs

## references
* https://github.com/kubernetes/kops/blob/05378903178e66cbb36a934cb9c0ab02214568a4/cmd/kops/root.go#L131
