### PR TITLE
Set TF_PLUGIN_CACHE_DIR at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,11 +189,6 @@ ENV KUBE_PS1_VERSION 0.6.0
 ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/${KUBE_PS1_VERSION}/kube-ps1.sh /etc/profile.d/prompt:kube-ps1.sh
 
 #
-# Terraform defaults
-#
-ENV TF_PLUGIN_CACHE_DIR=/localhost/.terraform.d/plugins
-
-#
 # AWS
 #
 ENV AWS_DATA_PATH=/localhost/.aws/

--- a/rootfs/etc/profile.d/terraform.sh
+++ b/rootfs/etc/profile.d/terraform.sh
@@ -13,3 +13,6 @@ function terraform_prompt() {
 if [ -x '/usr/bin/terraform' ]; then
 	complete -C /usr/bin/terraform terraform
 fi
+
+# Set default plugin cache dir
+export TF_PLUGIN_CACHE_DIR="${TF_PLUGIN_CACHE_DIR:-/localhost/.terraform.d/plugins}"


### PR DESCRIPTION
## what

Move `TF_PLUGIN_CACHE_DIR` to runtime var

## why

This should be a non breaking change as it defaults to 
`/localhost/.terraform/plugins` but allows us to override if necessary
e.g. The atlantis user does not have write access to /localhost