### PR TITLE
Eliminate non-local effects of shopt -s nullglob

### DIFF
--- a/rootfs/etc/profile.d/terraform.sh
+++ b/rootfs/etc/profile.d/terraform.sh
@@ -1,7 +1,7 @@
 PROMPT_HOOKS+=("terraform_prompt")
 function terraform_prompt() {
 	# Test if there are any files with names ending in ".tf"
-	if compgen -G '*.tf' > /dev/null; then
+	if compgen -G '*.tf' >/dev/null; then
 		if [ ! -d ".terraform" ]; then
 			echo -e "-> Run '$(green init-terraform)' to use this project"
 		fi

--- a/rootfs/etc/profile.d/terraform.sh
+++ b/rootfs/etc/profile.d/terraform.sh
@@ -1,8 +1,7 @@
 PROMPT_HOOKS+=("terraform_prompt")
 function terraform_prompt() {
-	shopt -s nullglob
-	TF_FILES=(*.tf)
-	if [ ! -z "${TF_FILES}" ]; then
+	# Test if there are any files with names ending in ".tf"
+	if compgen -G '*.tf' > /dev/null; then
 		if [ ! -d ".terraform" ]; then
 			echo -e "-> Run '$(green init-terraform)' to use this project"
 		fi

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -108,12 +108,14 @@ function use() {
 		if [ -d "$mount_path/c/Users/${windows_user_name}/AppData/Local/lxss/" ]; then
 			local_home=${user_local_app_data}/lxss${HOME}
 		else
+			local restore_nullglob=$(shopt -p nullglob)
 			shopt -s nullglob
 			for dir in $mount_path/c/Users/${windows_user_name}/AppData/Local/Packages/CanonicalGroupLimited.Ubuntu*; do
 				folder_name=$(basename ${dir})
 				local_home=${user_local_app_data}/Packages/${folder_name}/LocalState/rootfs${HOME}
 				break
 			done
+			$restore_nullglob
 		fi
 
 		if [ -z "${local_home}" ]; then


### PR DESCRIPTION
## what
Eliminate cases where turning on the `bash` shell's `nullglob` option lingers past its intended scope.

## why
The `bash` shell setting `shopt -s nullglob` changes the way "globs" are handled when they do not match any files. It had been being set in the prompt hook, meaning it was set for every command running in Geodesic. This caused weird behavior, like this:
```
 ⨠ ls
a-file	b-file
 ⨠ ls a*
a-file
 ⨠ ls b*
b-file
 ⨠ ls c*
a-file	b-file
```
It could likewise cause other commands and shell scripts to fail or behave unexpectedly. 

## references
[Why is nullglob not default?](https://unix.stackexchange.com/a/204944)
[Test whether a glob has any matches in bash](https://stackoverflow.com/a/34195247)