### PR TITLE
Add configurable `idleTimeoutSeconds` for k8s API load balancer

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -31,7 +31,7 @@ spec:
   api:
     loadBalancer:
       type: Public
-      idleTimeoutSeconds: {{ getenv "KOPS_API_SERVER_ELB_TIMEOUT" "300" }}
+      idleTimeoutSeconds: {{ getenv "KOPS_API_LOAD_BALANCER_IDLE_TIMEOUT_SECONDS" "300" }}
   hooks:
   {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
     - name: kops-hook-authenticator-config.service

--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -31,7 +31,7 @@ spec:
   api:
     loadBalancer:
       type: Public
-      idleTimeoutSeconds: {{ getenv "KOPS_API_LOAD_BALANCER_IDLE_TIMEOUT_SECONDS" "300" }}
+      idleTimeoutSeconds: {{ getenv "KOPS_API_LOAD_BALANCER_IDLE_TIMEOUT_SECONDS" "600" }}
   hooks:
   {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
     - name: kops-hook-authenticator-config.service

--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -31,12 +31,13 @@ spec:
   api:
     loadBalancer:
       type: Public
+      idleTimeoutSeconds: {{ getenv "KOPS_API_SERVER_ELB_TIMEOUT" "300" }}
   hooks:
   {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
     - name: kops-hook-authenticator-config.service
       before:
         - kubelet.service
-      roles: 
+      roles:
         - Master
       manifest: |-
         [Unit]
@@ -196,7 +197,7 @@ spec:
   {{- range (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
   - {{ . }}
   {{- end }}
-    
+
 {{/* Allow the manifest to be extended via a datasource */}}
 {{- if (datasourceExists "extensions") -}}
 ---


### PR DESCRIPTION
## what
* Add configurable `idleTimeoutSeconds` for k8s API load balancer

## why
* Some `helm` deployments take more than 5 minutes (default apiserver ELB timeout)
* https://github.com/kubernetes/kops/pull/1886
