### PR TITLE
portal ingress.tls.enabled from env

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -1304,8 +1304,9 @@ releases:
     - name: "ingress.dns.enabled"
       value: "false"
 
+    ### Optional: PORTAL_INGRESS_TLS_ENABLED; e.g. false
     - name: "ingress.tls.enabled"
-      value: "true"
+      value: '{{ env "PORTAL_INGRESS_TLS_ENABLED" | default "true" }}'
 
     - name: "ingress.annotations.kubernetes\\.io/ingress\\.class"
       value: "nginx"


### PR DESCRIPTION
## What
Optionally read the value for the portal's `ingress.tls.enabled` from an environment variable

## Why
Allow the portal chart to be installed in scenarios where TLS is not used.