### PR TITLE
[kopsctl] add commands to facilitate management of cluster

### DIFF
--- a/rootfs/usr/local/bin/kopsctl
+++ b/rootfs/usr/local/bin/kopsctl
@@ -26,9 +26,9 @@ tasks:
       plan:
         description: "Show a plan of pending changes"
         script:
+        - *exit_on_errors
         - *chamber
         - |
-          set -e
           kops cluster update
           kops cluster rolling-update
 
@@ -36,9 +36,9 @@ tasks:
       apply:
         description: "Apply pending changes"
         script:
+        - *exit_on_errors
         - *chamber
         - |
-          set -e
           kops update cluster --yes
           kops rolling-update cluster --force --yes 
 
@@ -51,7 +51,6 @@ tasks:
           default: admin
           description: "SSH Public Key secret name"
           required: true
-      
         tasks:
           # Connect to bastion instance
           bastion:

--- a/rootfs/usr/local/bin/kopsctl
+++ b/rootfs/usr/local/bin/kopsctl
@@ -80,7 +80,7 @@ tasks:
 
           # Delete Public Key
           delete:
-            description: "Rotate the cluster SSH key pair"
+            description: "Delete the cluster SSH public key"
             script:
             - *exit_on_errors
             - *chamber

--- a/rootfs/usr/local/bin/kopsctl
+++ b/rootfs/usr/local/bin/kopsctl
@@ -32,7 +32,7 @@ tasks:
           kops cluster update
           kops cluster rolling-update
 
-      # Apply pendnig changes
+      # Apply pending changes
       apply:
         description: "Apply pending changes"
         script:

--- a/rootfs/usr/local/bin/kopsctl
+++ b/rootfs/usr/local/bin/kopsctl
@@ -1,0 +1,100 @@
+#!/usr/bin/variant
+# vim:set ft=yaml
+
+mixins:
+  # Import chamber environment
+  chamber: &chamber
+    source <(chamber exec kops -- sh -c 'export -p' 2>/dev/null)
+
+  # Exit on all errors
+  exit_on_errors: &exit_on_errors
+    set -e
+
+  # Default runner
+  runner: &runner
+    command: "bash"
+    args: ["-ex", "-c"]
+
+tasks:
+
+ # Cluster Operations
+  cluster:
+    description: "Operations to perform on the kops cluster"
+
+    tasks:
+      # Show a plan of pending changes
+      plan:
+        description: "Show a plan of pending changes"
+        script:
+        - *chamber
+        - |
+          set -e
+          kops cluster update
+          kops cluster rolling-update
+
+      # Apply pendnig changes
+      apply:
+        description: "Apply pending changes"
+        script:
+        - *chamber
+        - |
+          set -e
+          kops update cluster --yes
+          kops rolling-update cluster --force --yes 
+
+      # SSH Operations
+      ssh:
+        description: "SSH Key Management"
+        parameters:
+        - name: name
+          type: string
+          default: admin
+          description: "SSH Public Key secret name"
+          required: true
+      
+        tasks:
+          # Connect to bastion instance
+          bastion:
+            description: "Connect to the bastion using ssh-agent forwarding"
+            interactive: true
+            <<: *runner
+            script:
+            - *exit_on_errors
+            - *chamber
+            - |
+              eval $(ssh-agent -s)
+              ssh-add - <<<${KOPS_SSH_PRIVATE_KEY}
+              ssh -A admin@bastion.${KOPS_CLUSTER_NAME}
+              eval $(ssh-agent -k) >/dev/null
+
+           # Create Public Key 
+          create:
+            description: "Create the cluster SSH public key"
+            script:
+            - *exit_on_errors
+            - *chamber
+            - |
+              public_key_file=$(mktemp)
+              chamber read kops -q kops_ssh_public_key > "${public_key_file}"
+              kops create secret sshpublickey {{ get "name" }} -i "${public_key_file}"
+              rm -f "${public_key_file}"
+
+          # Delete Public Key
+          delete:
+            description: "Rotate the cluster SSH key pair"
+            script:
+            - *exit_on_errors
+            - *chamber
+            - |
+              kops delete secret sshpublickey {{ get "name" }}
+
+          # Key Rotation
+          rotate:
+            description: "Rotate the cluster SSH public key"
+            steps:
+              - or:
+                - task: "cluster.ssh.delete"
+                - script: "true"
+              - task: "cluster.ssh.create"
+              - task: "cluster.apply"
+


### PR DESCRIPTION
## what
* Add commands to easily rotate a kops cluster's ssh keys
* Add command to easily connect to a kops cluster
* Add command to see a kops plan

## why
* This are routine operations that are complicated to express in documentation

## example
![image](https://user-images.githubusercontent.com/52489/52320208-dce51a00-2982-11e9-98c0-aa7c047468a8.png)
![image](https://user-images.githubusercontent.com/52489/52320212-e2dafb00-2982-11e9-9274-8acc4aa3b701.png)
