### PR TITLE
default value for DATADOG_APM_ENABLED in kops helmfile

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -921,9 +921,10 @@ releases:
 
     - name: "datadog.collectEvents"
       value: "true"
-      
+    
+    ### Optional: DATADOG_APM_ENABLED; e.g. true
     - name: "datadog.apmEnabled"
-      value: '{{ env "DATADOG_APM_ENABLED" }}'
+      value: '{{ env "DATADOG_APM_ENABLED" | default "false" }}'
 
     - name: "rbac.create"
       value: "false"


### PR DESCRIPTION
Set default value to "false" since APM is an upgrade feature in DataDog