### PR TITLE
Copy installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ RUN echo 'set noswapfile' >> /etc/vim/vimrc
 
 WORKDIR /tmp
 
+# Copy installer over to make package upgrades easy
+COPY --from=packages /packages/install/ /packages/install/
+
+# Copy select binary packages
 COPY --from=packages /dist/ /usr/local/bin/
 
 #


### PR DESCRIPTION
## what
* Add `/packages/install` to image

## why
* To make it easier for inheritors to upgrade select packages
* It's referenced in our [documentation](https://docs.cloudposse.com/geodesic/kops/upgrade-cluster/)

e.g. Add this to a `Dockerfile`
```
RUN make -C /packages/install kubectl KUBECTL_VERSION=1.10.0
```

## demo
```
❌   (none) ~ ➤  make -C /packages/install kubectl KUBECTL_VERSION=1.10.0
make: Entering directory '/packages/install'
curl --fail -sSL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
chmod +x /usr/local/bin/kubectl
make: Leaving directory '/packages/install'
```