### PR TITLE
Add --with-docker arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER root
 # Install common packages
 ARG APK_PACKAGES="unzip curl tar python make bash vim jq figlet openssl openssh-client sshpass \
                  iputils drill gcc libffi-dev python-dev musl-dev ncurses openssl-dev py-pip py-virtualenv \
-                 git coreutils less groff bash-completion fuse syslog-ng libc6-compat util-linux"
+                 git coreutils less groff bash-completion fuse syslog-ng libc6-compat util-linux libltdl"
 ENV APK_PACKAGES=${APK_PACKAGES}
 
 RUN apk update \

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -81,6 +81,7 @@ function use() {
                        --volume "/var/run/docker.sock:/var/run/docker.sock")
     else
       echo "Not supported on $(uname -s)"
+      exit 1
     fi
   fi
 

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -73,6 +73,17 @@ function use() {
     DOCKER_ARGS+=(--env-file ${ENV_FILE})
   fi
 
+  if [ "${WITH_DOCKER}" == "true" ]; then
+    if [ `uname -s` == 'Linux' ]; then
+        # Bind-mount docker client and docker socket into container (linux only)
+        echo "# Enabling docker support"
+        DOCKER_ARGS+=( --volume "$(which docker):/usr/bin/docker" 
+                       --volume "/var/run/docker.sock:/var/run/docker.sock")
+    else
+      echo "Not supported on $(uname -s)"
+    fi
+  fi
+
   # allow users to override value of GEODESIC_DEFAULT_ENV_FILE
   local geodesic_default_env_file=${GEODESIC_DEFAULT_ENV_FILE:-~/.geodesic/env}
   if [ -f "${geodesic_default_env_file}" ]; then


### PR DESCRIPTION
## what
* Add `--with-docker` argument 

## why
* Access docker daemon from inside of geodesic
* Run tasks that need docker (E.g. from `build-harness`)

## caveats
* Only works on Linux because sockets cannot be bind mounted into VMs