### PR TITLE
Enable run-time customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,6 @@ FROM alpine:3.9.2
 
 ENV BANNER "geodesic"
 
-# Where to store state
-ENV CACHE_PATH=/localhost/.geodesic
-
 ENV GEODESIC_PATH=/usr/local/include/toolbox
 ENV MOTD_URL=http://geodesic.sh/motd
 ENV HOME=/conf
@@ -210,9 +207,8 @@ ENV AWS_SHARED_CREDENTIALS_FILE=${AWS_DATA_PATH}/credentials
 #
 # Shell
 #
-ENV HISTFILE=${CACHE_PATH}/history
 ENV SHELL=/bin/bash
-ENV LESS=-Xr
+ENV LESS=R
 ENV SSH_AGENT_CONFIG=/var/tmp/.ssh-agent
 
 # Reduce `make` verbosity

--- a/packages.txt
+++ b/packages.txt
@@ -12,10 +12,12 @@ curl
 direnv@testing
 drill
 dumb-init
+emacs-nox
 fetch@cloudposse
 emailcli@cloudposse
 figlet
 figurine@cloudposse
+file
 fuse
 fzf
 gettext

--- a/rootfs/conf/.emacs
+++ b/rootfs/conf/.emacs
@@ -1,0 +1,1 @@
+/localhost/.emacs

