### PR TITLE
[direnv] Add atlantis support for planfile

### DIFF
--- a/rootfs/etc/direnv/rc.d/atlantis
+++ b/rootfs/etc/direnv/rc.d/atlantis
@@ -1,0 +1,13 @@
+# Usage: use_atlantis [...]
+#
+# Support the atlantis `PLANFILE` argument by mapping it to a `TF_CLI_` environment variable
+# <https://www.runatlantis.io/docs/atlantis-yaml-reference.html#reference>
+# This should be called before `use tfenv`
+#
+function use_atlantis() {
+	if [ -n "${PLANFILE}" ]; then
+		# The `TF_CLI_*` envs are handled by <https://github.com/cloudposse/tfenv>
+		export TF_CLI_PLAN_OUT=${PLANFILE}
+		export TF_CLI_APPLY=${PLANFILE}
+	fi
+}

--- a/rootfs/etc/direnv/rc.d/terraform
+++ b/rootfs/etc/direnv/rc.d/terraform
@@ -2,10 +2,12 @@
 #
 # Load environment variables for a `terraform` project.
 # Any arguments given will be passed to the terraform project.
+# This should be called before `use tfenv`
 # 
 function use_terraform() {
 
 	# The environment mapping below is not strictly necessary. Setting the `TF_CLI_*` envs is recommended.
+	# The `TF_CLI_*` envs are handled by <https://github.com/cloudposse/tfenv>
 	# This is done to preserve backwards compatibility with older environments and should eventually be deprecated.
 	#
 	# Terraform backend for a given project using envs


### PR DESCRIPTION
## what
* Add `use atlantis` direnv stdlib function

## why
* This adds `atlantis` specific run-time functionality that we can use with `tfenv` to support [planfiles](https://www.terraform.io/docs/commands/plan.html#out-path)

## use-case

Run `terraform plan` and `terraform apply` and automatically use planfiles without needing to pass any arguments