### PR TITLE
[direnv] Avoid infinite loop

### DIFF
--- a/rootfs/etc/direnv/rc.d/envrc
+++ b/rootfs/etc/direnv/rc.d/envrc
@@ -8,7 +8,7 @@ function use_envrc() {
 	# Export all .envrc files in the current directory
 	
 	for file in $wildcard; do
-		[ -e "$wildcard" ] || break
+		[ -e "$file" ] || break
 		source_env $file
 	done
 }

--- a/rootfs/etc/direnv/rc.d/envrc
+++ b/rootfs/etc/direnv/rc.d/envrc
@@ -5,9 +5,10 @@
 #
 function use_envrc() {
 	local wildcard="${1:-*.envrc}"
-	# Export terraform environent
+	# Export all .envrc files in the current directory
 	
 	for file in $wildcard; do
+		[ -e "$wildcard" ] || break
 		source_env $file
 	done
 }

--- a/rootfs/etc/direnv/rc.d/envrc
+++ b/rootfs/etc/direnv/rc.d/envrc
@@ -9,6 +9,6 @@ function use_envrc() {
 	
 	for file in $wildcard; do
 		[ -e "$file" ] || break
-		source_env $file
+		source_env "$file"
 	done
 }


### PR DESCRIPTION
## what
Fix to `use envrc` addition to `direnv` to avoid an infinite loop condition.

## why
Apparently, direnv executes a separate shell with `nullglob` and `failglob` both off, causing the raw glob to be passed to a future `eval`, causing a loop.