### PR TITLE
Add direnv support

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -8,6 +8,7 @@ busybox-extras
 coreutils
 chamber@cloudposse
 curl
+direnv@testing
 drill
 dumb-init
 fetch@cloudposse

--- a/rootfs/etc/profile.d/direnv.sh
+++ b/rootfs/etc/profile.d/direnv.sh
@@ -1,0 +1,5 @@
+PROMPT_HOOKS+=("direnv_prompt")
+
+function direnv_prompt() {
+	eval "$(direnv hook bash)"
+}


### PR DESCRIPTION
## what
* Add `direnv` support which automatically loads *allowed* `.envrc` files

## why
* Simplify env management in a standardized way that's commonly used by the community

## use-case
* Automatically export envs from chamber

Sample `conf/kops/.envrc`:
```
eval "$(chamber exec kops -- sh -c "export -p")"
```

## references
* https://direnv.net/