### PR TITLE
Create aws-vault parent directories

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -6,7 +6,7 @@ if [ -n "${AWS_VAULT}" ]; then
   echo "* Assumed role $(green ${TF_VAR_aws_assume_role_arn})"
 else
   AWS_VAULT_ARGS=("--assume-role-ttl=${AWS_VAULT_ASSUME_ROLE_TTL}")
-  [ -d /localhost/.awsvault ] || mkdir /localhost/.awsvault
+  [ -d /localhost/.awsvault ] || mkdir -p /localhost/.awsvault
   ln -sf /localhost/.awsvault ${HOME}
   if [ "${VAULT_SERVER_ENABLED:-true}" == "true" ]; then
     curl -sSL -o /dev/null --stderr /dev/null http://169.254.169.254/latest/meta-data/iam/security-credentials
@@ -16,7 +16,7 @@ else
         aws-vault server &
         AWS_VAULT_ARGS+=("--server")
      else
-        echo "* Metadata server already running"
+        echo "* EC2 metadata server already running"
      fi
   fi
 fi


### PR DESCRIPTION
## what
* use `mkdir -p` to create parent dirs

## why
* If `/localhost` is not mounted, this fails

## use-case
* running under CI/CD `/localhost` may not be mounted