### PR TITLE
Better support for aws-iam-authenticator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,6 @@ ENV AWS_OKTA_ENABLED=false
 # Install kubectl
 #
 ENV KUBERNETES_VERSION 1.10.11
-ENV KUBECONFIG=${SECRETS_PATH}/kubernetes/kubeconfig
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
 ENV KUBECTX_COMPLETION_VERSION 0.6.2
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubens.bash /etc/bash_completion.d/kubens.sh
@@ -139,7 +138,10 @@ ENV KOPS_BASTION_PUBLIC_NAME="bastion"
 ENV KOPS_PRIVATE_SUBNETS="172.20.32.0/19,172.20.64.0/19,172.20.96.0/19,172.20.128.0/19"
 ENV KOPS_UTILITY_SUBNETS="172.20.0.0/22,172.20.4.0/22,172.20.8.0/22,172.20.12.0/22"
 ENV KOPS_AVAILABILITY_ZONES="us-west-2a,us-west-2b,us-west-2c"
+
 ENV KUBECONFIG=/dev/shm/kubecfg
+ENV KUBECONFIG_TEMPLATE=/templates/kops/kubecfg.yaml
+
 RUN /usr/bin/kops completion bash > /etc/bash_completion.d/kops.sh
 
 # Instance sizes

--- a/rootfs/etc/profile.d/_colors.sh
+++ b/rootfs/etc/profile.d/_colors.sh
@@ -13,3 +13,9 @@ function yellow() {
 function cyan() {
 	echo "$(tput setaf 6)$*$(tput sgr0)"
 }
+
+export FZF_DEFAULT_OPTS='
+  --color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
+  --color=fg:#839496,header:#586e75,info:#cb4b16,pointer:#719e07
+  --color=marker:#719e07,fg+:#839496,prompt:#719e07,hl+:#719e07
+'

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -50,13 +50,13 @@ if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
 
 	# Start a shell or run a command with an assumed role
 	function aws_vault_assume_role() {
-		role=${1:-$(choose_role_interactive)}
-
 		# Do not allow nested roles
 		if [ -n "${AWS_VAULT}" ]; then
 			echo "Type '$(green exit)' before attempting to assume another role"
 			return 1
 		fi
+
+		role=${1:-$(choose_role_interactive)}
 
 		if [ -z "${role}" ]; then
 			echo "Usage: $0 [role]"

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -35,9 +35,22 @@ if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
 		fi
 	}
 
+	function choose_role_interactive() {
+		_preview="${FZF_PREVIEW:-crudini --format=ini --get "$AWS_CONFIG_FILE" 'profile {}'}"
+		crudini --get "${AWS_CONFIG_FILE}" |
+			awk -F ' ' '{print $2}' |
+			fzf \
+				--height 30% \
+				--reverse \
+				--prompt='-> ' \
+				--header 'Select AWS profile' \
+				--query "${AWS_ORG:-${NAMESPACE}}-" \
+				--preview "$_preview"
+	}
+
 	# Start a shell or run a command with an assumed role
 	function aws_vault_assume_role() {
-		role=${1:-${AWS_DEFAULT_PROFILE}}
+		role=${1:-$(choose_role_interactive)}
 
 		# Do not allow nested roles
 		if [ -n "${AWS_VAULT}" ]; then

--- a/rootfs/templates/kops/kubecfg.yaml
+++ b/rootfs/templates/kops/kubecfg.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+
+clusters:
+- cluster:
+    server: https://{{ getenv "KOPS_API_SERVER" }}
+    certificate-authority-data: {{ getenv "KOPS_CLUSTER_CA" | base64.Encode }}
+  name: {{ getenv "KOPS_CLUSTER_NAME" }}
+
+contexts:
+- context:
+    cluster: {{ getenv "KOPS_CLUSTER_NAME" }}
+    user: {{ getenv "KOPS_CLUSTER_NAME" }}
+  name: {{ getenv "KOPS_CLUSTER_NAME" }}
+
+current-context: {{ getenv "KOPS_CLUSTER_NAME" }}
+
+{{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
+users:
+- name: {{ getenv "KOPS_CLUSTER_NAME" }}
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: aws-iam-authenticator
+      args:
+        - token
+        - -i
+        - {{ getenv "KOPS_CLUSTER_NAME" }}
+{{- end }}

--- a/rootfs/usr/local/bin/build-kubecfg
+++ b/rootfs/usr/local/bin/build-kubecfg
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eo pipefail
+
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+KUBECONFIG_DIR="$(dirname "$KUBECONFIG")"
+EXTRA_ARGS=${@:1}
+GOMPLATE_EXTRA_ARGS=${EXTRA_ARGS:-$GOMPLATE_EXTRA_ARGS}
+
+mkdir -p ${KUBECONFIG_DIR}
+
+function ensure_env_vars() {
+	export KOPS_API_SERVER="${KOPS_API_SERVER:-api.$KOPS_CLUSTER_NAME}"
+	export KOPS_CLUSTER_CA="$(cluster_ca)"
+
+	if [ -z "$KOPS_API_SERVER" ]; then
+		echo "KOPS_API_SERVER not defined"
+		exit 1
+	fi
+
+	if [ -z "$KOPS_CLUSTER_CA" ]; then
+		echo "KOPS_CLUSTER_CA not defined"
+		exit 1
+	fi
+}
+
+function cluster_ca() {
+	openssl s_client -connect "$KOPS_API_SERVER":443 2>&1 </dev/null | sed -ne '/BEGIN CERT/,/END CERT/p'
+}
+
+function write_kube_config() {
+	direnv exec ${KUBECONFIG_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} -f ${KUBECONFIG_TEMPLATE} >${KUBECONFIG}
+}
+
+ensure_env_vars
+write_kube_config
+
+echo "Wrote configuration to ${KUBECONFIG}..."

--- a/rootfs/usr/local/bin/kopsctl
+++ b/rootfs/usr/local/bin/kopsctl
@@ -22,6 +22,17 @@ tasks:
     description: "Operations to perform on the kops cluster"
 
     tasks:
+      # kubecfg operationss
+      kubecfg:
+        description: "Manage kubernetes client configuration (kubecfg)"
+        tasks:
+          # Writes out kubecfg
+          build:
+            description: "Build kubecfg"
+            script:
+            - *exit_on_errors
+            - build-kubecfg
+
       # Show a plan of pending changes
       plan:
         description: "Show a plan of pending changes"

--- a/rootfs/usr/local/bin/kopsctl
+++ b/rootfs/usr/local/bin/kopsctl
@@ -17,22 +17,18 @@ mixins:
 
 tasks:
 
+  login:
+    # Write out kubecfg
+    description: "Login to Kops cluster uusing IAM role"
+    script:
+    - *exit_on_errors
+    - build-kubecfg
+
  # Cluster Operations
   cluster:
     description: "Operations to perform on the kops cluster"
 
     tasks:
-      # kubecfg operationss
-      kubecfg:
-        description: "Manage kubernetes client configuration (kubecfg)"
-        tasks:
-          # Writes out kubecfg
-          build:
-            description: "Build kubecfg"
-            script:
-            - *exit_on_errors
-            - build-kubecfg
-
       # Show a plan of pending changes
       plan:
         description: "Show a plan of pending changes"


### PR DESCRIPTION
## what

This commit adds a command `kopsctl login` to build a kubecfg that optionally can use
aws-iam-authenticator, given we have the `KOPS_AWS_IAM_AUTHENTICATOR_ENABLED` set to true

## why

We want to enable RBAC using aws-iam-authenticator to auth users against the Kops cluster via IAM roles.

Note that we have to fetch the CA data using `openssl s_client` as we don’t have a kubecfg to pull it from yet and we don't want to have to access the Kops state store S3 bucket where this information is stored.

Note this is a non breaking change and while we _can_ use the templated `kubecfg`, as admin operators, we can still run `kops export kubectl`.

`kopsctl login` should be run after assuming an AWS role within Geodesic.

There will be further PRs to create specific IAM roles for `KubernetesAdmin` and `KubernetesRead` See: https://github.com/cloudposse/terraform-root-modules/pull/111

## Testing

Given an aws-iam-authenticator configMap of:

```
clusterID: us-west-2.testing.cloudposse.co
    server:
      mapRoles:
      - roleARN: arn:aws:iam::126450723953:role/KubernetesAdmin
        username: kubernetes-admin
        groups: ["system:masters"]
      - roleARN: arn:aws:iam::126450723953:role/KubernetesReadOnly
        username: kubernetes-readonly
        groups: ["system:authenticated"]
```
and `~/.aws/config` containing:

```
[profile cpco-testing-admin]
region         = us-west-2
role_arn       = arn:aws:iam::126450723953:role/OrganizationAccountAccessRole
mfa_serial     = arn:aws:iam::323330167063:mfa/josh
source_profile = cpco

[profile cpco-testing-admin-kubernetes]
region         = us-west-2
role_arn       = arn:aws:iam::126450723953:role/KubernetesAdmin
mfa_serial     = arn:aws:iam::323330167063:mfa/josh
source_profile = cpco

[profile cpco-testing-readonly-kubernetes]
region         = us-west-2
role_arn       = arn:aws:iam::126450723953:role/KubernetesReadOnly
mfa_serial     = arn:aws:iam::323330167063:mfa/josh
source_profile = cpco

[profile cpco-root-admin]
region         = us-west-2
role_arn       = arn:aws:iam::323330167063:role/cpco-root-admin
mfa_serial     = arn:aws:iam::323330167063:mfa/josh
source_profile = cpco

[profile cpco]
```

![cp](https://user-images.githubusercontent.com/3025844/52557424-4338c500-2de7-11e9-83a1-ab027cb502b7.gif)

---
login to `testing.cloudposse.co` geodesic

Try and `kubectl get nodes`:
```
 ✗   (none) ~ ⨠  kubectl get nodes
The connection to the server localhost:8080 was refused - did you specify the right host or port?
``` 

Build our kubecfg:
```
 ✗   (none) ~ ⨠  kopsctl cluster kubecfg build
kopsctl ≫ starting task cluster.kubecfg.build
Wrote configuration to /dev/shm/kubecfg...
 ⧉  testing (⎈ |us-west-2.testing.cloudposse.co:default)
```

Check our kubecfg:

```
 ✗   (none) ~ ⨠  cat /dev/shm/kubecfg
apiVersion: v1
kind: Config
preferences: {}

clusters:
- cluster:
    server: https://api.us-west-2.testing.cloudposse.co
    certificate-authority-data: <<REDACTED>>
  name: us-west-2.testing.cloudposse.co

contexts:
- context:
    cluster: us-west-2.testing.cloudposse.co
    user: us-west-2.testing.cloudposse.co
  name: us-west-2.testing.cloudposse.co

current-context: us-west-2.testing.cloudposse.co
users:
- name: us-west-2.testing.cloudposse.co
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      command: aws-iam-authenticator
      args:
        - token
        - -i
        - us-west-2.testing.cloudposse.co
```

Try and get nodes without having assumed our IAM role:

```
 ✗   (none) ~ ⨠  kubectl get nodes
could not get token: could not create session: SharedConfigAssumeRoleError: failed to load assume role for arn:aws:iam::126450723953:role/OrganizationAccountAccessRole, source profile has no shared credentials
could not get token: could not create session: SharedConfigAssumeRoleError: failed to load assume role for arn:aws:iam::126450723953:role/OrganizationAccountAccessRole, source profile has no shared credentials
could not get token: could not create session: SharedConfigAssumeRoleError: failed to load assume role for arn:aws:iam::126450723953:role/OrganizationAccountAccessRole, source profile has no shared credentials
could not get token: could not create session: SharedConfigAssumeRoleError: failed to load assume role for arn:aws:iam::126450723953:role/OrganizationAccountAccessRole, source profile has no shared credentials
could not get token: could not create session: SharedConfigAssumeRoleError: failed to load assume role for arn:aws:iam::126450723953:role/OrganizationAccountAccessRole, source profile has no shared credentials
Unable to connect to the server: getting credentials: exec: exit status 1
```

Assume IAM role so we can successfully run some kubectl commands:

```
 ⧉  testing (⎈ |us-west-2.testing.cloudposse.co:default)
 ✗   (none) ~ ⨠  assume-role
Enter passphrase to unlock /conf/.awsvault/keys/:
* Assumed role arn:aws:iam::126450723953:role/OrganizationAccountAccessRole
 ✓   (cpco-testing-admin) ~ ⨠  kubectl get nodes
NAME                                           STATUS     ROLES    AGE   VERSION
ip-172-20-100-72.us-west-2.compute.internal    Ready      master   2d    v1.10.11
ip-172-20-111-167.us-west-2.compute.internal   Ready      node     25d   v1.10.11
ip-172-20-35-199.us-west-2.compute.internal    Ready      node     15d   v1.10.11
ip-172-20-41-111.us-west-2.compute.internal    Ready      master   2d    v1.10.11
ip-172-20-45-164.us-west-2.compute.internal    Ready      node     58d   v1.10.11
ip-172-20-92-206.us-west-2.compute.internal    Ready      node     3d    v1.10.11
ip-172-20-94-81.us-west-2.compute.internal     NotReady   master   2d    v1.10.11
```