### PR TITLE
[rootfs/templates/wrapper] Use docker native filtering with ps

### DIFF
--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -4,7 +4,7 @@ BANNER_COLOR="${BANNER_COLOR:-[36m}"
 BANNER_INDENT="${BANNER_INDENT:-    }"
 BANNER_FONT="${BANNER_FONT:-Nancyj.flf}"
 
-if [ -z "${ASSUME_ROLE}" ]; then
+if [ "${SHLVL}" == "1" ]; then
 	# Display a banner message for interactive shells (if we're not in aws-vault or aws-okta)
 	if [ -n "${BANNER}" ]; then
 		if [ "$BANNER_COMMAND" == "figlet" ]; then

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -139,13 +139,10 @@ function use() {
 		--name "${DOCKER_NAME}"
 		--rm
 		--env KUBERNETES_API_PORT=${GEODESIC_PORT})
-	# With set -o pipefail, the pipe below fails ~50% of the time on Mac due to a bug in bash.
-	# With set +o pipefail, this bug is mitigated, and the only difference is the behavior when `docker ps` fails.
-	# If `docker ps` fails, then it is likely that any further docker action will fail too, so it does not matter.
-	set +o pipefail
-	docker ps | grep -q ${DOCKER_NAME} >/dev/null 2>&1
-	if [ $? -eq 0 ]; then
-		echo "# Attaching to existing ${DOCKER_NAME} session"
+
+	local container_id=$(docker ps --quiet --filter name="${DOCKER_NAME}" --format "{{`{{ .ID }}`}}")
+	if [ -n "$container_id" ]; then
+		echo "# Attaching to existing ${DOCKER_NAME} session ($container_id)"
 		if [ $# -eq 0 ]; then
 			set -- "/bin/bash" "-l" "$@"
 		fi

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -140,7 +140,8 @@ function use() {
 		--rm
 		--env KUBERNETES_API_PORT=${GEODESIC_PORT})
 
-	local container_id=$(docker ps --quiet -a --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
+       # the extra curly braces around .ID are because this file goes through go template substitution local before being installed as a shell script
+       container_id=$(docker ps --quiet -a --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
 	if [ -n "$container_id" ]; then
 		echo "# Attaching to existing ${DOCKER_NAME} session ($container_id)"
 		if [ $# -eq 0 ]; then

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -140,7 +140,7 @@ function use() {
 		--rm
 		--env KUBERNETES_API_PORT=${GEODESIC_PORT})
 
-	local container_id=$(docker ps --quiet --filter name="${DOCKER_NAME}" --format "{{`{{ .ID }}`}}")
+	local container_id=$(docker ps --quiet -a --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
 	if [ -n "$container_id" ]; then
 		echo "# Attaching to existing ${DOCKER_NAME} session ($container_id)"
 		if [ $# -eq 0 ]; then

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -140,8 +140,8 @@ function use() {
 		--rm
 		--env KUBERNETES_API_PORT=${GEODESIC_PORT})
 
-       # the extra curly braces around .ID are because this file goes through go template substitution local before being installed as a shell script
-       container_id=$(docker ps --quiet -a --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
+	# the extra curly braces around .ID are because this file goes through go template substitution local before being installed as a shell script
+	container_id=$(docker ps --quiet -a --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
 	if [ -n "$container_id" ]; then
 		echo "# Attaching to existing ${DOCKER_NAME} session ($container_id)"
 		if [ $# -eq 0 ]; then


### PR DESCRIPTION
## what
* Update wrapper script to use the `docker ps --filter` option rather than pipe/grep pattern

## why
- #415 points out that `pipefail` is unreliable, so lets just eliminate it as a factor in this case