### PR TITLE
add DataDog useHostPort and updateStrategy values to master helmfile

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -892,7 +892,7 @@ releases:
     vendor: "datadog"
     default: "false"
   chart: "stable/datadog"
-  version: "0.11.2"
+  version: "0.16.0"
   set:
     - name: "image.repository"
       value: "datadog/agent"
@@ -931,6 +931,14 @@ releases:
 
     - name: "kube-state-metrics.rbac.create"
       value: "false"
+      
+    ### Optional: DATADOG_USE_HOST_PORT; e.g. false
+    - name: "daemonset.useHostPort"
+      value: '{{ env "DATADOG_USE_HOST_PORT" | default "true" }}'
+
+    ### Optional: DATADOG_UPDATE_STRATEGY; e.g. RollingUpdate
+    - name: "daemonset.updateStrategy"
+      value: '{{ env "DATADOG_UPDATE_STRATEGY" | default "OnDelete" }}'
 
 #######################################################################################
 ## Fluentd to datadog logs


### PR DESCRIPTION
## What
* Bump DataDog chart version
* Add `daemonset.useHostPort` value
* Add `daemonset.updateStrategy` value

## Why
* The latest chart version supports newer versions of the DataDog agent
* `daemonset.useHostPort` set to `true` allows trace agents from pods on the same node to report using the `hostIP`
* `daemonset.updateStrategy` can be set to `RollingUpdate` to relaunch DataDog agent pods when the chart is installed or updated