### PR TITLE
[helm] add helm-s3 plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,12 +138,14 @@ ENV HELM_DIFF_VERSION 2.10.0+1
 ENV HELM_EDIT_VERSION 0.2.0
 ENV HELM_GITHUB_VERSION 0.2.0
 ENV HELM_SECRETS_VERSION 1.2.9
+ENV HELM_S3_VERSION 0.7.0
 
 RUN helm plugin install https://github.com/app-registry/appr-helm-plugin --version v${HELM_APPR_VERSION} \
     && helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} \
     && helm plugin install https://github.com/mstrzele/helm-edit --version v${HELM_EDIT_VERSION} \
     && helm plugin install https://github.com/futuresimple/helm-secrets --version ${HELM_SECRETS_VERSION} \
-    && helm plugin install https://github.com/sagansystems/helm-github --version ${HELM_GITHUB_VERSION}
+    && helm plugin install https://github.com/sagansystems/helm-github --version ${HELM_GITHUB_VERSION} \
+    && helm plugin install https://github.com/hypnoglow/helm-s3 --version v${HELM_S3_VERSION}
 
 #
 # Install Google Cloud SDK


### PR DESCRIPTION
## what
added helm-s3 plugin that allows to have private Helm chart repositories hosted on Amazon S3

## why
closes #269 