### PR TITLE
Add envrc stdlib function

### DIFF
--- a/rootfs/etc/direnv/rc.d/envrc
+++ b/rootfs/etc/direnv/rc.d/envrc
@@ -1,0 +1,13 @@
+# Usage: use_envrc [...]
+#
+# Load environment variables from all `*.envrc` files
+# Any arguments given will be treated as a glob.
+#
+function use_envrc() {
+	local wildcard="${1:-*.envrc}"
+	# Export terraform environent
+	
+	for file in $wildcard; do
+		source_env $file
+	done
+}


### PR DESCRIPTION
## what
* Add `use envrc` helper

## why
* Load all `.envrc` files in a directory (or based on a custom wildcard)

## usage

Add `use envrc` to your `.envrc` files to automatically include all envrcs
