### PR TITLE
Fixing SSH agent for Atlantis

### DIFF
--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -69,7 +69,7 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 
 	# Add SSH key to agent, if one is configured so we can pull from private git repos
 	if [ -n "${ATLANTIS_SSH_PRIVATE_KEY}" ]; then
-		source <(ssh-agent -s)
+		source <(gosu ${ATLANTIS_USER} ssh-agent -s)
 		ssh-add - <<<${ATLANTIS_SSH_PRIVATE_KEY}
 		# Sanitize environment
 		unset ATLANTIS_SSH_PRIVATE_KEY


### PR DESCRIPTION
This PR fixes the SSH agent for Atlantis by running it under the "ATLANTIS_USER" account.