### PR TITLE
[.inputrc] Use symlink in /conf instead of another script

### DIFF
--- a/rootfs/conf/.inputrc
+++ b/rootfs/conf/.inputrc
@@ -1,0 +1,1 @@
+/localhost/.inputrc

--- a/rootfs/etc/profile.d/inputrc.sh
+++ b/rootfs/etc/profile.d/inputrc.sh
@@ -1,5 +1,0 @@
-# If we do not have one of our own, source inputrc from localhost.
-if [ ! -f ~/.inputrc ] && [ -f /localhost/.inputrc ]; then
-	# Use new bindings for current shell.
-	bind -f /localhost/.inputrc
-fi


### PR DESCRIPTION
## What's changing

Removes the script `profile.d/inputrc.sh`.
In its place, we add symlink to the default geodesic user's home directory:
   `/conf/.inputrc -> /localhost/.inputrc` 

This seems simpler than a script that tests for and reads the file from `/localhost`.

## Why

Why add a script when a simple symlink suffices?