### PR TITLE
[kops/template] Update `aws-iam-authenticator`

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -32,28 +32,10 @@ spec:
     loadBalancer:
       type: Public
       idleTimeoutSeconds: {{ getenv "KOPS_API_LOAD_BALANCER_IDLE_TIMEOUT_SECONDS" "600" }}
-  hooks:
-  {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
-    - name: kops-hook-authenticator-config.service
-      before:
-        - kubelet.service
-      roles:
-        - Master
-      manifest: |-
-        [Unit]
-        Description=Download AWS Authenticator configs from S3
-        [Service]
-        Type=oneshot
-        ExecStart=/bin/mkdir -p /srv/kubernetes/aws-iam-authenticator
-        ExecStart=/usr/local/bin/aws s3 cp --recursive {{ getenv "KOPS_STATE_STORE" }}/{{ getenv "KOPS_CLUSTER_NAME" }}/addons/authenticator /srv/kubernetes/aws-iam-authenticator/
-  {{- end }}
   kubeAPIServer:
   {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
     authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC,AlwaysAllow" }}
     authorizationRbacSuperUser: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_RBAC_SUPER_USER" "admin" }}
-    {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
-    authenticationTokenWebhookConfigFile: /srv/kubernetes/aws-iam-authenticator/kubeconfig.yaml
-    {{- end }}
   {{- end }}
   {{- if bool (getenv "KOPS_ADMISSION_CONTROL_ENABLED" "true") }}
     admissionControl:
@@ -68,6 +50,10 @@ spec:
     - ResourceQuota
     - NodeRestriction
     - Priority
+  {{- end }}
+  {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
+  authentication:
+    aws: {}
   {{- end }}
   authorization:
     {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}


### PR DESCRIPTION
## what
* [kops/template] Update `aws-iam-authenticator` settings

## why
* Kubernetes `1.10` and newer has `aws-iam-authenticator` installed by default, no need to add scripts to install it from S3

## references
* https://github.com/kubernetes/kops/blob/master/docs/authentication.md
* https://github.com/kubernetes-sigs/aws-iam-authenticator
* https://aws.amazon.com/blogs/opensource/deploying-heptio-authenticator-kops/
* https://ifritltd.com/2018/09/09/kubernetes-authentication-with-aws-iam/

## note
* `IAM authenticator config map` (to map IAM principals to k8s users) still needs to be created and applied in TF
