### PR TITLE
[kops template] Optionally install Teleport on all Instances

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -16,6 +16,7 @@ function assume_active_role() {
 			if [ -z "$AWS_VAULT" ] || [ "$AWS_VAULT" == "$aws_vault" ]; then
 				echo "* Attaching to exising aws-vault session and assuming role ${aws_vault}"
 				export AWS_VAULT="$aws_vault"
+				export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION-${AWS_REGION}}"
 			fi
 		else
 			unset TF_VAR_aws_assume_role_arn

--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -4,30 +4,49 @@ metadata:
   name: {{ getenv "KOPS_CLUSTER_NAME" }}
 spec:
   additionalPolicies:
-      nodes: |
-        [
-          {
-            "Sid": "assumeClusterRole",
+    master: |
+      [
+        {
+           "Effect": "Allow",
             "Action": [
-              "sts:AssumeRole"
-            ],
-            "Effect": "Allow",
-            "Resource": ["*"]
-          {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "autoscaling:DescribeAutoScalingGroups",
-                  "autoscaling:DescribeAutoScalingInstances",
-                  "autoscaling:DescribeTags",
-                  "autoscaling:SetDesiredCapacity",
-                  "autoscaling:TerminateInstanceInAutoScalingGroup"
-              ],
+               "ec2:DescribeTags"
+             ],
               "Resource": "*"
-          {{- end }}
-          }
-        ]
+        }
+      ]
+    bastion: |
+      [
+        {
+           "Effect": "Allow",
+            "Action": [
+               "ec2:DescribeTags"
+             ],
+              "Resource": "*"
+        }
+      ]
+    node: |
+      [
+        {
+           "Effect": "Allow",
+           "Action": [
+               "ec2:DescribeTags"
+           ],
+           "Resource": "*"
+        {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeTags",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup"
+            ],
+            "Resource": "*"
+        {{- end }}
+        }
+      ]
   api:
     loadBalancer:
       type: Public
@@ -100,6 +119,52 @@ spec:
       Type=oneshot
       ExecStart=/usr/bin/chattr +i /usr/bin/docker-runc
     name: cve-2019-5736.service
+{{- if getenv "TELEPORT_PROXY_DOMAIN_NAME" }}
+  - name: teleport-node.service
+    roles: [Node, Master, Bastion]
+    requires: [network.target, teleport-node-install.service]
+    after: [network.target]
+    manifest: |
+      Type=simple
+      Restart=on-failure
+      ExecStart=/bin/bash -c '/usr/local/bin/teleport start --config=/etc/teleport.yaml \
+      --pid-file=/var/run/teleport.pid \
+      --auth-server="{{- print (getenv "TELEPORT_AUTH_DOMAIN_NAME" | default (print "auth." (getenv "TELEPORT_PROXY_DOMAIN_NAME"))) ":3025" -}}" \
+      --advertise-ip="$(curl -sS http://169.254.169.254/latest/meta-data/local-ipv4)" \
+      --labels "id=$(curl -sS http://169.254.169.254/latest/meta-data/instance-id)"'
+      ExecReload=/bin/kill -HUP $MAINPID
+      PIDFile=/var/run/teleport.pid
+  - name: teleport-node-install.service
+    roles: [Node, Master, Bastion]
+    before: [teleport-node.service]
+    requires: [network.target]
+    after: [network.target]
+    manifest: |
+      Type=oneshot
+      ExecStart=/bin/bash -c 'set -e -o pipefail && \
+      wget -q -t 3 -O /tmp/teleport.tar.gz \
+      https://get.gravitational.com/teleport-ent-v{{- getenv "TELEPORT_VERSION" -}}-linux-amd64-bin.tar.gz && \
+      tar  -xzf /tmp/teleport.tar.gz -C /tmp && \
+      cp -f /tmp/teleport-ent/teleport /usr/local/bin/teleport && \
+      chmod 550 /usr/local/bin/teleport'
+  fileAssets:
+    - name: teleport.yaml
+      # path is actually the path plus the filename
+      path: /etc/teleport.yaml
+      roles: [Node, Master, Bastion]
+      content: |
+        teleport:
+          auth_token: {{ getenv "TELEPORT_NODE_TOKEN" | default "node-not-completely-secure-but-not-a-huge-risk" }}
+          log:
+            output: stdout
+            severity: INFO
+        ssh_service:
+          enabled: true
+        auth_service:
+          enabled: false
+        proxy_service:
+          enabled: false
+{{- end }}
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: {{ getenv "KUBERNETES_VERSION" }}


### PR DESCRIPTION
## what
- Optionally install [Teleport](https://gravitational.com/teleport/) node agent on all instances
- Give all instances permission to view AWS tags (permission `ec2:DescribeTags`)
- Restore permissions to allow Masters to autoscale when `KOPS_CLUSTER_AUTOSCALER_ENABLED` is `true`

## why
- Teleport node agents must be installed on instances, so it must be done by `kops`. 
- Permission to read tags in preparation of better automatic labeling.
- Autoscale permissions were previously not enabled due to a typo.