### PR TITLE
[direnv]  Support multiple arguments to `use_envrc`

### DIFF
--- a/rootfs/etc/direnv/rc.d/envrc
+++ b/rootfs/etc/direnv/rc.d/envrc
@@ -5,9 +5,10 @@
 #
 function use_envrc() {
 	local wildcard="${1:-*.envrc}"
-	# Export terraform environent
+	# Export all .envrc files in the current directory
 	
 	for file in $wildcard; do
+		[ -e "$wildcard" ] || break
 		source_env $file
 	done
 }

--- a/rootfs/etc/direnv/rc.d/envrc
+++ b/rootfs/etc/direnv/rc.d/envrc
@@ -1,14 +1,14 @@
 # Usage: use_envrc [...]
 #
-# Load environment variables from all `*.envrc` files
+# Load environment variables from multiple envrc files. By default, `*.envrc`.
 # Any arguments given will be treated as a glob.
 #
 function use_envrc() {
-	local wildcard="${1:-*.envrc}"
-	# Export all .envrc files in the current directory
+	local wildcard="${@:-*.envrc}"
+	# Export a bunch of .envrc-like files, defaulting to all *.envrc files in the current directory
 	
 	for file in $wildcard; do
-		[ -e "$wildcard" ] || break
-		source_env $file
+		[ -e "$file" ] || continue
+		source_env "$file"
 	done
 }


### PR DESCRIPTION
## what
Following up on #418, match function execution with description, specifically: allow multiple arguments to `use_envrc`

## why
Convenience of multiple arguments vs multiple single-argument calls. 

## references
https://github.com/direnv/direnv/issues/480
#418 