### PR TITLE
aws-vault - fix shell concurrency

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -12,7 +12,7 @@ else
     curl -sSL -o /dev/null --stderr /dev/null http://169.254.169.254/latest/meta-data/iam/security-credentials
     result=$?
     if [ $result -ne 0 ]; then
-        echo "* Started EC2 metadata service at http://169.254.169.254/latest"
+        echo "* Started EC2 metadata service at $(green http://169.254.169.254/latest)"
         aws-vault server &
         AWS_VAULT_ARGS+=("--server")
      else

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -8,14 +8,16 @@ else
   AWS_VAULT_ARGS=("--assume-role-ttl=${AWS_VAULT_ASSUME_ROLE_TTL}")
   [ -d /localhost/.awsvault ] || mkdir /localhost/.awsvault
   ln -sf /localhost/.awsvault ${HOME}
-  curl -sSL -o /dev/null --stderr /dev/null http://169.254.169.254/latest/meta-data/iam/security-credentials
-  result=$?
-  if [ "${VAULT_SERVER_ENABLED:-true}" == "true" ] && [ $result -ne 0 ]; then
-    echo "* Started EC2 metadata service at $(green http://169.254.169.254/latest)"
-    aws-vault server &
-    AWS_VAULT_ARGS+=("--server")
-  else
-    echo "* Metadata server already running"
+  if [ "${VAULT_SERVER_ENABLED:-true}" == "true" ]; then
+    curl -sSL -o /dev/null --stderr /dev/null http://169.254.169.254/latest/meta-data/iam/security-credentials
+    result=$?
+    if [ $result -ne 0 ]; then
+        echo "* Started EC2 metadata service at http://169.254.169.254/latest"
+        aws-vault server &
+        AWS_VAULT_ARGS+=("--server")
+     else
+        echo "* Metadata server already running"
+     fi
   fi
 fi
 

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -8,10 +8,14 @@ else
   AWS_VAULT_ARGS=("--assume-role-ttl=${AWS_VAULT_ASSUME_ROLE_TTL}")
   [ -d /localhost/.awsvault ] || mkdir /localhost/.awsvault
   ln -sf /localhost/.awsvault ${HOME}
-  if [ "${VAULT_SERVER_ENABLED:-true}" == "true" ]; then
+  curl -sSL -o /dev/null --stderr /dev/null http://169.254.169.254/latest/meta-data/iam/security-credentials
+  result=$?
+  if [ "${VAULT_SERVER_ENABLED:-true}" == "true" ] && [ $result -ne 0 ]; then
     echo "* Started EC2 metadata service at http://169.254.169.254/latest"
     aws-vault server &
     AWS_VAULT_ARGS+=("--server")
+  else
+    echo "Metadata server already running"
   fi
 fi
 

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -15,7 +15,7 @@ else
     aws-vault server &
     AWS_VAULT_ARGS+=("--server")
   else
-    echo "Metadata server already running"
+    echo "* Metadata server already running"
   fi
 fi
 


### PR DESCRIPTION
## what
* Check if aws-vault server is already running before attempting to start

## why
* Can only run once since it attempts to bind to `169.254.169.254`

## references
* #195 