### PR TITLE
[atlantis] Turn on auto approve

### DIFF
--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -31,7 +31,7 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 	export TF_INPUT=false
 
 	# Disable color on all terraform commands
-	export TF_CLI_ARGS="${TF_CLI_ARGS:--no-color}"
+	export TF_CLI_DEFAULT_NO_COLOR=true
 
 	# Auto approve apply
 	export TF_CLI_APPLY_AUTO_APPROVE=true

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -33,6 +33,9 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 	# Disable color on all terraform commands
 	export TF_CLI_ARGS="${TF_CLI_ARGS:--no-color}"
 
+	# Auto approve apply
+	export TF_CLI_APPLY_AUTO_APPROVE=true
+
 	# Disable color terminals (direnv)
 	export TERM=dumb
 


### PR DESCRIPTION
## what
* Turn on `-auto-approve` in `atlantis`

## why
* Atlantis cannot prompt the user for interactive approval (That's what Pull Request "approvals" are for..)