### PR TITLE
Intelligently sync the clocks when they are out of sync

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -80,12 +80,12 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 		# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift.
 		# Assume whichever clock is behind by more than 10 seconds is wrong, since virtual clocks
 		# almost never gain time.
-		let diff=$(date '+%s')-$(date -d "`hwclock -r`" '+%s')
+		let diff=$(date '+%s')-$(date -d "$(hwclock -r)" '+%s')
 		if [ $diff -gt 10 ]; then
-          hwclock -w >/dev/null 2>&1
-        elif [ $diff -lt -10 ]; then 
-	      # (Only works in privileged mode)
-		  hwclock -s >/dev/null 2>&1
+			hwclock -w >/dev/null 2>&1
+		elif [ $diff -lt -10 ]; then
+			# (Only works in privileged mode)
+			hwclock -s >/dev/null 2>&1
 		fi
 		if [ $? -ne 0 ]; then
 			echo "* $(yellow Failed to sync system time from hardware clock)"

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
+if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 	if ! which aws-vault >/dev/null; then
 		echo "aws-vault not installed"
 		exit 1
@@ -77,9 +77,16 @@ if [ "${AWS_VAULT_ENABLED}" == "true" ]; then
 			echo "Usage: assume-role [role]"
 			return 1
 		fi
-		# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift
-		# (Only works in privileged mode)
-		hwclock -s >/dev/null 2>&1
+		# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift.
+		# Assume whichever clock is behind by more than 10 seconds is wrong, since virtual clocks
+		# almost never gain time.
+		let diff=$(date '+%s')-$(date -d "`hwclock -r`" '+%s')
+		if [ $diff -gt 10 ]; then
+          hwclock -w >/dev/null 2>&1
+        elif [ $diff -lt -10 ]; then 
+	      # (Only works in privileged mode)
+		  hwclock -s >/dev/null 2>&1
+		fi
 		if [ $? -ne 0 ]; then
 			echo "* $(yellow Failed to sync system time from hardware clock)"
 		fi


### PR DESCRIPTION
## what
When the System Time and the Hardware Clock disagree, sync them.

Specifically, if one clock is behind the other by more than 10 seconds, set the lagging clock to the leading clock, because it is almost always the case that the slow clock is wrong.

## why
AWS credentials have very limited lifetime which is enforced by tying their validity to real-world time. If the clock is wrong, then authentication will fail, so accurate real-world time is essential.
