### PR TITLE
Restore white checkmark in unicode prompt

### DIFF
--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -58,7 +58,7 @@ function geodesic_prompt() {
     ROLE_PROMPT="(none)"
   fi
 
-  PS1=$'${STATUS}'
+  PS1="\["$'${STATUS}'"\]"
   PS1+="  ${ROLE_PROMPT} \W "
   PS1+=$'${BLACK_RIGHTWARDS_ARROWHEAD} '
 

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -39,7 +39,7 @@ function geodesic_prompt() {
       ;;
     *)
       # unicode
-      AWS_VAULT_ACTIVE_MARK=$'\u2714 '      # '✔'
+      AWS_VAULT_ACTIVE_MARK=$'\u2705 '      # '✅'
       AWS_VAULT_INACTIVE_MARK=$'\u274C '    # '❌'
       BLACK_RIGHTWARDS_ARROWHEAD=$'\u27A4 ' # '➤', suggest '▶' may be present in more fonts
       BANNER_MARK=$'\u29C9 '                # '⧉'


### PR DESCRIPTION
## what
* Restore ✅

## why
* The ✔is too discreet and doesn't match ❌