### PR TITLE
Remove default for DOCKER_DNS

### DIFF
--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -91,9 +91,7 @@ function use() {
 		DOCKER_ARGS+=(--env-file=${geodesic_default_env_file})
 	fi
 
-	if [ "${OS}" == "Darwin" ]; then
-		# Run in privleged mode to enable time synchronization of system clock with hardware clock
-		# Implement DNS fix related to https://github.com/docker/docker/issues/24344
+	if [ -n "${DOCKER_DNS}" ]; then
 		DOCKER_ARGS+=("--dns=${DOCKER_DNS}")
 	fi
 
@@ -258,7 +256,7 @@ if [ -n "${PORT}" ]; then
 	export GEODESIC_PORT=${PORT}
 fi
 
-export DOCKER_DNS=${DNS:-8.8.8.8}
+export DOCKER_DNS=${DNS:-${DOCKER_DNS}}
 
 if [ "${GEODESIC_SHELL}" == "true" ]; then
 	echo "Cannot run while in a geodesic shell"


### PR DESCRIPTION
## what
* Remove default value for `DOCKER_DNS`

## why
* In corporate environments, DNS is often tightly regulated
* No longer needed to address the [original problem](https://github.com/moby/moby/issues/24344)
* Closes #320