### PR TITLE
[kube-ps1] add fancy kube PS1 prompt support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,11 @@ indent_size = 4
 [*.yaml]
 intent_style = space
 indent_size = 2
+
+[*.sh]
+indent_style = tab
+indent_size = 4
+
+[*.{tf,tfvars,tpl}]
+indent_size = 2
+indent_style = space

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,7 +181,8 @@ RUN helm plugin install https://github.com/app-registry/appr-helm-plugin --versi
 # 
 # Install fancy Kube PS1 Prompt
 #
-ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/0.6.0/kube-ps1.sh /etc/profile.d/
+ENV KUBE_PS1_VERSION 0.6.0
+ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/${KUBE_PS1_VERSION}/kube-ps1.sh /etc/profile.d/
 
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,12 @@ RUN helm plugin install https://github.com/app-registry/appr-helm-plugin --versi
     && helm plugin install https://github.com/hypnoglow/helm-s3 --version v${HELM_S3_VERSION} \
     && helm plugin install https://github.com/chartmuseum/helm-push --version v${HELM_PUSH_VERSION}
 
+# 
+# Install fancy Kube PS1 Prompt
+#
+ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/0.6.0/kube-ps1.sh /etc/profile.d/
+
+
 #
 # Terraform defaults
 #

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -71,7 +71,7 @@ function geodesic_prompt() {
 	PS1+=$'${BLACK_RIGHTWARDS_ARROWHEAD} '
 
 	if [ -n "${BANNER}" ]; then
-		PS1=$' ${BANNER_MARK}'" ${BANNER}\n"${PS1}
+		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)\n"${PS1}
 	fi
 	export PS1
 }


### PR DESCRIPTION
## what
* Add support for the fancy `PS1` prompt for kubernetes

## why
* Improved UX - show current kubernetes context/namespace
* Useful when operating with multiple kubernetes clusters

## references
* closes #290 