### PR TITLE
[kops/template] Add `KOPS_NETWORK_CIDR` ENV var

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -108,10 +108,10 @@ spec:
   - 0.0.0.0/0
   kubernetesVersion: {{ getenv "KUBERNETES_VERSION" }}
   masterPublicName: api.{{ getenv "KOPS_CLUSTER_NAME" }}
-  networkCIDR: 172.20.0.0/16
+  networkCIDR: {{ getenv "KOPS_NETWORK_CIDR" "172.20.0.0/16" }}
   networking:
     calico: {}
-  nonMasqueradeCIDR: 100.64.0.0/10
+  nonMasqueradeCIDR: {{ getenv "KOPS_NON_MASQUERADE_CIDR" "100.64.0.0/10" }}
   sshAccess:
   - 0.0.0.0/0
   subnets:


### PR DESCRIPTION
## what
* [kops/template] Add `KOPS_NETWORK_CIDR` ENV var

## why
* When using custom `KOPS_PRIVATE_SUBNETS` and `KOPS_UTILITY_SUBNETS`, need to update `networkCIDR` as well. Otherwise the error is thrown:

```
error: error creating cluster: Spec.Subnets[0].CIDR: Invalid value: "10.90.128.0/25": Subnet had a CIDR "10.90.128.0/25" that was not a subnet of the NetworkCIDR "172.20.0.0/16"
```