--- a/rootfs/etc/profile.d/_colors.sh
+++ b/rootfs/etc/profile.d/_colors.sh
@@ -13,4 +13,3 @@ function yellow() {
 function cyan() {
 	echo "$(tput setaf 6)$*$(tput sgr0)"
 }
-

--- a/rootfs/etc/profile.d/_colors.sh
+++ b/rootfs/etc/profile.d/_colors.sh
@@ -1,3 +1,6 @@
+# Files in the profile.d directory are executed by the lexicographical order of their file names.
+# This file is named _colors.sh. The leading underscore is needed to ensure this file executes before
+# other files that depend on the functions defined here. This file has no dependencies and should come first.
 function red() {
 	echo "$(tput setaf 1)$*$(tput sgr0)"
 }

--- a/rootfs/etc/profile.d/_colors.sh
+++ b/rootfs/etc/profile.d/_colors.sh
@@ -14,8 +14,3 @@ function cyan() {
 	echo "$(tput setaf 6)$*$(tput sgr0)"
 }
 
-export FZF_DEFAULT_OPTS='
-  --color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
-  --color=fg:#839496,header:#586e75,info:#cb4b16,pointer:#719e07
-  --color=marker:#719e07,fg+:#839496,prompt:#719e07,hl+:#719e07
-'

--- a/rootfs/etc/profile.d/_geodesic-config.sh
+++ b/rootfs/etc/profile.d/_geodesic-config.sh
@@ -1,5 +1,10 @@
-# bash funnctions to import
+# Files in the profile.d directory are executed by the lexicographical order of their file names.
+# This file is named _geodesic-config.sh. The leading underscore is needed to ensure this file executes before
+# other files that depend on the functions defined here.
+# This file has depends on _colors.sh and should come second.
 
+# bash functions that support the user customization framework
+#
 # Given the name of a resource, _search_geodesic_dirs assembles an array of matching, Geodesic-specific resources,
 # in order from most general to most specific. They should be applied in order with the later ones overriding
 # the earlier ones.
@@ -9,7 +14,7 @@
 # * If it is a directory, all the non-hidden files in that directory are loaded in glob sort order
 #
 # Several directories are searched for resources, in this order:
-# * $base/defaults/ ($base itself defaults to /localhost/.geodesic, can be set via GEODESIC_DOT_DIR)
+# * $base/defaults/ ($base itself defaults to /localhost/.geodesic, can be set via GEODESIC_CONFIG_HOME)
 # * $base/ if and only if there is no $base/defaults/ directory
 # * $base/$(dirname $DOCKER_IMAGE)/defaults/
 # * $base/$(dirname $DOCKER_IMAGE)/ if and only if there is no $base/$(dirname $DOCKER_IMAGE)/defaults/ directory
@@ -24,7 +29,7 @@
 function _search_geodesic_dirs() {
 	local -n search_list=$1
 	local resource=$2
-	local base="${GEODESIC_DOT_DIR}"
+	local base="${GEODESIC_CONFIG_HOME}"
 
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: looking for resources of type "$resource"
 

--- a/rootfs/etc/profile.d/_geodesic-dotfiles.sh
+++ b/rootfs/etc/profile.d/_geodesic-dotfiles.sh
@@ -69,7 +69,7 @@ function _search_geodesic_dirs() {
 function _expand_dir_or_file() {
 	local -n expand_list=$1
 	local dir=${3-${PWD}}
-	local default_exclusion_pattern="(~|.old|.orig|.disabled)$"
+	local default_exclusion_pattern="(~|.bak|.log|.old|.orig|.disabled)$"
 	local exclude="${GEODESIC_AUTO_LOAD_EXCLUSIONS:-$default_exclusion_pattern}"
 
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: looking for resources of type "$resource" in "$dir"

--- a/rootfs/etc/profile.d/_geodesic-dotfiles.sh
+++ b/rootfs/etc/profile.d/_geodesic-dotfiles.sh
@@ -26,10 +26,10 @@ function _search_geodesic_dirs() {
 	local resource=$2
 	local base="${GEODESIC_DOT_DIR}"
 
-	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: looking for resources of type "$resource"
+	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: looking for resources of type "$resource"
 
 	if [[ ! -d $base ]]; then
-		[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: "$base" is not a directory, giving up the search for "$resource"
+		[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: "$base" is not a directory, giving up the search for "$resource"
 		return
 	fi
 
@@ -72,13 +72,13 @@ function _expand_dir_or_file() {
 	local default_exclusion_pattern="(~|.old|.orig|.disabled)$"
 	local exclude="${GEODESIC_AUTO_LOAD_EXCLUSIONS:-$default_exclusion_pattern}"
 
-	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: looking for resources of type "$resource" in "$dir"
+	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: looking for resources of type "$resource" in "$dir"
 
 	for item in "${dir}/$2" "${dir}/${2}.d"/*; do
 		if [[ -f $item ]]; then
 			[[ $item =~ $exclude ]] && continue
 			expand_list+=($item)
-			[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: found "$item"
+			[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: found "$item"
 		fi
 	done
 }

--- a/rootfs/etc/profile.d/_geodesic-dotfiles.sh
+++ b/rootfs/etc/profile.d/_geodesic-dotfiles.sh
@@ -1,0 +1,86 @@
+# bash funnctions to import
+
+# Given the name of a resource, _search_geodesic_dirs assembles an array of matching, Geodesic-specific resources,
+# in order from most general to most specific. They should be applied in order with the later ones overriding
+# the earlier ones.
+#
+# Every resource, for example "preferences", can be either a file or a directory.
+# * If it is a file, it is loaded directly
+# * If it is a directory, all the non-hidden files in that directory are loaded in glob sort order
+#
+# Several directories are searched for resources, in this order:
+# * $base/defaults/ ($base itself defaults to /localhost/.geodesic, can be set via GEODESIC_DOT_DIR)
+# * $base/ if and only if there is no $base/defaults/ directory
+# * $base/$(dirname $DOCKER_IMAGE)/defaults/
+# * $base/$(dirname $DOCKER_IMAGE)/ if and only if there is no $base/$(dirname $DOCKER_IMAGE)/defaults/ directory
+# * $base/$(base $DOCKER_IMAGE)/
+# * $base/$DOCKER_IMAGE/
+#
+# Usage: _search_geodesic_dirs array-ref resource-name
+# The first argument to _search_geodesic_dirs is the name of a variable. That variable will be treated as an array
+# and all the files found will be added in the order described above. The second argument is the name of the resource
+# See example usages in _preferences.sh
+
+
+function _search_geodesic_dirs() {
+	local -n search_list=$1
+	local resource=$2
+	local base="${GEODESIC_DOT_DIR}"
+
+	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: looking for resources of type "$resource"
+
+	if [[ ! -d $base ]]; then
+		[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: "$base" is not a directory, giving up the search for "$resource"
+		return
+	fi
+
+	if [[ -d $base/defaults ]]; then
+		_expand_dir_or_file search_list "${resource}" "${base}/defaults"
+	else
+		_expand_dir_or_file search_list "${resource}" "${base}"
+	fi
+
+	local company=$(dirname "${DOCKER_IMAGE}")
+	local stage=$(basename "${DOCKER_IMAGE}")
+
+	if [[ -n $company && -d $base/$company ]]; then
+		if [[ -d $base/$company/defaults ]]; then
+			_expand_dir_or_file search_list "${resource}" "${base}/${company}/defaults"
+		else
+			_expand_dir_or_file search_list "${resource}" "${base}/${company}"
+		fi
+	fi
+
+	if [[ -n $stage && ($stage != $company) && -d $base/$stage ]]; then
+		_expand_dir_or_file search_list "${resource}" "${base}/${stage}"
+	fi
+
+	if [[ -n $DOCKER_IMAGE && -d $base/$DOCKER_IMAGE ]]; then
+		_expand_dir_or_file search_list "${resource}" "${base}/${DOCKER_IMAGE}"
+	fi
+}
+
+
+# _expand_dir_or_file is a helper function
+#
+# Usage: _expand_dir_or_file array-ref resource-name [base-directory]
+# Look for either a file named resource-name and a directory named resource-name.d
+# * If there is a file, add that file to the array-ref
+# * If there is a directory, add all the non-hidden files, except the ones matching
+#   the exclusion pattern in GEODESIC_AUTO_LOAD_EXCLUSIONS, in the directory to the array-ref
+function _expand_dir_or_file() {
+	local -n expand_list=$1
+	local dir=${3-${PWD}}
+	local default_exclusion_pattern="(~|.old|.orig|.disabled)$"
+	local exclude="${GEODESIC_AUTO_LOAD_EXCLUSIONS:-$default_exclusion_pattern}"
+
+	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: looking for resources of type "$resource" in "$dir"
+
+	for item in "${dir}/$2" "${dir}/${2}.d"/*; do
+		if [[ -f $item ]]; then
+			[[ $item =~ $exclude ]] && continue
+			expand_list+=($item)
+			[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: found "$item"
+		fi
+	done
+}

--- a/rootfs/etc/profile.d/_geodesic-dotfiles.sh
+++ b/rootfs/etc/profile.d/_geodesic-dotfiles.sh
@@ -21,7 +21,6 @@
 # and all the files found will be added in the order described above. The second argument is the name of the resource
 # See example usages in _preferences.sh
 
-
 function _search_geodesic_dirs() {
 	local -n search_list=$1
 	local resource=$2
@@ -59,7 +58,6 @@ function _search_geodesic_dirs() {
 		_expand_dir_or_file search_list "${resource}" "${base}/${DOCKER_IMAGE}"
 	fi
 }
-
 
 # _expand_dir_or_file is a helper function
 #

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -54,5 +54,10 @@ function _load_geodesic_preferences() {
 	done
 }
 
-_load_geodesic_preferences
+if [[ ${GEODESIC_CUSTOMIZATION_DISABLED-false} != false ]]; then
+	echo $(yellow Disabling user customizations: GEODESIC_CUSTOMIZATION_DISABLED is set and not 'false')
+else
+	_load_geodesic_preferences
+fi
+
 unset -f _load_geodesic_preferences

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -4,8 +4,6 @@
 # This file has depends on _geodesic-config.sh and should come third.
 # This file loads user preferences/customizations and must load before any user-visible configuration takes place.
 
-
-
 # Parse the GEODESIC_TRACE variable and set the internal _GEODESIC_TRACE_CUSTOMIZATION flag if needed
 if [[ $GEODESIC_TRACE =~ custom ]]; then
 	export _GEODESIC_TRACE_CUSTOMIZATION=true
@@ -14,7 +12,6 @@ else
 fi
 
 [[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_CONFIG_HOME is found to be "${GEODESIC_CONFIG_HOME:-<unset>}"
-
 
 #
 # Determine the base directory for all customizations.

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -1,20 +1,20 @@
 if [[ $GEODESIC_TRACE =~ custom ]]; then
-	export GEODESIC_CUSTOM_TRACE=true
+	export _GEODESIC_TRACE_CUSTOMIZATION=true
 else
-	unset GEODESIC_CUSTOM_TRACE
+	unset _GEODESIC_TRACE_CUSTOMIZATION
 fi
 
 #.geodesic/default/
 #.geodesic/$(basename $DOCKER_IMAGE)/
 
-[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: GEODESIC_DOT_DIR is found to be "${GEODESIC_DOT_DIR:-<unset>}"
+[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_DOT_DIR is found to be "${GEODESIC_DOT_DIR:-<unset>}"
 
 export GEODESIC_DOT_DIR
-GEODESIC_DOT_DIR_DEFAULT="/localhost/.geodesic"
+_GEODESIC_DOT_DIR_DEFAULT="/localhost/.geodesic"
 
 if [[ -z $GEODESIC_DOT_DIR ]]; then
 	# Not set, use default
-	GEODESIC_DOT_DIR="${GEODESIC_DOT_DIR_DEFAULT}"
+	GEODESIC_DOT_DIR="${_GEODESIC_DOT_DIR_DEFAULT}"
 elif [[ ! -d $GEODESIC_DOT_DIR ]]; then
 	# Set, but not correctly. See if it is relative to /localhost (host ~)
 	if [[ -d /localhost/$GEODESIC_DOT_DIR ]]; then
@@ -25,27 +25,34 @@ elif [[ ! -d $GEODESIC_DOT_DIR ]]; then
 	else
 		echo $(red Invalid value of GEODESIC_DOT_DIR: "${GEODESIC_DOT_DIR}")
 		echo $(red GEODESIC_DOT_DIR should be relative to /localhost \(normally your home directory\))
-		echo $(red Using default value of ${GEODESIC_DOT_DIR_DEFAULT} instead)
-		GEODESIC_DOT_DIR="${GEODESIC_DOT_DIR_DEFAULT}"
+		echo $(red Using default value of ${_GEODESIC_DOT_DIR_DEFAULT} instead)
+		GEODESIC_DOT_DIR="${_GEODESIC_DOT_DIR_DEFAULT}"
 	fi
 fi
 
-unset GEODESIC_DOT_DIR_DEFAULT
+unset _GEODESIC_DOT_DIR_DEFAULT
 
-[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: GEODESIC_DOT_DIR is ultimately set to "${GEODESIC_DOT_DIR}"
+[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_DOT_DIR is ultimately set to "${GEODESIC_DOT_DIR}"
 
-## Save shell history in the most specific place
-HISTFILE_LIST=(${HISTFILE:-${GEODESIC_DOT_DIR}/history})
-_search_geodesic_dirs HISTFILE_LIST history
-HISTFILE="${HISTFILE_LIST[-1]}"
-[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: HISTFILE set to "${HISTFILE}"
-unset HISTFILE_LIST
+function _geodesic_set_histfile() {
+	## Save shell history in the most specific place
+	local histfile_list=(${HISTFILE:-${GEODESIC_DOT_DIR}/history})
+	_search_geodesic_dirs HISTFILE_LIST history
+	HISTFILE="${histfile_list[-1]}"
+	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"
+}
+_geodesic_set_histfile
+unset -f _geodesic_set_histfile
 
-## Load user's custom preferences
-PREFERENCE_LIST=()
-_search_geodesic_dirs PREFERENCE_LIST preferences
-for file in "${PREFERENCE_LIST[@]}"; do
-	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: loading preference file "$file"
-	source "$file"
-done
-unset PREFERENCE_LIST
+function _load_geodesic_preferences() {
+	local preference_list=()
+
+	_search_geodesic_dirs preference_list preferences
+	for file in "${preference_list[@]}"; do
+		[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: loading preference file "$file"
+		source "$file"
+	done
+}
+
+_load_geodesic_preferences
+unset -f _load_geodesic_preferences

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -1,0 +1,53 @@
+
+if [[ $GEODESIC_TRACE =~ custom ]]; then
+	export GEODESIC_CUSTOM_TRACE=true
+else
+	unset GEODESIC_CUSTOM_TRACE
+fi
+
+#.geodesic/default/
+#.geodesic/$(basename $DOCKER_IMAGE)/
+
+[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: GEODESIC_DOT_DIR is found to be "${GEODESIC_DOT_DIR:-<unset>}"
+
+export GEODESIC_DOT_DIR
+GEODESIC_DOT_DIR_DEFAULT="/localhost/.geodesic"
+
+if [[ -z $GEODESIC_DOT_DIR ]]; then
+	# Not set, use default
+	GEODESIC_DOT_DIR="${GEODESIC_DOT_DIR_DEFAULT}"
+elif [[ ! -d $GEODESIC_DOT_DIR ]]; then
+	# Set, but not correctly. See if it is relative to /localhost (host ~)
+	if [[ -d /localhost/$GEODESIC_DOT_DIR ]]; then
+		GEODESIC_DOT_DIR="/localhost/$GEODESIC_DOT_DIR"
+	# See if it is a full host path ending under host ~
+	elif [[ -d /localhost/$(basename $GEODESIC_DOT_DIR) ]]; then
+		GEODESIC_DOT_DIR="/localhost/$(basename $GEODESIC_DOT_DIR)"
+	else
+		echo $(red Invalid value of GEODESIC_DOT_DIR: "${GEODESIC_DOT_DIR}")
+		echo $(red GEODESIC_DOT_DIR should be relative to /localhost \(normally your home directory\))
+		echo $(red Using default value of ${GEODESIC_DOT_DIR_DEFAULT} instead)
+		GEODESIC_DOT_DIR="${GEODESIC_DOT_DIR_DEFAULT}"
+	fi
+fi
+
+unset GEODESIC_DOT_DIR_DEFAULT
+
+[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: GEODESIC_DOT_DIR is ultimately set to "${GEODESIC_DOT_DIR}"
+
+
+## Save shell history in the most specific place
+HISTFILE_LIST=(${HISTFILE:-${GEODESIC_DOT_DIR}/history})
+_search_geodesic_dirs HISTFILE_LIST history
+HISTFILE="${HISTFILE_LIST[-1]}"
+[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: HISTFILE set to "${HISTFILE}"
+unset HISTFILE_LIST
+
+## Load user's custom preferences
+PREFERENCE_LIST=()
+_search_geodesic_dirs PREFERENCE_LIST preferences
+for file in "${PREFERENCE_LIST[@]}"; do
+	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: loading preference file "$file"
+	source "$file"
+done
+unset PREFERENCE_LIST

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -1,42 +1,55 @@
+# Files in the profile.d directory are executed by the lexicographical order of their file names.
+# This file is named _preferences.sh. The leading underscore is needed to ensure this file executes before
+# other files that depend on the functions defined here.
+# This file has depends on _geodesic-config.sh and should come third.
+# This file loads user preferences/customizations and must load before any user-visible configuration takes place.
+
+
+
+# Parse the GEODESIC_TRACE variable and set the internal _GEODESIC_TRACE_CUSTOMIZATION flag if needed
 if [[ $GEODESIC_TRACE =~ custom ]]; then
 	export _GEODESIC_TRACE_CUSTOMIZATION=true
 else
 	unset _GEODESIC_TRACE_CUSTOMIZATION
 fi
 
-#.geodesic/default/
-#.geodesic/$(basename $DOCKER_IMAGE)/
+[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_CONFIG_HOME is found to be "${GEODESIC_CONFIG_HOME:-<unset>}"
 
-[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_DOT_DIR is found to be "${GEODESIC_DOT_DIR:-<unset>}"
 
-export GEODESIC_DOT_DIR
-_GEODESIC_DOT_DIR_DEFAULT="/localhost/.geodesic"
+#
+# Determine the base directory for all customizations.
+# We do some extra processing because GEODESIC_CONFIG_HOME needs to be set as a path in the Geodesic file system,
+# but the user may have set it as a path on the host computer system. We try to accomodate that by
+# searching a few other places for the directory if $GEODESIC_CONFIG_HOME does point to a valid directory
+export GEODESIC_CONFIG_HOME
+_GEODESIC_CONFIG_HOME_DEFAULT="/localhost/.geodesic"
 
-if [[ -z $GEODESIC_DOT_DIR ]]; then
+if [[ -z $GEODESIC_CONFIG_HOME ]]; then
 	# Not set, use default
-	GEODESIC_DOT_DIR="${_GEODESIC_DOT_DIR_DEFAULT}"
-elif [[ ! -d $GEODESIC_DOT_DIR ]]; then
+	GEODESIC_CONFIG_HOME="${_GEODESIC_CONFIG_HOME_DEFAULT}"
+elif [[ ! -d $GEODESIC_CONFIG_HOME ]]; then
 	# Set, but not correctly. See if it is relative to /localhost (host ~)
-	if [[ -d /localhost/$GEODESIC_DOT_DIR ]]; then
-		GEODESIC_DOT_DIR="/localhost/$GEODESIC_DOT_DIR"
+	if [[ -d /localhost/$GEODESIC_CONFIG_HOME ]]; then
+		GEODESIC_CONFIG_HOME="/localhost/$GEODESIC_CONFIG_HOME"
 		# See if it is a full host path ending under host ~
-	elif [[ -d /localhost/$(basename $GEODESIC_DOT_DIR) ]]; then
-		GEODESIC_DOT_DIR="/localhost/$(basename $GEODESIC_DOT_DIR)"
+	elif [[ -d /localhost/$(basename $GEODESIC_CONFIG_HOME) ]]; then
+		GEODESIC_CONFIG_HOME="/localhost/$(basename $GEODESIC_CONFIG_HOME)"
 	else
-		echo $(red Invalid value of GEODESIC_DOT_DIR: "${GEODESIC_DOT_DIR}")
-		echo $(red GEODESIC_DOT_DIR should be relative to /localhost \(normally your home directory\))
-		echo $(red Using default value of ${_GEODESIC_DOT_DIR_DEFAULT} instead)
-		GEODESIC_DOT_DIR="${_GEODESIC_DOT_DIR_DEFAULT}"
+		echo $(red Invalid value of GEODESIC_CONFIG_HOME: "${GEODESIC_CONFIG_HOME}")
+		echo $(red GEODESIC_CONFIG_HOME should be relative to /localhost \(normally your home directory\))
+		echo $(red Using default value of ${_GEODESIC_CONFIG_HOME_DEFAULT} instead)
+		GEODESIC_CONFIG_HOME="${_GEODESIC_CONFIG_HOME_DEFAULT}"
 	fi
 fi
 
-unset _GEODESIC_DOT_DIR_DEFAULT
+unset _GEODESIC_CONFIG_HOME_DEFAULT
 
-[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_DOT_DIR is ultimately set to "${GEODESIC_DOT_DIR}"
+[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_CONFIG_HOME is ultimately set to "${GEODESIC_CONFIG_HOME}"
 
+# Search for and find the history file most specificly targeted to this DOCKER_IMAGE
 function _geodesic_set_histfile() {
 	## Save shell history in the most specific place
-	local histfile_list=(${HISTFILE:-${GEODESIC_DOT_DIR}/history})
+	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
 	_search_geodesic_dirs HISTFILE_LIST history
 	HISTFILE="${histfile_list[-1]}"
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -1,4 +1,3 @@
-
 if [[ $GEODESIC_TRACE =~ custom ]]; then
 	export GEODESIC_CUSTOM_TRACE=true
 else
@@ -20,7 +19,7 @@ elif [[ ! -d $GEODESIC_DOT_DIR ]]; then
 	# Set, but not correctly. See if it is relative to /localhost (host ~)
 	if [[ -d /localhost/$GEODESIC_DOT_DIR ]]; then
 		GEODESIC_DOT_DIR="/localhost/$GEODESIC_DOT_DIR"
-	# See if it is a full host path ending under host ~
+		# See if it is a full host path ending under host ~
 	elif [[ -d /localhost/$(basename $GEODESIC_DOT_DIR) ]]; then
 		GEODESIC_DOT_DIR="/localhost/$(basename $GEODESIC_DOT_DIR)"
 	else
@@ -34,7 +33,6 @@ fi
 unset GEODESIC_DOT_DIR_DEFAULT
 
 [[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: GEODESIC_DOT_DIR is ultimately set to "${GEODESIC_DOT_DIR}"
-
 
 ## Save shell history in the most specific place
 HISTFILE_LIST=(${HISTFILE:-${GEODESIC_DOT_DIR}/history})

--- a/rootfs/etc/profile.d/aliases.sh
+++ b/rootfs/etc/profile.d/aliases.sh
@@ -2,3 +2,82 @@
 alias kube-system='kubectl --namespace=kube-system'
 alias default='kubectl --namespace=default'
 alias telnet='busybox-extras telnet'
+alias ll='ls -l'
+
+
+
+
+# Automatically add bash command-line completion for all aliases to commands having completion functions
+# Note, we only define the function here. It has to be applied later, after all completions have been installed.
+
+# Source: https://superuser.com/a/437508
+# Author: https://superuser.com/users/101110/kopischke
+# License: cc-wiki, a.k.a. cc by-sa https://creativecommons.org/licenses/by-sa/3.0/
+# Originally named "alias_completion"
+function _install_alias_completion {
+	local namespace="alias_completion"
+
+	# parse function based completion definitions, where capture group 2 => function and 3 => trigger
+	local compl_regex='complete( +[^ ]+)* -F ([^ ]+) ("[^"]+"|[^ ]+)'
+	# parse alias definitions, where capture group 1 => trigger, 2 => command, 3 => command arguments
+	local alias_regex="alias ([^=]+)='(\"[^\"]+\"|[^ ]+)(( +[^ ]+)*)'"
+
+	# create array of function completion triggers, keeping multi-word triggers together
+	eval "local completions=($(complete -p | sed -Ene "/$compl_regex/s//'\3'/p"))"
+	(( ${#completions[@]} == 0 )) && return 0
+
+	# create temporary file for wrapper functions and completions
+	rm -f "/tmp/${namespace}-*.tmp" # preliminary cleanup
+	local tmp_file; tmp_file="$(mktemp "/tmp/${namespace}-${RANDOM}XXX.tmp")" || return 1
+
+	local completion_loader; completion_loader="$(complete -p -D 2>/dev/null | sed -Ene 's/.* -F ([^ ]*).*/\1/p')"
+
+	# read in "<alias> '<aliased command>' '<command args>'" lines from defined aliases
+	local line; while read line; do
+		eval "local alias_tokens; alias_tokens=($line)" 2>/dev/null || continue # some alias arg patterns cause an eval parse error
+		local alias_name="${alias_tokens[0]}" alias_cmd="${alias_tokens[1]}" alias_args="${alias_tokens[2]# }"
+
+		# skip aliases to pipes, boolean control structures and other command lists
+		# (leveraging that eval errs out if $alias_args contains unquoted shell metacharacters)
+		eval "local alias_arg_words; alias_arg_words=($alias_args)" 2>/dev/null || continue
+		# avoid expanding wildcards
+		read -a alias_arg_words <<< "$alias_args"
+
+		# skip alias if there is no completion function triggered by the aliased command
+		if [[ ! " ${completions[*]} " =~ " $alias_cmd " ]]; then
+			if [[ -n "$completion_loader" ]]; then
+				# force loading of completions for the aliased command
+				eval "$completion_loader $alias_cmd"
+				# 124 means completion loader was successful
+				[[ $? -eq 124 ]] || continue
+				completions+=($alias_cmd)
+			else
+				continue
+			fi
+		fi
+		local new_completion="$(complete -p "$alias_cmd")"
+
+		# create a wrapper inserting the alias arguments if any
+		if [[ -n $alias_args ]]; then
+			local compl_func="${new_completion/#* -F /}"; compl_func="${compl_func%% *}"
+			# avoid recursive call loops by ignoring our own functions
+			if [[ "${compl_func#_$namespace::}" == $compl_func ]]; then
+				local compl_wrapper="_${namespace}::${alias_name}"
+				echo "function $compl_wrapper {
+                            (( COMP_CWORD += ${#alias_arg_words[@]} ))
+                            COMP_WORDS=($alias_cmd $alias_args \${COMP_WORDS[@]:1})
+                            (( COMP_POINT -= \${#COMP_LINE} ))
+                            COMP_LINE=\${COMP_LINE/$alias_name/$alias_cmd $alias_args}
+                            (( COMP_POINT += \${#COMP_LINE} ))
+                            $compl_func
+                        }" >> "$tmp_file"
+				new_completion="${new_completion/ -F $compl_func / -F $compl_wrapper }"
+			fi
+		fi
+
+		# replace completion trigger by alias
+		new_completion="${new_completion% *} $alias_name"
+		echo "$new_completion" >> "$tmp_file"
+	done < <(alias -p | sed -Ene "s/$alias_regex/\1 '\2' '\3'/p")
+	source "$tmp_file" && rm -f "$tmp_file"
+};

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -17,6 +17,7 @@ function assume_active_role() {
 				echo "* $(green Attaching to exising aws-vault session and assuming role) $(cyan ${aws_vault})"
 				export AWS_VAULT="$aws_vault"
 				export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION-${AWS_REGION}}"
+				export AWS_VAULT_SERVER_EXTERNAL=true
 			fi
 		else
 			unset TF_VAR_aws_assume_role_arn
@@ -80,6 +81,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 			fzf \
 				--height 30% \
 				--reverse \
+				--select-1 \
 				--prompt='-> ' \
 				--header 'Select AWS profile' \
 				--query "${ASSUME_ROLE_INTERACTIVE_QUERY:-${NAMESPACE}-${STAGE}-}" \

--- a/rootfs/etc/profile.d/direnv.sh
+++ b/rootfs/etc/profile.d/direnv.sh
@@ -1,4 +1,3 @@
-
 # Install `direnv` via PROMPT_COMMAND hook
 #
 

--- a/rootfs/etc/profile.d/direnv.sh
+++ b/rootfs/etc/profile.d/direnv.sh
@@ -1,5 +1,5 @@
-PROMPT_HOOKS+=("direnv_prompt")
 
-function direnv_prompt() {
-	eval "$(direnv hook bash)"
-}
+# Install `direnv` via PROMPT_COMMAND hook
+#
+
+eval "$(direnv hook bash)"

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -36,7 +36,6 @@ function _set_fzf_default_opts() {
 	local olive="3"
 	local keep="-1" # Keep the exsiting terminal setting for this field
 
-
 	case "$1" in
 	solar_24)
 		export FZF_DEFAULT_OPTS='--color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
@@ -60,7 +59,7 @@ function _set_fzf_default_opts() {
 		# Built-in basic color schemes
 		export FZF_DEFAULT_OPTS="--color=$1"
 		;;
-	mild|*) # "mild" is redundant with "*", but I want this to have an explicit name in case the default changes later
+	mild | *) # "mild" is redundant with "*", but I want this to have an explicit name in case the default changes later
 		export FZF_DEFAULT_OPTS="--border
 			--color fg:$keep,bg:$keep,hl:$burntOrange,fg+:$olive,bg+:$gray2,hl+:$veryPaleYellow
 			--color info:$teal,prompt:$blue,spinner:$teal,pointer:$orange,marker:$salmon,header:$green"

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -1,5 +1,73 @@
+#!/bin/bash
 # Install fzf shell completion when an interactive shell is enabled
 # This is a fix for: `/etc/bash_completion.d/fzf.sh: line 34: bind: warning: line editing not enabled`
 if [ -t 1 ] && ! [ -e '/etc/bash_completion.d/fzf.sh' ]; then
 	ln -s /usr/share/bash-completion/completions/fzf /etc/bash_completion.d/fzf.sh
+fi
+
+# https://github.com/junegunn/fzf/wiki/Color-schemes
+# https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+
+# A lot of terminals (including Apple's) do not support 24-bit color and the mapping from 24-bit to 8-bit is horrible.
+# So most of the color schemes are limited to the 256 ANSI colors that nearly every terminal supports.
+# Color schemes that only render properly with 24_bit color support are suffixed with _24
+
+function _set_fzf_default_opts() {
+	local gray1="232"
+	local gray2="233"
+	local gray3="234"
+	local gray4="235"
+	local gray5="240"
+	local gray6="241"
+	local gray8="244"
+	local gray9="245"
+	local grayE="254"
+	local veryPaleYellow="229"
+	local salmon="174"
+	local burntOrange="136"
+	local orange="166"
+	local red="160"
+	local teal="150"
+	local magenta="125"
+	local violet="61"
+	local blue="33"
+	local cyan="37"
+	local green="2"
+	local olive="3"
+	local keep="-1" # Keep the exsiting terminal setting for this field
+
+
+	case "$1" in
+	solar_24)
+		export FZF_DEFAULT_OPTS='--color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
+			--color=fg:#839496,header:#586e75,info:#cb4b16,pointer:#719e07
+			--color=marker:#719e07,fg+:#839496,prompt:#719e07,hl+:#719e07'
+		;;
+	solar_light)
+		## Solarized Light color scheme for fzf
+		export FZF_DEFAULT_OPTS="--border
+			--color fg:$keep,bg:$keep,hl:$blue,fg+:$gray4,bg+:$grayE,hl+:$blue
+			--color info:$burntOrange,prompt:$burntOrange,pointer:$gray3,marker:$gray3,spinner:$burntOrange"
+		;;
+	solar_dark)
+		# Solarized Dark color scheme for fzf
+		export FZF_DEFAULT_OPTS="--border
+			--color fg:$keep,bg:$keep,hl:$blue,fg+:$grayE,bg+:$gray4,hl+:$blue
+			--color info:$burntOrange,prompt:$burntOrange,pointer:$veryPaleYellow
+			--color marker:$veryPaleYellow,spinner:$burntOrange"
+		;;
+	dark | light | 16 | bw)
+		# Built-in basic color schemes
+		export FZF_DEFAULT_OPTS="--color=$1"
+		;;
+	mild|*) # "mild" is redundant with "*", but I want this to have an explicit name in case the default changes later
+		export FZF_DEFAULT_OPTS="--border
+			--color fg:$keep,bg:$keep,hl:$burntOrange,fg+:$olive,bg+:$gray2,hl+:$veryPaleYellow
+			--color info:$teal,prompt:$blue,spinner:$teal,pointer:$orange,marker:$salmon,header:$green"
+		;;
+	esac
+}
+
+if [[ -z $FZF_DEFAULT_OPTS ]]; then
+	_set_fzf_default_opts "$FZF_COLORS"
 fi

--- a/rootfs/etc/profile.d/geodesic.kube-ps1.sh
+++ b/rootfs/etc/profile.d/geodesic.kube-ps1.sh
@@ -1,3 +1,4 @@
+# A little extra help for https://github.com/jonmosco/kube-ps1
 PROMPT_HOOKS+=("kube_ps1_cache_buster")
 function kube_ps1_cache_buster() {
 	# If config cache is empty

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -5,7 +5,23 @@ shopt -s checkwinsize
 # Cache the current screen size
 export SCREEN_SIZE="${LINES}x${COLUMNS}"
 
-export PROMPT_COMMAND=prompter
+export PROMPT_COMMAND
+function _install_prompter() {
+	if ! [[ $PROMPT_COMMAND =~ prompter ]]; then
+		local final_colon=';$'
+
+		if [[ -z $PROMPT_COMMAND ]]; then
+			PROMPT_COMMAND="prompter;"
+		elif [[ $PROMPT_COMMAND =~ $final_colon ]]; then
+			PROMPT_COMMAND="${PROMPT_COMMAND}prompter;"
+		else
+			PROMPT_COMMAND="${PROMPT_COMMAND};prompter;"
+		fi
+	fi
+}
+_install_prompter
+unset -f _install_prompter
+
 function prompter() {
 	for hook in ${PROMPT_HOOKS[@]}; do
 		"${hook}"
@@ -26,6 +42,7 @@ function reload() {
 
 # Define our own prompt
 PROMPT_HOOKS+=("geodesic_prompt")
+KUBE_PS1_SYMBOL_ENABLE=${KUBE_PS1_SYMBOL_ENABLE:-false}
 function geodesic_prompt() {
 
 	case $PROMPT_STYLE in

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -5,6 +5,17 @@ shopt -s checkwinsize
 # Cache the current screen size
 export SCREEN_SIZE="${LINES}x${COLUMNS}"
 
+# Here we install our `prompter` prompt command to run the array of PROMPT_HOOKS we set up.
+# We like managing our stuff via the PROMPT_HOOKS array because it is easier to add things,
+# but bash only runs the command string in PROMPT_COMMAND,
+# in part because you cannot export an array or pass it to a child process.
+# However, not all the utilities we use support being managed through our PROMPT_HOOKS.
+# Some utilities (such as `direnv`) operate directly on the PROMPT_COMMAND variable, adding
+# themselves to it. Also, the PROMPT_COMMAND is inheritied by subshells, but we will be
+# running this initialization script again in the subshell.
+# So we cannot just unthinkingly set PROMPT_COMMAND=prompter or PROMPT_COMMAND="${PROMPT_COMMAND};prompter"
+# Instead, we examine the PROMPT_COMMAND variable, initialize it to "prompter;" if it is empty,
+# or otherwise add "prompter;" to the end of the command string (inserting a ; before it if needed).
 export PROMPT_COMMAND
 function _install_prompter() {
 	if ! [[ $PROMPT_COMMAND =~ prompter ]]; then

--- a/rootfs/etc/profile.d/stty.sh
+++ b/rootfs/etc/profile.d/stty.sh
@@ -1,5 +1,5 @@
 # By default Ctrl-S (a.k.a C-s or ^S) stops terminal output.
-#  However, in bash, it is  mapped to forward-search (through command history),
+# However, in bash, it is mapped to forward-search (through command history),
 # which is the standard emacs mapping. Unfortunately, it cannot do both, and by default, stop output wins.
 # This can be confusing and is definitely annoying in that it prevents the use of forward search.
 # Mapping a different key to stop terminal output is one possibility, but most of the control keys are already

--- a/rootfs/etc/profile.d/stty.sh
+++ b/rootfs/etc/profile.d/stty.sh
@@ -1,4 +1,3 @@
-
 # By default Ctrl-S (a.k.a C-s or ^S) stops terminal output.
 #  However, in bash, it is  mapped to forward-search (through command history),
 # which is the standard emacs mapping. Unfortunately, it cannot do both, and by default, stop output wins.

--- a/rootfs/etc/profile.d/stty.sh
+++ b/rootfs/etc/profile.d/stty.sh
@@ -1,0 +1,9 @@
+
+# By default Ctrl-S (a.k.a C-s or ^S) stops terminal output.
+#  However, in bash, it is  mapped to forward-search (through command history),
+# which is the standard emacs mapping. Unfortunately, it cannot do both, and by default, stop output wins.
+# This can be confusing and is definitely annoying in that it prevents the use of forward search.
+# Mapping a different key to stop terminal output is one possibility, but most of the control keys are already
+# mapped to something somewhere, so instead we just turn off the flow control altogether.
+
+stty -ixon

--- a/rootfs/etc/profile.d/tfenv.sh
+++ b/rootfs/etc/profile.d/tfenv.sh
@@ -1,3 +1,7 @@
 # Automatically export the current environment to `TF_VAR`
 # Use a regex defined in the `TFENV_WHITELIST` and `TFENV_BLACKLIST` environment variables to include and exclude variables
-source <(tfenv)
+#
+[[ ${LOAD_GLOBAL_TFENV:-false} == "true" ]] && \
+ echo $(red Global use of ) tfenv $(red is not recommended) && \
+ echo $(red use the) '"use tfenv"' $(red function of) '"direnv"' $(red to automatically execute it in certain directories) && \
+ source <(tfenv)

--- a/rootfs/etc/profile.d/tfenv.sh
+++ b/rootfs/etc/profile.d/tfenv.sh
@@ -1,7 +1,8 @@
 # Automatically export the current environment to `TF_VAR`
 # Use a regex defined in the `TFENV_WHITELIST` and `TFENV_BLACKLIST` environment variables to include and exclude variables
 #
-[[ ${LOAD_GLOBAL_TFENV:-false} == "true" ]] &&
+if [[ ${TFENV_LOAD_GLOBALLY:-false} == "true" ]]; then
 	echo $(red Global use of) tfenv $(red is not recommended) &&
-	echo $(red use the) '"use tfenv"' $(red function of) '"direnv"' $(red to automatically execute it in certain directories) &&
-	source <(tfenv)
+		echo $(red use the) '"use tfenv"' $(red function of) '"direnv"' $(red to automatically execute it in certain directories) &&
+		source <(tfenv)
+fi

--- a/rootfs/etc/profile.d/tfenv.sh
+++ b/rootfs/etc/profile.d/tfenv.sh
@@ -1,7 +1,7 @@
 # Automatically export the current environment to `TF_VAR`
 # Use a regex defined in the `TFENV_WHITELIST` and `TFENV_BLACKLIST` environment variables to include and exclude variables
 #
-[[ ${LOAD_GLOBAL_TFENV:-false} == "true" ]] && \
- echo $(red Global use of ) tfenv $(red is not recommended) && \
- echo $(red use the) '"use tfenv"' $(red function of) '"direnv"' $(red to automatically execute it in certain directories) && \
- source <(tfenv)
+[[ ${LOAD_GLOBAL_TFENV:-false} == "true" ]] &&
+	echo $(red Global use of) tfenv $(red is not recommended) &&
+	echo $(red use the) '"use tfenv"' $(red function of) '"direnv"' $(red to automatically execute it in certain directories) &&
+	source <(tfenv)

--- a/rootfs/etc/profile.d/Ω_finalize.sh
+++ b/rootfs/etc/profile.d/Ω_finalize.sh
@@ -3,7 +3,6 @@
 # other files that this function needs to be able to see.
 # This file should come next to last, followed only by Ω_overrides.sh.
 
-
 ## Perform any clean-up or post-setup actions
 
 # Set up command completion for command aliases.

--- a/rootfs/etc/profile.d/Ω_finalize.sh
+++ b/rootfs/etc/profile.d/Ω_finalize.sh
@@ -1,0 +1,17 @@
+## Perform any clean-up or post-setup actions
+
+# Set up command completion for command aliases
+
+_install_alias_completion
+
+# remove duplicates from PROMPT_COMMAND
+function _dedupe_prompt_command() {
+	local prompt_command=( ${PROMPT_COMMAND//;/ } )
+	PROMPT_COMMAND=
+
+	for cmd in "${prompt_command[@]}"; do
+		[[ $PROMPT_COMMAND =~ $cmd ]] || PROMPT_COMMAND="${PROMPT_COMMAND}$cmd;"
+	done
+}
+
+_dedupe_prompt_command

--- a/rootfs/etc/profile.d/Ω_finalize.sh
+++ b/rootfs/etc/profile.d/Ω_finalize.sh
@@ -6,7 +6,7 @@ _install_alias_completion
 
 # remove duplicates from PROMPT_COMMAND
 function _dedupe_prompt_command() {
-	local prompt_command=( ${PROMPT_COMMAND//;/ } )
+	local prompt_command=(${PROMPT_COMMAND//;/ })
 	PROMPT_COMMAND=
 
 	for cmd in "${prompt_command[@]}"; do

--- a/rootfs/etc/profile.d/Ω_finalize.sh
+++ b/rootfs/etc/profile.d/Ω_finalize.sh
@@ -1,10 +1,18 @@
+# Files in the profile.d directory are executed by the lexicographical order of their file names.
+# This file is named Ω_finalize.sh. The leading Ω (Capital Greek Omega) is needed to ensure this file executes after
+# other files that this function needs to be able to see.
+# This file should come next to last, followed only by Ω_overrides.sh.
+
+
 ## Perform any clean-up or post-setup actions
 
-# Set up command completion for command aliases
+# Set up command completion for command aliases.
+# This requires that all commands and command completions are installed, and also that all aliases are defined.
 
 _install_alias_completion
 
-# remove duplicates from PROMPT_COMMAND
+# Remove duplicates from PROMPT_COMMAND
+# This is only effective if all commands that modify the PROMPT_COMMAND variable have already executed.
 function _dedupe_prompt_command() {
 	local prompt_command=(${PROMPT_COMMAND//;/ })
 	PROMPT_COMMAND=

--- a/rootfs/etc/profile.d/Ω_overrides.sh
+++ b/rootfs/etc/profile.d/Ω_overrides.sh
@@ -1,0 +1,10 @@
+## Load user's custom overrides
+OVERRIDE_LIST=()
+_search_geodesic_dirs OVERRIDE_LIST overrides
+for file in "${OVERRIDE_LIST[@]}"; do
+	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: loading override file "$file"
+	source "$file"
+done
+unset OVERRIDE_LIST
+
+unset GEODESIC_CUSTOM_TRACE

--- a/rootfs/etc/profile.d/Ω_overrides.sh
+++ b/rootfs/etc/profile.d/Ω_overrides.sh
@@ -10,7 +10,7 @@ function _load_geodesic_overrides() {
 	done
 }
 
-_load_geodesic_overrides
+[[ ${GEODESIC_CUSTOMIZATION_DISABLED-false} != false ]] || _load_geodesic_overrides
 unset -f _load_overrides
 
 unset _GEODESIC_TRACE_CUSTOMIZATION

--- a/rootfs/etc/profile.d/Ω_overrides.sh
+++ b/rootfs/etc/profile.d/Ω_overrides.sh
@@ -6,7 +6,6 @@
 # This must come after all setup has happened so that the final configuration is availble for inspection,
 # and there must not be any configuration after this to ensure that anything set here remains set as the user intended.
 
-
 ## Load user's custom overrides
 
 function _load_geodesic_overrides() {

--- a/rootfs/etc/profile.d/Ω_overrides.sh
+++ b/rootfs/etc/profile.d/Ω_overrides.sh
@@ -1,3 +1,12 @@
+# Files in the profile.d directory are executed by the lexicographical order of their file names.
+# This file is named Ω_overrides.sh. The leading Ω (Capital Greek Omega) is needed to ensure this file executes after
+# other files that this function needs to be able to see.
+# This file should be the last file in profile.d to execute.
+# This loads user's overrides, which take actions based on any setup that has already occurred.
+# This must come after all setup has happened so that the final configuration is availble for inspection,
+# and there must not be any configuration after this to ensure that anything set here remains set as the user intended.
+
+
 ## Load user's custom overrides
 
 function _load_geodesic_overrides() {
@@ -11,6 +20,6 @@ function _load_geodesic_overrides() {
 }
 
 [[ ${GEODESIC_CUSTOMIZATION_DISABLED-false} != false ]] || _load_geodesic_overrides
-unset -f _load_overrides
+unset -f _load_geodesic_overrides
 
 unset _GEODESIC_TRACE_CUSTOMIZATION

--- a/rootfs/etc/profile.d/Ω_overrides.sh
+++ b/rootfs/etc/profile.d/Ω_overrides.sh
@@ -1,10 +1,16 @@
 ## Load user's custom overrides
-OVERRIDE_LIST=()
-_search_geodesic_dirs OVERRIDE_LIST overrides
-for file in "${OVERRIDE_LIST[@]}"; do
-	[[ -n $GEODESIC_CUSTOM_TRACE ]] && echo trace: loading override file "$file"
-	source "$file"
-done
-unset OVERRIDE_LIST
 
-unset GEODESIC_CUSTOM_TRACE
+function _load_geodesic_overrides() {
+	local override_list=()
+
+	_search_geodesic_dirs override_list overrides
+	for file in "${override_list[@]}"; do
+		[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: loading override file "$file"
+		source "$file"
+	done
+}
+
+_load_geodesic_overrides
+unset -f _load_overrides
+
+unset _GEODESIC_TRACE_CUSTOMIZATION

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -69,10 +69,6 @@ function use() {
 		DOCKER_ARGS=()
 	fi
 
-	if [ -n "${ENV_FILE}" ]; then
-		DOCKER_ARGS+=(--env-file ${ENV_FILE})
-	fi
-
 	if [ "${WITH_DOCKER}" == "true" ]; then
 		if [ $(uname -s) == 'Linux' ]; then
 			# Bind-mount docker client and docker socket into container (linux only)
@@ -85,10 +81,19 @@ function use() {
 		fi
 	fi
 
-	# allow users to override value of GEODESIC_DEFAULT_ENV_FILE
-	local geodesic_default_env_file=${GEODESIC_DEFAULT_ENV_FILE:-~/.geodesic/env}
-	if [ -f "${geodesic_default_env_file}" ]; then
-		DOCKER_ARGS+=(--env-file=${geodesic_default_env_file})
+	if [[ ${GEODESIC_CUSTOMIZATION_DISABLED-false} == false ]]; then
+		if [ -n "${ENV_FILE}" ]; then
+			DOCKER_ARGS+=(--env-file ${ENV_FILE})
+		fi
+
+		# allow users to override value of GEODESIC_DEFAULT_ENV_FILE
+		local geodesic_default_env_file=${GEODESIC_DEFAULT_ENV_FILE:-~/.geodesic/env}
+		if [ -f "${geodesic_default_env_file}" ]; then
+			DOCKER_ARGS+=(--env-file=${geodesic_default_env_file})
+		fi
+	else
+		echo "# Disabling user customizations: GEODESIC_CUSTOMIZATION_DISABLED is set and not 'false'"
+		DOCKER_ARGS+=(--env GEODESIC_CUSTOMIZATION_DISABLED)
 	fi
 
 	if [ -n "${DOCKER_DNS}" ]; then


### PR DESCRIPTION
## what
In addition to some small cleanups and additions, provide a capability for users to customize Geodesic at runtime.

## why
Because people vary, their computers vary, what they are trying to accomplish varies, and while we love to standardize, we know there is no such things as one best way for everyone.

## README
### Customizing Geodesic

Users can place bash shell scripts on their host computer, to be read either at the start of `bash` profile script processing or at the end of it. Users can also choose whether to have a single `bash` history file for all containers or to have separate history files.

#### Root directory for configuration
All configuration files are stored under `GEODESIC_DOT_DIR`, which defaults to `/localhost/.geodesic`. At this time, `/localhost` is mapped to the host `$HOME` directory and this cannot be configured yet, so all configuration files must be under `$HOME`, but within that limitation they can be placed anywhere. So if you set `GEODESIC_DOT_DIR` to `/localhost/work/config/geodesic`, then files would go in `~/work/config/geodesic/` and below on your Docker host machine.

#### Resources
There are currently 3 Resources used for configuration:
- Preferences, which are shell scripts loaded very early in the launch of the Geodesic shell. 
- Overrides, which are shell scripts loaded very late in the launch of the Geodesic shell.
- `bash` history files, which store `bash` command line history.

Both preferences and overrides can be either a single file, named `preferences` and `overrides` respectively, or can be a collection of files in directories named `preferences.d` and `overrides.d`. If they are directories, all the visible files in the directories will be sourced, except for hidden files and files with names matching the `GEODESIC_AUTO_LOAD_EXCLUSIONS` regex, which defaults to `(~|.bak|.log|.old|.orig|.disabled)$`. `bash` history is always stored in a single file named `history`.

#### Configuration by file placement
Resources can be in several places, and will be loaded from most general to most specific, according to the name of the docker container image. 

- The most general resources are the ones directly in `GEODESIC_DOT_DIR`. These are applied first. To keep the top-level directory less cluttered and to avoid name clashes, you can put them in a subdirectory named `defaults`. If that subdirectory exists, then `GEODESIC_DOT_DIR` itself is not searched.
- The `DOCKER_IMAGE` name is then parsed. Everything before the final `/` is considered the "company" name and everything after is, following the Cloudposse reference architecture, referred to as the "stage" name. So for the `DOCKER_IMAGE` name `cloudposse/geodesic`, the company name is `cloudposse` and the stage name is `geodesic`
- The next place searched for resources is the directory with the same name as the company name: `$GEODESIC_DOT_DIR/$company`, or in our example, `~/.geodesic/cloudposse`. Here you can put resources that are common to all the containers for that company. Here again you can use a `defaults` subdirectory instead of (but not in addition to) putting resources directly here.
- The next place searched for resources is the directory with the same name as the "stage", which is generally the name of the project. In our example, that would be `~/.geodesic/geodesic`. Resources here would apply to all containers with the same base name, perhaps various forks of the same project.
- The final place searched is the directory with the full name of the Docker image: `$GEODESIC_DOT_DIR/$DOCKER_IMAGE`, i.e. `~/.geodesic/cloudposse/geodesic`. Files here are the most specific to this container. 

By loading them in this order, you can put your defaults at one level and then override/customize them at another, minimizing the amount of duplication needed to customize a wide range of containers. 

#### Usage details
Preferences and Overrides are loaded in the order specified above and all that are found are loaded. For history files, only the last one found is used. To start keeping separate history, just create an empty history file in the appropriate place. 

While Preferences and Override files themselves must be `bash` scripts and will be directly loaded into the top-level Geodesic shell, they can of course call other programs. You can even use them to pull configuration out of other places.

Symbolic links must be relative if you want them to work both inside Geodesic and outside of it. Symbolic links that reference directories that are not below `$HOME` on the host will not work.

In general, you should put most of your customization in the Preferences files. Geodesic (usually) takes care to respect and adapt to preferences set before it starts adding on top of them. The primary use for overrides is if you need the results of the initialization process as inputs to your configuration, or if you need to undo something Geodesic does not yet provide a configuration option for not doing in the first place. 

# Warning
One of the key benefits of Geodesic is that it provides a consistent environment for all users regardless of their local machine. It eliminates the "it works on my machine" excuse. While these new customization options can be great productivity enhancements as well as provide the opportunity to install new features to try them out before committing to installing them permanently, they can also create the kind of divergence in environments that brings back the "it works on my machine" problem. 

Therefore, we have included an option to disable the customization files: the preferences, the overrides, and the docker environment files. Simply set and export `GEODESIC_CUSTOMIZATION_DISABLED` to any value other than "false" 

### Other goodies
There are a few other goodies in this release.
- [`fzf`](https://github.com/junegunn/fzf) colors can now be configured via the new configuration methods described above. You can, in your preferences, set whatever color you want by setting `FZF_DEFAULT_OPTS` directly, or you can set `FZF_COLORS` to one of several options:
  - `solar_24` which only works on [terminals that support 24 bit color](https://gist.github.com/XVilka/8346728).
  - `solar_light` and `solar_dark`, which are recommended by the `fzf` author.
  - `mild`, which is the default, and is minimally showy
  - `dark`, `light`, `16`, or `bw`, which are the built-in themes

- We finally added `emacs` to the toolbox. It will load your `~/.emacs` configuration by default, but your `.emacs.d` directory will not be mapped. 
- In the `emacs` spirit, we have liberated `C-s`, a.k.a. Ctrl-S, so it can be used on the command line to forward-search through history. Previously it was mapped to `xoff` which stopped terminal output until you hit Ctrl-Q. 
- Since you can now create command aliases, we now install command line completions for aliases of commands that have completions. Thanks to [kopischke](https://superuser.com/users/101110/kopischke) at [superuser](https://superuser.com/a/437508).
- We disabled by default something we only installed a few months ago, our very own [`tfenv`](https://github.com/cloudposse/tfenv). It makes your shell environment variables available to [`terraform`](https://www.terraform.io/docs/cli-index.html) by copying them over to Terraform-specific environment variable, which we still kind of like, but we do not need to do it on a global basis anymore. Now you can install and uninstall those extra environment variables only when you need them, using our [`use tfenv`](https://github.com/cloudposse/geodesic/blob/65b76a9958a558a1241d0a766ceabd4f79832a75/rootfs/etc/direnv/rc.d/tfenv) extension to the [`direnv`](https://github.com/direnv/direnv) library. If you have been using `use tfenv` you will probably now notice that `direnv` is exporting a ton more variables than before. It's not that extra variables are newly available, it's that they used to be available everywhere so `direnv` did not need to load them. If you have not started using `direnv`, this would be a good time to do it. If you just have to have the old behavior back, you can set `export TFENV_LOAD_GLOBALLY=true` in your preferences. 