### PR TITLE
syslog-ng: check existing instance

### DIFF
--- a/rootfs/etc/profile.d/syslog-ng.sh
+++ b/rootfs/etc/profile.d/syslog-ng.sh
@@ -1,1 +1,5 @@
-syslog-ng -f /etc/syslog-ng/syslog-ng.conf
+if pidof -x syslog-ng >/dev/null; then
+    echo "syslog-ng is already running"
+else
+    syslog-ng -f /etc/syslog-ng/syslog-ng.conf
+fi


### PR DESCRIPTION
## what
Check if syslog-ng is already running

## why
#211 