### PR TITLE
Fix AWS Configure Support

### DIFF
--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -1,0 +1,11 @@
+if [ ! -d "${AWS_DATA_PATH}" ]; then
+  echo "* Initializing ${AWS_DATA_PATH}"
+  mkdir -p "${AWS_DATA_PATH}" 
+fi
+
+# `aws configure` does not respect ENVs
+if [ ! -e "${HOME}/.aws" ]; then
+  ln -s "${AWS_DATA_PATH}" "${HOME}/.aws"
+fi
+
+

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -8,4 +8,9 @@ if [ ! -e "${HOME}/.aws" ]; then
   ln -s "${AWS_DATA_PATH}" "${HOME}/.aws"
 fi
 
+if [ ! -f "${AWS_CONFIG_FILE}" ]; then
+  echo "* Initializing ${AWS_CONFIG_FILE}"
+  # Required for AWS_PROFILE=default
+  echo '[default]' > ${AWS_CONFIG_FILE}
+fi
 


### PR DESCRIPTION
## what
* Symlink `/conf/.aws` to `/localhost/.aws`

## why
* In geodesic `HOME=/conf` and `/localhost/.aws` is the canonical aws configuration
* `aws configure` does not respect `AWS_DATA_PATH`

## references
* https://github.com/cloudposse/geodesic/issues/225