### PR TITLE
Add script to easily setup `~/.aws/config` with `aws-vault`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ansible==2.7.0
-boto==2.49.0
-Jinja2==2.10
 awsebcli==3.14.6
 awscli==1.16.28
+boto==2.49.0
+crudini==0.9
+Jinja2==2.10

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -35,22 +35,26 @@ crudini --set ${AWS_CONFIG_FILE} "profile ${AWS_SOURCE_PROFILE}"
 # Define default profile
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AWS_REGION}"
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
-crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
 
-read SETUP_MFA -p "Use MFA? [y/n] "
+# Prompt the user to setup MFA
+read -p "Use MFA? [y/n] " SETUP_MFA
 
 if [ "${SETUP_MFA}" == "y" ]; then
-	read AWS_USERNAME -p "AWS IAM Username: "
+	read -p "AWS IAM Username: " AWS_USERNAME
 	export AWS_MFA_SERIAL="arn:aws:iam::${AWS_ROOT_ACCOUNT_ID}:mfa/${AWS_USERNAME}"
 	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial "${AWS_MFA_SERIAL}"
 else
 	crudini --del "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial
 fi
 
-read SETUP_VAULT -p "Setup AWS Credentials? [y/n] "
+# Reference the source profile settings
+crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
 
-if [ "${SETUP_MFA}" == "y" ]; then
+# Prompt the user to setup their AWS credentials in aws-vault
+read -p "Setup AWS Credentials (aws-vault)? [y/n] " SETUP_VAULT
+
+if [ "${SETUP_VAULT}" == "y" ]; then
 	aws-vault add "${AWS_SOURCE_PROFILE}"
 fi
 
-echo "Configured AWS ${AWS_DEFAULT_PROFILE} profile for ${AWS_REGION} region for ${AWS_ACCOUNT_ID} account ID"
+echo "Configured AWS ${AWS_DEFAULT_PROFILE} profile for ${AWS_REGION} region in the ${AWS_ACCOUNT_ID} account"

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -16,6 +16,11 @@ if [ -z "${AWS_ACCOUNT_ID}" ]; then
 	exit 1
 fi
 
+if [ -z "${AWS_ROOT_ACCOUNT_ID}" ]; then
+	echo "AWS_ROOT_ACCOUNT_ID not defined"
+	exit 1
+fi
+
 # Derive the source profile from the prefix of the default profile
 export AWS_SOURCE_PROFILE=$(echo ${AWS_DEFAULT_PROFILE} | cut -d- -f1)
 
@@ -32,6 +37,20 @@ crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AW
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
 
-aws-vault add "${AWS_SOURCE_PROFILE}"
+read SETUP_MFA -p "Setup MFA? [y/n] "
 
-echo "Configured ${AWS_DEFAULT_PROFILE} for ${AWS_REGION} region with ${AWS_ACCOUNT_ID} AWS account id"
+if [ "${SETUP_MFA}" == "y" ]; then
+	read AWS_USERNAME -p "AWS Username: "
+	export AWS_MFA_SERIAL="arn:aws:iam::${AWS_ROOT_ACCOUNT_ID}:mfa/${AWS_USERNAME}"
+	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial "${AWS_MFA_SERIAL}"
+else
+	crudini --del "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial
+fi
+
+read SETUP_VAULT -p "Setup AWS Credentials? [y/n] "
+
+if [ "${SETUP_MFA}" == "y" ]; then
+	aws-vault add "${AWS_SOURCE_PROFILE}"
+fi
+
+echo "Configured AWS ${AWS_DEFAULT_PROFILE} profile for ${AWS_REGION} region for ${AWS_ACCOUNT_ID} account ID"

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -37,10 +37,10 @@ crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AW
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
 
-read SETUP_MFA -p "Setup MFA? [y/n] "
+read SETUP_MFA -p "Use MFA? [y/n] "
 
 if [ "${SETUP_MFA}" == "y" ]; then
-	read AWS_USERNAME -p "AWS Username: "
+	read AWS_USERNAME -p "AWS IAM Username: "
 	export AWS_MFA_SERIAL="arn:aws:iam::${AWS_ROOT_ACCOUNT_ID}:mfa/${AWS_USERNAME}"
 	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial "${AWS_MFA_SERIAL}"
 else

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -1,0 +1,37 @@
+#!/bin/bash
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+
+if [ -z "${AWS_CONFIG_FILE}" ]; then
+	echo "AWS_CONFIG_FILE not defined"
+	exit 1
+fi
+
+if [ -z "${AWS_DEFAULT_PROFILE}" ]; then
+	echo "AWS_DEFAULT_PROFILE not defined"
+	exit 1
+fi
+
+if [ -z "${AWS_ACCOUNT_ID}" ]; then
+	echo "AWS_ACCOUNT_ID not defined"
+	exit 1
+fi
+
+# Derive the source profile from the prefix of the default profile
+export AWS_SOURCE_PROFILE=$(echo ${AWS_DEFAULT_PROFILE} | cut -d- -f1)
+
+if [ "${AWS_SOURCE_PROFILE}" == "${AWS_DEFAULT_PROFILE}" ]; then
+	echo "AWS_DEFAULT_PROFILE should look like namespace-stage-role (e.g. eg-testing-admin)"
+	exit 1
+fi
+
+# Define empty source profile
+crudini --set ${AWS_CONFIG_FILE} "profile ${AWS_SOURCE_PROFILE}"
+
+# Define default profile
+crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AWS_REGION}"
+crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
+crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
+
+aws-vault add "${AWS_SOURCE_PROFILE}"
+
+echo "Configured ${AWS_DEFAULT_PROFILE} for ${AWS_REGION} region with ${AWS_ACCOUNT_ID} AWS account id"


### PR DESCRIPTION
## what 
* Add a script to easily configure `.aws/config` profiles for the given account following cloudposse conventions
* Call `aws-vault add` to prompt for access credentials
* Add crudini to easily manipulate ini files (because `aws configure` sucks)

## why
* Simplify the coldstart problem for new users when using a preconfigured shell