### PR TITLE
Fixing outdated syntax for Prometheus PVCs

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -845,10 +845,10 @@ releases:
     - name: "prometheus.resources.requests.memory"
       value: "512Mi"
 
-    - name: "prometheus.storageSpec.volumeClaimTemplate.spec.accessModes[0]"
+    - name: "prometheus.storage.volumeClaimTemplate.spec.accessModes[0]"
       value: "ReadWrite"
 
-    - name: "prometheus.storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
+    - name: "prometheus.storage.volumeClaimTemplate.spec.resources.requests.storage"
       value: "50Gi"
 
     - name: "prometheus.service.type"


### PR DESCRIPTION
## What it is 
Previously this used an old spec that caused newer installations of the this chart to fail. `storageSpec` has since been updated to just `storage`

See:
https://github.com/coreos/prometheus-operator/issues/860#issuecomment-370999129

## How I Tested

Modified this file and deployed the kube-prometheus chart to a cluster.