### PR TITLE
[gke] Use Google Cloud SDK Image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible ==2.6.4
-boto == 2.49.0
-Jinja2 == 2.10
-awsebcli ==3.14.4
-awscli ==1.16.9
+ansible==2.6.4
+boto==2.49.0
+Jinja2==2.10
+awsebcli==3.14.4
+awscli==1.16.9


### PR DESCRIPTION
## what
* Copy Google Cloud SDK from official Docker image using multi-stage build
* Upgrade to latest release
* Fix `gcloud` bash completion

## why
* Support automatic dependency updates by dependabot
* Faster build times
