### PR TITLE
Fix autocomplete for terraform and aws

### DIFF
--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -13,3 +13,8 @@ if [ ! -f "${AWS_CONFIG_FILE}" ]; then
 	# Required for AWS_PROFILE=default
 	echo '[default]' >${AWS_CONFIG_FILE}
 fi
+
+# Install autocompletion rules
+if [ -x "/usr/bin/aws_completer" ]; then
+	complete -C '/usr/bin/aws_completer' aws
+fi

--- a/rootfs/etc/profile.d/terraform.sh
+++ b/rootfs/etc/profile.d/terraform.sh
@@ -10,6 +10,6 @@ function terraform_prompt() {
 }
 
 # Install autocompletion rules
-if which terraform >/dev/null 2>&1; then
-	complete -C /usr/local/bin/terraform terraform
+if [ -x '/usr/bin/terraform' ]; then
+	complete -C /usr/bin/terraform terraform
 fi


### PR DESCRIPTION
## what
* Fix autocomplete for `aws` and `terraform` 

## why
* They broke when we moved to install alpine packages
* Fixes #300