### PR TITLE
Preserve Exit Status Code on Exit

### DIFF
--- a/rootfs/etc/profile.d/iterm.sh
+++ b/rootfs/etc/profile.d/iterm.sh
@@ -6,9 +6,10 @@ set_badge() {
 
 ## Display an exit greeting
 function _exit() {
+  local status=$?
   set_badge ""
   echo 'Goodbye'
-  exit 0
+  exit $status
 }
 trap _exit EXIT
 


### PR DESCRIPTION
## what
* Preserve exit status code of last command when exiting

## why
* Necessary for proper testing
