### PR TITLE
[aws-vault] Resume current role if aws-vault server is running

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -26,7 +26,6 @@ function assume_active_role() {
 	fi
 }
 
-
 if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 	if ! which aws-vault >/dev/null; then
 		echo "aws-vault not installed"


### PR DESCRIPTION
## what
If the login shell detects that the `aws-vault` credential server is running, immediately assume that role.

## why
The `aws-vault` credential server is not just convenient, it is essential for enabling long-running tasks (such as `kops rolling-update cluster`) to complete without credentials expiring. However, `aws-vault` has a limitation that `aws-vault exec` will not use an existing credential server, forcing the user to use non-server mode, where expired credentials will not be renewed.  This change works around that limitation by detecting a running credential server and acting as if `assume-role` had been called to assume the role being served by the credential server.