### PR TITLE
[fzf] Fix for non-interactive mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,6 @@ COPY packages.txt /etc/apk/
 
 RUN apk add --update $(grep -v '^#' /etc/apk/packages.txt) && \
     mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
-    ln -s /usr/share/bash-completion/completions/fzf /etc/bash_completion.d/fzf.sh && \
     touch /conf/.gitconfig
 
 RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -1,7 +1,5 @@
-
 # Install fzf shell completion when an interactive shell is enabled
 # This is a fix for: `/etc/bash_completion.d/fzf.sh: line 34: bind: warning: line editing not enabled`
 if [ -t 1 ]; then
 	ln -s /usr/share/bash-completion/completions/fzf /etc/bash_completion.d/fzf.sh
 fi
-

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -1,0 +1,7 @@
+
+# Install fzf shell completion when an interactive shell is enabled
+# This is a fix for: `/etc/bash_completion.d/fzf.sh: line 34: bind: warning: line editing not enabled`
+if [ -t 1 ]; then
+	ln -s /usr/share/bash-completion/completions/fzf /etc/bash_completion.d/fzf.sh
+fi
+


### PR DESCRIPTION
## what
* Disable bash completion for `fzf` if non-interactive terminal

## why
* The upstream bash completion script has a bug where it doesn't handle this use-case