### PR TITLE
Default to AWS_DEFAULT_PROFILE for IAM assume-role

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -48,6 +48,10 @@ if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
 				--preview "$_preview"
 	}
 
+	function choose_role() {
+		[ -n "${ASSUME_ROLE_INTERACTIVE}" ] && echo "$(choose_role_interactive)" || echo "${AWS_DEFAULT_PROFILE}"
+	}
+
 	# Start a shell or run a command with an assumed role
 	function aws_vault_assume_role() {
 		# Do not allow nested roles
@@ -56,7 +60,7 @@ if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
 			return 1
 		fi
 
-		role=${1:-$(choose_role_interactive)}
+		role=${1:-$(choose_role)}
 
 		if [ -z "${role}" ]; then
 			echo "Usage: $0 [role]"


### PR DESCRIPTION
## what
Default to AWS_DEFAULT_PROFILE for IAM assume-role

## why
If AWS_IAM_ROLE_INTERACTIVE is not set, we default to previous behaviour
of using AWS_DEFAULT_PROFILE and not prompting via selector. Rather
than removing our (CloudPosse) use of AWS_DEFAULT_PROFILE from the stage
Dockerfiles, check for the presence of AWS_IAM_ROLE_INTERACTIVE var. AWS_DEFAULT_PROFILE is used in other places, so we don’t want to remove it. 

`assume-role` therefore has the following precedence:

`assume-role $role` - assumes $role
`assume-role`           - with AWS_IAM_ROLE_INTERACTIVE set will prompt with a  role selector 
`assume-role`           - assumes $AWS_DEFAULT_PROFILE