### PR TITLE
Add helm-git plugin instead of helm-github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,7 @@ RUN helm repo add cloudposse-incubator https://charts.cloudposse.com/incubator/ 
 ENV HELM_APPR_VERSION 0.7.0
 ENV HELM_DIFF_VERSION 2.11.0+2
 ENV HELM_EDIT_VERSION 0.2.0
-ENV HELM_GITHUB_VERSION 0.2.0
+ENV HELM_GIT_VERSION 0.3.0
 ENV HELM_SECRETS_VERSION 1.2.9
 ENV HELM_S3_VERSION 0.7.0
 ENV HELM_PUSH_VERSION 0.7.1
@@ -184,7 +184,7 @@ RUN helm plugin install https://github.com/app-registry/appr-helm-plugin --versi
     && helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} \
     && helm plugin install https://github.com/mstrzele/helm-edit --version v${HELM_EDIT_VERSION} \
     && helm plugin install https://github.com/futuresimple/helm-secrets --version ${HELM_SECRETS_VERSION} \
-    && helm plugin install https://github.com/sagansystems/helm-github --version ${HELM_GITHUB_VERSION} \
+    && helm plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \
     && helm plugin install https://github.com/hypnoglow/helm-s3 --version v${HELM_S3_VERSION} \
     && helm plugin install https://github.com/chartmuseum/helm-push --version v${HELM_PUSH_VERSION}
 


### PR DESCRIPTION
## what

Add helm-git plugin instead of helm-github

## why

We would like a a way to release from non-packages helm repositories, 
directly from git, with a ref and path specification. See [1]

`helm-git` supports `git` scheme making it compatible with `helmfile`

This closes [2]

[1] https://github.com/roboll/helmfile/issues/435
[2] https://github.com/cloudposse/geodesic/issues/355