### PR TITLE
Fix path for AWS Autocompletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,8 +180,8 @@ ENV AWSCLI_VERSION 1.11.185
 RUN pip install awscli==${AWSCLI_VERSION} && \
     rm -rf /root/.cache && \
     find / -type f -regex '.*\.py[co]' -delete && \
-    ln -s /usr/local/aws/bin/aws_bash_completer /etc/bash_completion.d/aws.sh && \
-    ln -s /usr/local/aws/bin/aws_completer /usr/local/bin/
+    ln -s /usr/bin/aws_bash_completer /etc/bash_completion.d/aws.sh && \
+    ln -s /usr/bin/aws_completer /usr/local/bin/
 
 #
 # Shell


### PR DESCRIPTION
### what
* Use correct path for autocompletion scripts

### why
* Completers are located in another directory

## references
- <https://github.com/cloudposse/geodesic/issues/144>