### PR TITLE
[aws-config-setup] Fix typo

### DIFF
--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -35,7 +35,7 @@ crudini --set ${AWS_CONFIG_FILE} "profile ${AWS_SOURCE_PROFILE}"
 # Define default profile
 crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AWS_REGION}"
 
-if [ "${AWS_ACCOUNT_ID}" == "${AWS_ROOT_ACOUNT_ID}" ]; then
+if [ "${AWS_ACCOUNT_ID}" == "${AWS_ROOT_ACCOUNT_ID}" ]; then
 	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
 else
 	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/OrganizationAccountAccessRole"


### PR DESCRIPTION
## what
* Use correct spelling of `ACCOUNT`

## why
* Typo