### PR TITLE
Install `oath-toolkit`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG PACKAGES_IMAGE=cloudposse/packages:0.6.0
+ARG PACKAGES_IMAGE=cloudposse/packages:0.8.0
 FROM ${PACKAGES_IMAGE} as packages
 
 WORKDIR /packages
 
-# 
+#
 # Install the select packages from the cloudposse package manager image
 #
 # Repo: <https://github.com/cloudposse/packages>
@@ -114,9 +114,9 @@ RUN helm repo add cloudposse-incubator https://charts.cloudposse.com/incubator/ 
     && helm repo add coreos-stable https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/ \
     && helm repo update
 
-# 
+#
 # Install helm plugins
-# 
+#
 ENV HELM_APPR_VERSION 0.7.0
 ENV HELM_EDIT_VERSION 0.2.0
 ENV HELM_GITHUB_VERSION 0.2.0
@@ -173,6 +173,14 @@ RUN pip install awscli==${AWSCLI_VERSION} && \
     find / -type f -regex '.*\.py[co]' -delete && \
     ln -s /usr/bin/aws_bash_completer /etc/bash_completion.d/aws.sh && \
     ln -s /usr/bin/aws_completer /usr/local/bin/
+
+#
+# Install oath-toolkit
+# https://www.nongnu.org/oath-toolkit/
+# https://www.nongnu.org/oath-toolkit/oathtool.1.html
+#
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+    && apk add --no-cache oath-toolkit-oathtool
 
 #
 # Shell

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /packages
 #
 # Repo: <https://github.com/cloudposse/packages>
 #
-
 ARG PACKAGES="awless aws-vault cfssl cfssljson chamber fetch figurine github-commenter gomplate goofys helm helmfile kops kubectl kubectx kubens sops stern terraform terragrunt yq"
 ENV PACKAGES=${PACKAGES}
 RUN make dist
@@ -28,10 +27,17 @@ ENV KOPS_CLUSTER_NAME=example.foo.bar
 # Install all packages as root
 USER root
 
+# oath-toolkit
+# https://www.nongnu.org/oath-toolkit/
+# https://www.nongnu.org/oath-toolkit/oathtool.1.html
+RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
 # Install common packages
 ARG APK_PACKAGES="unzip curl tar python make bash vim jq figlet openssl openssh-client sshpass \
                  iputils drill gcc libffi-dev python-dev musl-dev ncurses openssl-dev py-pip py-virtualenv \
-                 git coreutils less groff bash-completion fuse syslog-ng libc6-compat util-linux libltdl"
+                 git coreutils less groff bash-completion fuse syslog-ng libc6-compat util-linux libltdl \
+                 oath-toolkit-oathtool@testing"
+
 ENV APK_PACKAGES=${APK_PACKAGES}
 
 RUN apk update \
@@ -173,14 +179,6 @@ RUN pip install awscli==${AWSCLI_VERSION} && \
     find / -type f -regex '.*\.py[co]' -delete && \
     ln -s /usr/bin/aws_bash_completer /etc/bash_completion.d/aws.sh && \
     ln -s /usr/bin/aws_completer /usr/local/bin/
-
-#
-# Install oath-toolkit
-# https://www.nongnu.org/oath-toolkit/
-# https://www.nongnu.org/oath-toolkit/oathtool.1.html
-#
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk add --no-cache oath-toolkit-oathtool
 
 #
 # Shell


### PR DESCRIPTION
## what
* Install `oath-toolkit`

## why
* Easy build one-time password authentication systems (including for AWS with MFA)
* Required for Terraform CI/CD

## install

```
Step 65/74 : RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories     && apk add --no-cache oath-toolkit-oathtool
 ---> Running in b83396d5fa96
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
(1/5) Installing perl (5.26.2-r1)
(2/5) Installing cvs (1.11.23-r0)
(3/5) Installing diffutils (3.6-r1)
(4/5) Installing oath-toolkit-liboath (2.6.2-r0)
(5/5) Installing oath-toolkit-oathtool (2.6.2-r0)
Executing busybox-1.28.4-r0.trigger
OK: 299 MiB in 99 packages
```

## references
* https://www.nongnu.org/oath-toolkit
* https://www.nongnu.org/oath-toolkit/oathtool.1.html
* https://piotrkazmierczak.com/2016/mfa-tokens-in-your-terminal/
* https://hub.docker.com/r/toolbelt/oathtool/~/dockerfile/
* https://hub.docker.com/r/gzm55/oathtool/~/dockerfile/
* https://github.com/OpenGov/docker-oathtool/blob/master/Dockerfile

