### PR TITLE
[helm-diff] upgrade to 2.11.0+2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ RUN helm repo add cloudposse-incubator https://charts.cloudposse.com/incubator/ 
 # Install helm plugins
 #
 ENV HELM_APPR_VERSION 0.7.0
-ENV HELM_DIFF_VERSION 2.10.0+1
+ENV HELM_DIFF_VERSION 2.11.0+2
 ENV HELM_EDIT_VERSION 0.2.0
 ENV HELM_GITHUB_VERSION 0.2.0
 ENV HELM_SECRETS_VERSION 1.2.9


### PR DESCRIPTION
## what
* Upgrade helm-diff

## why
* To support `--set-file` syntax which was recently added to `helm`
* Breaks our CI without it