### PR TITLE
Rename aws-vault server enabled flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,10 @@ RUN ln -s /usr/local/google-cloud-sdk/completion.bash.inc /etc/bash_completion.d
 # Configure aws-vault to easily assume roles (not related to HashiCorp Vault)
 #
 ENV AWS_VAULT_ENABLED=true
+ENV AWS_VAULT_SERVER_ENABLED=false
 ENV AWS_VAULT_BACKEND=file
 ENV AWS_VAULT_ASSUME_ROLE_TTL=1h
+ENV AWS_VAULT_SESSION_TTL=12h
 #ENV AWS_VAULT_FILE_PASSPHRASE=
 
 #
@@ -199,7 +201,7 @@ ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/${KUBE_PS1_VERSION}/kube
 #
 # AWS
 #
-ENV AWS_DATA_PATH=/localhost/.aws/
+ENV AWS_DATA_PATH=/localhost/.aws
 ENV AWS_CONFIG_FILE=${AWS_DATA_PATH}/config
 ENV AWS_SHARED_CREDENTIALS_FILE=${AWS_DATA_PATH}/credentials
 

--- a/packages.txt
+++ b/packages.txt
@@ -52,6 +52,7 @@ shfmt@cloudposse
 sops@cloudposse
 sshpass
 stern@cloudposse
+sudo
 syslog-ng
 tar
 terraform@cloudposse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==2.7.5
 awsebcli==3.14.8
-awscli==1.16.96
+awscli==1.16.113
 boto==2.49.0
 crudini==0.9
 Jinja2==2.10

--- a/rootfs/etc/profile.d/aws-okta.sh
+++ b/rootfs/etc/profile.d/aws-okta.sh
@@ -36,7 +36,7 @@ if [ "${AWS_OKTA_ENABLED}" == "true" ]; then
 		fi
 
 		if [ -z "${role}" ]; then
-			echo "Usage: $0 [role]"
+			echo "Usage: assume-role [role]"
 			return 1
 		fi
 		# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -56,7 +56,7 @@ if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
 	}
 
 	function choose_role() {
-		if [ -n "${ASSUME_ROLE_INTERACTIVE}" ]; then
+		if [ "${ASSUME_ROLE_INTERACTIVE:-true}" == "true" ]; then
 			echo "$(choose_role_interactive)"
 		else
 			echo "${AWS_DEFAULT_PROFILE}"


### PR DESCRIPTION
## what
* `$0` does not emit a helpful 
* Add `sudo` so the `--server` mode flag works without the `aws-vault server&` hack
* Update `aws-cli`
* Normalize `AWS_VAULT_SERVER_ENABLED` env
* Add support for `AWS_VAULT_SESSION_TTL`

## why
* `aws-vault` appears to be having some trouble with `--server` mode; rather than rip it out entirely, we'll disable it by default for now

## references
* https://github.com/99designs/aws-vault/issues/339
* https://github.com/99designs/aws-vault/issues/338
* https://github.com/99designs/aws-vault/issues/335
