### PR TITLE
[direnv] use new TF bucket prefix method

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -29,6 +29,7 @@ We leverage as many semantics of the linux shell as we can to make the experienc
 * `/etc/motd` is the current "Message of the Day"
 * `/mnt/local` is where we house the local state (like your temporary AWS credentials)
 * `/mnt/remote` is where we mount the S3 bucket for cluster state; these files are never written to disk and only kept in memory for security
+* `/conf` is where all module configuration is stored. Directory names are mapped directly to a bucket prefix, including subdirectories.
 
 ## Extending the Shell
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -29,7 +29,7 @@ We leverage as many semantics of the linux shell as we can to make the experienc
 * `/etc/motd` is the current "Message of the Day"
 * `/mnt/local` is where we house the local state (like your temporary AWS credentials)
 * `/mnt/remote` is where we mount the S3 bucket for cluster state; these files are never written to disk and only kept in memory for security
-* `/conf` is where all module configuration is stored. Directory names are mapped directly to a bucket prefix, including subdirectories.
+* `/conf` is where all configurations belong. For example, stick your terraform module invocations in this directory. When using `terraform`, the directory names are mapped directly to a bucket prefix for terraform state which include subdirectories (e.g. `/conf/us-west-2/vpc` will map to a state folder prefix of 'us-west-2/vpc`).
 
 ## Extending the Shell
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -29,7 +29,7 @@ We leverage as many semantics of the linux shell as we can to make the experienc
 * `/etc/motd` is the current "Message of the Day"
 * `/mnt/local` is where we house the local state (like your temporary AWS credentials)
 * `/mnt/remote` is where we mount the S3 bucket for cluster state; these files are never written to disk and only kept in memory for security
-* `/conf` is where all configurations belong. For example, stick your terraform module invocations in this directory. When using `terraform`, the directory names are mapped directly to a bucket prefix for terraform state which include subdirectories (e.g. `/conf/us-west-2/vpc` will map to a state folder prefix of 'us-west-2/vpc`).
+* `/conf` is where all configurations belong. For example, stick your terraform module invocations in this directory. When using `terraform`, the directory names are mapped directly to a bucket prefix for terraform state which include subdirectories (e.g. `/conf/us-west-2/vpc` will map to a state folder prefix of `us-west-2/vpc`).
 
 ## Extending the Shell
 

--- a/rootfs/etc/direnv/rc.d/terraform
+++ b/rootfs/etc/direnv/rc.d/terraform
@@ -13,7 +13,18 @@ function use_terraform() {
 	# Terraform backend for a given project using envs
 	export TF_STATE_FILE=${TF_FILE:-terraform.tfstate}
 	export TF_BUCKET_REGION=${TF_BUCKET_REGION:-${AWS_REGION}}
-	export TF_BUCKET_PREFIX=${TF_BUCKET_PREFIX:-$(basename $(pwd))}
+
+	case "${TF_BUCKET_PREFIX_FORMAT}" in
+		basename-pwd)
+			# Use old bucket prefix format (flat structure, uses leaf directory name only)
+			export TF_BUCKET_PREFIX=${TF_BUCKET_PREFIX:-$(basename $(pwd))}
+			;;
+		pwd|*)
+			# Use full directory path after /conf
+			# (default)
+			export TF_BUCKET_PREFIX=${TF_BUCKET_PREFIX:-$(pwd | cut -d/ -f3-)}
+			;;
+	esac
 	
 	# Disable color if not running in a TTY (e.g. CI/CD context)
 	if [ ! -t 1 ]; then


### PR DESCRIPTION
## what
* `TF_BUCKET_PREFIX_FORMAT` selects the format to use for setting the TF
remote state bucket prefix/key: the original `$(basename $(pwd))`
leaf-only format, or the new full path format.

## why

Old format uses leaf directory only, which could lead to unexpected
behaviour if you used subdirectories for structuring:

    /conf/us-east-1/vpc    -> s3://<bucket>/vpc
    /conf/eu-central-2/vpc -> s3://<bucket>/vpc

New format uses full path:

    /conf/us-east-1/vpc    -> s3://<bucket>/us-east-1/vpc
    /conf/eu-central-2/vpc -> s3://<bucket>/eu-central-2/vpc

## references
* closes #401 