### PR TITLE
kiam agents should use iptables to intercept traffic

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -70,7 +70,7 @@ releases:
 
     # show debug messages
     - name: "env.open.DEBUG"
-      value: '{{ env "CHARTMUSEUM_DEBUG" | default "true" }}'
+      value: '{{ env "CHARTMUSEUM_DEBUG" | default "false" }}'
 
     # allow chart versions to be re-uploaded
     - name: "env.open.ALLOW_OVERWRITE"

--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -188,7 +188,7 @@ releases:
 
     # show debug messages
     - name: "env.open.DEBUG"
-      value: '{{ env "CHARTMUSEUM_DEBUG" | default "true" }}'
+      value: '{{ env "CHARTMUSEUM_DEBUG" | default "false" }}'
 
     # use amazon s3 storage as backend
     - name: "env.open.STORAGE"

--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -68,6 +68,10 @@ releases:
     - name: "env.open.DISABLE_API"
       value: "true"
 
+    # show debug messages
+    - name: "env.open.DEBUG"
+      value: '{{ env "CHARTMUSEUM_DEBUG" | default "true" }}'
+
     # allow chart versions to be re-uploaded
     - name: "env.open.ALLOW_OVERWRITE"
       value: "false"
@@ -181,6 +185,10 @@ releases:
     # allow chart versions to be re-uploaded
     - name: "env.open.ALLOW_OVERWRITE"
       value: "true"
+
+    # show debug messages
+    - name: "env.open.DEBUG"
+      value: '{{ env "CHARTMUSEUM_DEBUG" | default "true" }}'
 
     # use amazon s3 storage as backend
     - name: "env.open.STORAGE"
@@ -447,6 +455,7 @@ releases:
       agent:
         gatewayTimeoutCreation: "5s"
         host:
+          iptables: "true"
           interface: "cali+"
         nodeSelector:
           kubernetes.io/role: "node"


### PR DESCRIPTION
## what
* Force iptables DNAT rule to reroute `169.254.169.254` to the `kiam` agent metadata proxy

## why
* Kiam stopped working; not entirely sure why
* Seems to have happened after upgrading to k8s 1.9.1

> This is the process that would typically be deployed as a DaemonSet to ensure that Pods have no access to the AWS Metadata API. Instead, the agent runs an HTTP proxy which intercepts credentials requests and passes on anything else. An DNAT iptables rule is required to intercept the traffic. The agent is capable of adding and removing the required rule for you through use of the --iptables flag. This is the name of the interface where pod traffic originates and it is different for the various CNI implementations. The flag also supports the ! prefix for inverted matches should you need to match all but one interface.



## references
* https://github.com/uswitch/kiam#agent