### PR TITLE
add datadog apm enabled value to kops helmfile

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -921,6 +921,9 @@ releases:
 
     - name: "datadog.collectEvents"
       value: "true"
+      
+    - name: "datadog.apmEnabled"
+      value: '{{ env "DATADOG_APM_ENABLED" }}'
 
     - name: "rbac.create"
       value: "false"


### PR DESCRIPTION
## What
* Add `datadog.apmEnabled` value to datadog release in the kops helmfile

## Why
* Allows the datadog daemonset to be deployed to APM enabled