### PR TITLE
Remove unsupported `-x` argument for `pidof`

### DIFF
--- a/rootfs/etc/profile.d/syslog-ng.sh
+++ b/rootfs/etc/profile.d/syslog-ng.sh
@@ -1,5 +1,5 @@
-if pidof -x syslog-ng >/dev/null; then
-    echo "syslog-ng is already running"
+if pidof syslog-ng >/dev/null; then
+    echo "* syslog-ng is already running"
 else
     syslog-ng -f /etc/syslog-ng/syslog-ng.conf
 fi


### PR DESCRIPTION
## what
* Remove `-x` argument

## why
* Unsupported on the `alpine` version of `pidof` command

## references
* https://github.com/cloudposse/geodesic/pull/215
* https://github.com/cloudposse/geodesic/issues/217