### PR TITLE
Add `datadog` helmfile

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -868,3 +868,58 @@ releases:
 
     - name: "prometheus.ingress.enabled"
       value: "false"
+
+
+#######################################################################################
+## datadog                                                                           ##
+## Datadog is a hosted infrastructure monitoring platform                            ##
+#######################################################################################
+
+#
+# References:
+#   - https://github.com/kubernetes/charts/tree/master/stable/datadog
+#   - https://github.com/kubernetes/charts/blob/master/stable/datadog/values.yaml
+#
+- name: "datadog"
+  namespace: "datadog"
+  labels:
+    chart: "datadog"
+    component: "datadog"
+    namespace: "datadog"
+    default: "false"
+  chart: "stable/datadog"
+  version: "0.11.2"
+  set:
+    - name: "image.repository"
+      value: "datadog/agent"
+
+    ### Optional: DATADOG_IMAGE_TAG; e.g. 6.1.2
+    - name: "image.tag"
+      value: '{{ coalesce (env "DATADOG_IMAGE_TAG") "6.1.2" }}'
+
+    - name: "image.pullPolicy"
+      value: "IfNotPresent"
+
+    - name: "resources.limits.cpu"
+      value: "256m"
+
+    - name: "resources.limits.memory"
+      value: "512Mi"
+
+    - name: "resources.requests.cpu"
+      value: "50m"
+
+    - name: "resources.requests.memory"
+      value: "64Mi"
+
+    - name: "datadog.apiKey"
+      value: '{{ env "DATADOG_API_KEY" }}'
+
+    - name: "datadog.collectEvents"
+      value: "true"
+
+    - name: "rbac.create"
+      value: "false"
+
+    - name: "kube-state-metrics.rbac.create"
+      value: "false"


### PR DESCRIPTION
## what
* Add `datadog` helmfile

## why
* To provision Datadog chart - hosted infrastructure monitoring platform

## test

![image](https://user-images.githubusercontent.com/7356997/39659438-1bc15dea-4ff6-11e8-8e61-1a0e4409633f.png)

![image](https://user-images.githubusercontent.com/7356997/39659443-28632eb6-4ff6-11e8-8aa7-2cc886dad990.png)

![image](https://user-images.githubusercontent.com/7356997/39659447-360af530-4ff6-11e8-94cb-c590015a210f.png)

![image](https://user-images.githubusercontent.com/7356997/39659449-3d0d9c16-4ff6-11e8-9382-dffacc95190a.png)
