### PR TITLE
[aws/kops] Mitigate cve-2019-5736 by making runc immutable

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -34,7 +34,8 @@ spec:
       idleTimeoutSeconds: {{ getenv "KOPS_API_LOAD_BALANCER_IDLE_TIMEOUT_SECONDS" "600" }}
   kubeAPIServer:
   {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
-    authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC,AlwaysAllow" }}
+    anonymousAuth: false
+    authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC" }}
     authorizationRbacSuperUser: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_RBAC_SUPER_USER" "admin" }}
   {{- end }}
   {{- if bool (getenv "KOPS_ADMISSION_CONTROL_ENABLED" "true") }}
@@ -50,6 +51,8 @@ spec:
     - ResourceQuota
     - NodeRestriction
     - Priority
+    - Initializers
+    - DenyEscalatingExec
   {{- end }}
   {{- if bool (getenv "KOPS_AWS_IAM_AUTHENTICATOR_ENABLED" "false") }}
   authentication:
@@ -90,6 +93,13 @@ spec:
       name: {{ . | regexp.Replace "^.*[0-9]" "" }}
     {{- end }}
     name: events
+  hooks:
+  - before:
+    - docker.service
+    manifest: |
+      Type=oneshot
+      ExecStart=/usr/bin/chattr +i /usr/bin/docker-runc
+    name: cve-2019-5736.service
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: {{ getenv "KUBERNETES_VERSION" }}


### PR DESCRIPTION
## what
Mitigate [cve-2019-5736](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736) by making runc immutable

## why
When running a process as root (UID 0) inside a container, that process can exploit a bug in `runc` to gain root privileges on the host running the container. This then allows them unlimited access to the server as well as any other containers on that server. The implemented change mitigates this risk.

## Further information

This mitigation was described [here](https://seclists.org/oss-sec/2019/q1/134) and affirmed [here](https://twitter.com/_staaldraad/status/1095354945073754112) and [here](https://github.com/kubernetes/kops/blob/master/docs/advisories/cve_2019_5736.md#cve-2019-5736---runc-container-breakout) with the caveat that privileged pods (that are effectively root anyway) and pods that have explicitly been granted CAP_LINUX_IMMUTABLE in the securityContext.capabilities remain vulnerable. 

This mitigation is essentially the same as what has been implemented in `kops` version 1.11.1. The real fix is a newer version of Docker that does not have this vulnerability, but none of the released versions of `kops` are certified to run with the fixed versions of Docker. It appears we will have to wait until `kops` version 1.12 to get the fixed version of Docker. 

Bastions are special cases. The bad news is that [hooks on bastions not honored](https://github.com/kubernetes/kops/pull/5856), so this change does not get applied to the bastion host. The good news is that the bastion host does not run anything other containers, so it is protected that way.
