### PR TITLE
Use `BANNER` instead of `KOPS_CLUSTER_NAME` for prompt

### DIFF
--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -46,8 +46,8 @@ function geodesic_prompt() {
     ROLE_PROMPT="(none)"
   fi
 
-  if [ -n "${KOPS_CLUSTER_NAME}" ]; then
-    PS1=$' ${TWO_JOINED_SQUARES}'" ${KOPS_CLUSTER_NAME}\n"$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
+  if [ -n "${BANNER}" ]; then
+    PS1=$' ${TWO_JOINED_SQUARES}'" ${BANNER}\n"$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
   else
     PS1=$'${STATUS}'"  $ROLE_PROMPT \W "$'${BLACK_RIGHTWARDS_ARROWHEAD} '
   fi


### PR DESCRIPTION
## what
* Use `BANNER` instead of `KOPS_CLUSTER_NAME` for prompt

## why
* When provisioning an architecture without `kops`, `KOPS_CLUSTER_NAME` does not exist, and `geodesic` shows the default prompt not related to the current solution
* `geodesic` is designed to work with many different architectures, not only `kops`
