### PR TITLE
Update Kops base image to 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ ENV KOPS_TEMPLATE=/templates/kops/default.yaml
 
 # https://github.com/kubernetes/kops/blob/master/channels/stable
 # https://github.com/kubernetes/kops/blob/master/docs/images.md
-ENV KOPS_BASE_IMAGE=kope.io/k8s-1.9-debian-jessie-amd64-hvm-ebs-2018-03-11
+ENV KOPS_BASE_IMAGE=kope.io/k8s-1.10-debian-jessie-amd64-hvm-ebs-2018-08-17
 
 ENV KOPS_BASTION_PUBLIC_NAME="bastion"
 ENV KOPS_PRIVATE_SUBNETS="172.20.32.0/19,172.20.64.0/19,172.20.96.0/19,172.20.128.0/19"

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ ENV AWS_VAULT_ASSUME_ROLE_TTL=1h
 #
 # Install kubectl
 #
-ENV KUBERNETES_VERSION 1.10.8
+ENV KUBERNETES_VERSION 1.10.11
 ENV KUBECONFIG=${SECRETS_PATH}/kubernetes/kubeconfig
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
 

--- a/rootfs/templates/scaffolding/Dockerfile
+++ b/rootfs/templates/scaffolding/Dockerfile
@@ -15,7 +15,7 @@ ENV KOPS_STATE_STORE_REGION "{{ getenv "KOPS_STATE_STORE_REGION" "us-east-1" }}"
 
 # https://github.com/kubernetes/kops/blob/master/channels/stable
 # https://github.com/kubernetes/kops/blob/master/docs/images.md
-ENV KOPS_BASE_IMAGE="{{ getenv "KOPS_BASE_IMAGE" "kope.io/k8s-1.7-debian-jessie-amd64-hvm-ebs-2017-07-28" }}"
+ENV KOPS_BASE_IMAGE="{{ getenv "KOPS_BASE_IMAGE" "kope.io/k8s-1.10-debian-jessie-amd64-hvm-ebs-2018-08-17" }}"
 ENV KOPS_DNS_ZONE "{{ getenv "KOPS_DNS_ZONE" "kops.example.com" }}"
 ENV KOPS_BASTION_PUBLIC_NAME="{{ getenv "KOPS_BASTION_PUBLIC_NAME" "bastion" }}"
 ENV KOPS_PRIVATE_SUBNETS="{{ getenv "KOPS_PRIVATE_SUBNETS" "172.20.32.0/19,172.20.64.0/19,172.20.96.0/19,172.20.128.0/19" }}"


### PR DESCRIPTION
## what

Update default KOPS_BASE_IMAGE for 1.10

We want to bump Kops to latest 1.10.X release for CVE-2018-1002105. This
commit ensures the default Kops AMI is 1.10. See [1]

[1] https://github.com/kubernetes/kops/blob/master/channels/stable#L22

## notes

This can be merged once https://github.com/cloudposse/geodesic/pull/326 has shipped and can be rebased to only include the KOPS_BASE_IMAGE changes.