### PR TITLE
use CHARTMUSEUM_API_HOSTNAME

### DIFF
--- a/rootfs/conf/kops/helmfile.yaml
+++ b/rootfs/conf/kops/helmfile.yaml
@@ -246,22 +246,22 @@ releases:
     - name: "ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/target"
       value: '{{ env "CHARTMUSEUM_INGRESS" }}'
 
-    # DNS TTL for CHARTMUSEUM_HOSTNAME; e.g. 60
+    # DNS TTL for CHARTMUSEUM_API_HOSTNAME; e.g. 60
     # FIXME: this is blocked by https://github.com/roboll/helmfile/issues/119
     #- name: "ingress.annotations.external-dns\\.alpha\\.kubernetes\\.io/ttl"
     #  value: "60"
 
-    ### Required: CHARTMUSEUM_HOSTNAME; e.g. charts.us-west-2.staging.cloudposse.org
-    - name: 'ingress.hosts.api\.{{ env "CHARTMUSEUM_HOSTNAME" | replace "." "\\." }}[0]'
+    ### Required: CHARTMUSEUM_API_HOSTNAME; e.g. api.charts.us-west-2.staging.cloudposse.org
+    - name: 'ingress.hosts.{{ env "CHARTMUSEUM_API_HOSTNAME" | replace "." "\\." }}[0]'
       value: "/api"
 
     ### Optional: CHARTMUSEUM_API_SECRET_NAME; e.g. chartmuseum-api-server-tls
     - name: "ingress.tls[0].secretName"
       value: '{{ env "CHARTMUSEUM_API_SECRET_NAME" | default "chartmuseum-api-server-tls" }}'
 
-    ### Required: CHARTMUSEUM_HOSTNAME; e.g. charts.us-west-2.staging.cloudposse.org
+    ### Required: CHARTMUSEUM_API_HOSTNAME; e.g. api.charts.us-west-2.staging.cloudposse.org
     - name: "ingress.tls[0].hosts[0]"
-      value: 'api.{{ env "CHARTMUSEUM_HOSTNAME" }}'
+      value: '{{ env "CHARTMUSEUM_API_HOSTNAME" }}'
 
 ################################################################################
 ## External DNS ################################################################


### PR DESCRIPTION
## What
Use env var CHARTMUSEUM_API_HOSTNAME for the chartmuseum API release instead of `api.{{ env "CHARTMUSEUM_HOSTNAME" }}`

## Why
Allow other host naming conventions.

In my case, I want to use `api-charts.us-west-2.staging.example.com` as the hostname so that a `*.us-west-2.staging.example.com` certificate applies.

## upgrading

1. Define `CHARTMUSEUM_API_HOSTNAME` with `chamber` (e.g. `api.charts.us-west-2.staging.cloudposse.org`)