### PR TITLE
Bump KUBERNETES_VERSION to 1.10.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ ENV AWS_VAULT_ASSUME_ROLE_TTL=1h
 #
 # Install kubectl
 #
-ENV KUBERNETES_VERSION 1.10.8
+ENV KUBERNETES_VERSION 1.10.11
 ENV KUBECONFIG=${SECRETS_PATH}/kubernetes/kubeconfig
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
 


### PR DESCRIPTION
## what

This commit updates k8s deployments to use 1.10.11 by default, mainly 
for CVE-2018-1002105 fixes. See [1] for more info.

KUBERNETES_VERSION is used by Geodesic & Kops to determine the k8s 
version that should be used. Kops and k8s versioning is lock step and 
the latest stable release of Kops is still 1.10.X, so we need to stick 
to that, rather than a 1.13.X shiny release. 

[1] https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md