### PR TITLE
Update helmfile.yaml

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -344,18 +344,8 @@ releases:
   chart: "stable/external-dns"
   version: "0.5.4"
   set:
-    - name: "nodeSelector.kubernetes\\.io/role"
-      value: "master"
-
     - name: "extraEnv.EXTERNAL_DNS_SOURCE"
       value: "service\ningress"
-
-    ## Tolerations
-    - name: "tolerations[0].key"
-      value: "node-role.kubernetes.io/master"
-
-    - name: "tolerations[0].effect"
-      value: "NoSchedule"
 
     ### Required: EXTERNAL_DNS_TXT_OWNER_ID; e.g. us-west-2.staging.cloudposse.org
     - name: "txtOwnerId"


### PR DESCRIPTION
## What
* Remove params that make `external-dns` runs on master

## Why
* There is no reason to execute `external-dns` on master nodes, 
  It was requirement for `kubernetes-route53` because it can not assume roles