### PR TITLE
[aws-vault] add feature flag for time drift correction

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -77,18 +77,27 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 			echo "Usage: assume-role [role]"
 			return 1
 		fi
-		# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift.
-		# Assume whichever clock is behind by more than 10 seconds is wrong, since virtual clocks
-		# almost never gain time.
-		let diff=$(date '+%s')-$(date -d "$(hwclock -r)" '+%s')
-		if [ $diff -gt 10 ]; then
-			hwclock -w >/dev/null 2>&1
-		elif [ $diff -lt -10 ]; then
-			# (Only works in privileged mode)
-			hwclock -s >/dev/null 2>&1
-		fi
-		if [ $? -ne 0 ]; then
-			echo "* $(yellow Failed to sync system time from hardware clock)"
+
+		if [ "${DOCKER_TIME_DRIFT_FIX:-true}" == "true" ]; then
+			# Use a timeout due to slow clock reads on EC2 (10 seconds).
+			# Fixes: hwclock: select() to /dev/rtc0 to wait for clock tick timed out
+			hwclock_time=$(timeout 1.5 hwclock -r)
+
+			# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift.
+			# Assume whichever clock is behind by more than 10 seconds is wrong, since virtual clocks
+			# almost never gain time.
+			if [ -n "${hwclock_time}" ]; then
+				let diff=$(date '+%s')-$(date -d "${hwclock_time}" '+%s')
+				if [ $diff -gt 10 ]; then
+					hwclock -w >/dev/null 2>&1
+				elif [ $diff -lt -10 ]; then
+					# (Only works in privileged mode)
+					hwclock -s >/dev/null 2>&1
+				fi
+				if [ $? -ne 0 ]; then
+					echo "* $(yellow Failed to sync system time from hardware clock)"
+				fi
+			fi
 		fi
 
 		shift


### PR DESCRIPTION
## what
* Support disabling the time-drift correction

## why
* It's slow and not necessary when running docker natively