### PR TITLE
Use cloudposse fluentd chart

### DIFF
--- a/rootfs/conf/kops/helmfile.d/0510.fluentd.yaml
+++ b/rootfs/conf/kops/helmfile.d/0510.fluentd.yaml
@@ -7,9 +7,9 @@ helmDefaults:
     - "--reset-values"
 
 repositories:
-# Incubator repo of official helm charts
-- name: "incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+# Cloud Posse incubator repo of helm charts
+- name: "cloudposse-incubator"
+  url: "https://charts.cloudposse.com/incubator/"
 
 releases:
 

--- a/rootfs/conf/kops/helmfile.d/0510.fluentd.yaml
+++ b/rootfs/conf/kops/helmfile.d/0510.fluentd.yaml
@@ -28,11 +28,11 @@ releases:
 - name: "logs"
   namespace: "kube-system"
   labels:
-    chart: "fluentd"
+    chart: "fluentd-kubernetes"
     component: "datadog"
     namespace: "kube-system"
     default: "false"
-  chart: "incubator/fluentd"
+  chart: "cloudposse-incubator/fluentd-kubernetes"
   version: "0.2.0"
   set:
     - name: "image.repository"


### PR DESCRIPTION
## What
* Switch `fluentd` chart to `fluentd-kubernetes`

## Why
* Use generic chart
* It's going to be a while before [official chart PR](https://github.com/kubernetes/charts/pull/5357) gets approved