### PR TITLE
Update syslog ng conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	@make --no-print-directory docker:build
 
 install:
-	@docker run --rm -e CLUSTER=galaxy $(DOCKER_IMAGE_NAME) | sudo bash -s dev
+	@docker run --rm -e CLUSTER=galaxy $(DOCKER_IMAGE_NAME) | sudo -E bash -s dev
 
 run:
 	@geodesic

--- a/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.9
+@version: 3.13.2-r3
 
 options {
     use_dns(no);


### PR DESCRIPTION
### what
* Bump `@version` in `syslog-ng.conf`

### why
* In `alpine:3.8` version of `syslog-ng` was bumped and now it throws WARNING

## references
- https://github.com/cloudposse/geodesic/issues/206