### PR TITLE
Deprecate VOLUME for CACHE_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,8 +192,6 @@ ENV LESS=-Xr
 ENV XDG_CONFIG_HOME=${CACHE_PATH}
 ENV SSH_AGENT_CONFIG=/var/tmp/.ssh-agent
 
-VOLUME ["${CACHE_PATH}"]
-
 COPY rootfs/ /
 
 WORKDIR /conf


### PR DESCRIPTION
## what
* Deprecate `VOLUME` definition for `CACHE_PATH`

## why
* It shadows `/localhost` which already is mounted
* If a volume is not explicitly mounted with `--volume` to match the `CACHE_PATH`, then docker creates a temporary ephemeral volume
* We want data to persist in this path