### PR TITLE
Upgrade kube-lego

### DIFF
--- a/conf/kops/helmfile.yaml
+++ b/conf/kops/helmfile.yaml
@@ -414,7 +414,7 @@ releases:
 
     ### Optional: KUBE_LEGO_IMAGE_TAG; e.g. 0.1.2
     - name: "image.tag"
-      value: '{{ coalesce (env "KUBE_LEGO_IMAGE_TAG") "0.1.2" }}'
+      value: '{{ coalesce (env "KUBE_LEGO_IMAGE_TAG") "0.1.5" }}'
 
     - name: "image.pullPolicy"
       value: "IfNotPresent"


### PR DESCRIPTION
## what
* `0.1.2` -> `0.1.5`

## why
* `0.1.2` contains a bug that prevents certs from getting generated