### PR TITLE
Preserve Environment When Sudo'ing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	@make --no-print-directory docker:build
 
 install:
-	@docker run --rm -e CLUSTER=galaxy $(DOCKER_IMAGE_NAME) | sudo bash -s dev
+	@docker run --rm -e CLUSTER=galaxy $(DOCKER_IMAGE_NAME) | sudo -E bash -s dev
 
 run:
 	@geodesic


### PR DESCRIPTION
## what
* Add -E option to sudo

## why
* All env variables doesn't import automatically 

## references
- <https://github.com/cloudposse/geodesic/issues/196>
- <https://github.com/cloudposse/root.cloudposse.co/issues/6>