### PR TITLE
profile.d: copy and use inputrc from localhost

### DIFF
--- a/rootfs/etc/profile.d/inputrc.sh
+++ b/rootfs/etc/profile.d/inputrc.sh
@@ -1,7 +1,4 @@
-# If we can, and do not have one, copy inputrc from localhost.
-[ -f ~/.inputrc ] && [ -f /localhost/.inputrc ] || {
-	cp /localhost/.inputrc ~/.inputrc &&
-		# Use new bindings for current shell.
-		bind -f ~/.inputrc
-}
-# Subsequent shells automatically read ${INPUTRC-"~/.inputrc"} at startup.
+# If we do not have one of our own, source inputrc from localhost.
+[ ! -f ~/.inputrc ] && [ -f /localhost/.inputrc ] &&
+	# Use new bindings for current shell.
+	bind -f /localhost/.inputrc

--- a/rootfs/etc/profile.d/inputrc.sh
+++ b/rootfs/etc/profile.d/inputrc.sh
@@ -1,7 +1,7 @@
 # If we can, and do not have one, copy inputrc from localhost.
 [ -f ~/.inputrc ] && [ -f /localhost/.inputrc ] || {
-    cp /localhost/.inputrc ~/.inputrc &&
-        # Use new bindings for current shell.
-        bind -f ~/.inputrc ;
+	cp /localhost/.inputrc ~/.inputrc &&
+		# Use new bindings for current shell.
+		bind -f ~/.inputrc
 }
 # Subsequent shells automatically read ${INPUTRC-"~/.inputrc"} at startup.

--- a/rootfs/etc/profile.d/inputrc.sh
+++ b/rootfs/etc/profile.d/inputrc.sh
@@ -1,0 +1,7 @@
+# if we do not have one, copy from localhost, and use bindings for this shell
+[ -f ~/.inputrc ] || {
+    cp /localhost/.inputrc ~/.inputrc &&
+        bind -f ~/.inputrc ;
+}
+# subsequent shells will read ~/.inputrc at startup, unless INPUTRC is set.
+

--- a/rootfs/etc/profile.d/inputrc.sh
+++ b/rootfs/etc/profile.d/inputrc.sh
@@ -1,4 +1,5 @@
 # If we do not have one of our own, source inputrc from localhost.
-[ ! -f ~/.inputrc ] && [ -f /localhost/.inputrc ] &&
+if [ ! -f ~/.inputrc ] && [ -f /localhost/.inputrc ]; then
 	# Use new bindings for current shell.
 	bind -f /localhost/.inputrc
+fi

--- a/rootfs/etc/profile.d/inputrc.sh
+++ b/rootfs/etc/profile.d/inputrc.sh
@@ -1,7 +1,7 @@
-# if we do not have one, copy from localhost, and use bindings for this shell
-[ -f ~/.inputrc ] || {
+# If we can, and do not have one, copy inputrc from localhost.
+[ -f ~/.inputrc ] && [ -f /localhost/.inputrc ] || {
     cp /localhost/.inputrc ~/.inputrc &&
+        # Use new bindings for current shell.
         bind -f ~/.inputrc ;
 }
-# subsequent shells will read ~/.inputrc at startup, unless INPUTRC is set.
-
+# Subsequent shells automatically read ${INPUTRC-"~/.inputrc"} at startup.


### PR DESCRIPTION
## what

adds a small profile.d script that copies the user's homedir `.inputrc` if it exists at geodesic container startup.

## why

Readline keybindings are typically stored in a user's `~/.intputrc`.
This script allows those keybindings to smoothly flow into the geodesic env.