### PR TITLE
[kube-ps1] Automatically enable/disable prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,8 +186,7 @@ RUN helm plugin install https://github.com/app-registry/appr-helm-plugin --versi
 # Install fancy Kube PS1 Prompt
 #
 ENV KUBE_PS1_VERSION 0.6.0
-ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/${KUBE_PS1_VERSION}/kube-ps1.sh /etc/profile.d/
-
+ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/${KUBE_PS1_VERSION}/kube-ps1.sh /etc/profile.d/prompt:kube-ps1.sh
 
 #
 # Terraform defaults

--- a/rootfs/etc/profile.d/geodesic.kube-ps1.sh
+++ b/rootfs/etc/profile.d/geodesic.kube-ps1.sh
@@ -1,0 +1,20 @@
+PROMPT_HOOKS+=("kube_ps1_cache_buster")
+function kube_ps1_cache_buster() {
+	# If config cache is empty
+	if [ -z "${KUBE_PS1_KUBECONFIG_CACHE}" ]; then
+		# And we have a config
+		if [ -f "${KUBECONFIG}" ]; then
+			# Then turn on the prompt
+			kubeon
+			_kube_ps1_get_context_ns
+		fi
+	else
+		# Config cache is not empty, but the file doesn't exist
+		if [ ! -f "${KUBE_PS1_KUBECONFIG_CACHE}" ]; then
+			# Then turn off the prompt
+			unset KUBE_PS1_KUBECONFIG_CACHE
+			kubeoff
+			_kube_ps1_get_context_ns
+		fi
+	fi
+}


### PR DESCRIPTION
## what
* Turn prompt on when `KUBECONFIG` found (`kubeon`)
* Turn prompt off when `KUBE_PS1_KUBECONFIG_CACHE` is no longer found (`kubeoff`)

## why
* `kube-ps1` does not properly handle kubeconfigs that go missing (it keeps displaying the last known context)
* Improve the UX by not expecting users to know they should run `kubeon` and `kubeoff`
