### PR TITLE
[syslog-ng] Update syslog-ng configuration to 3.19

### DIFF
--- a/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -1,7 +1,8 @@
-@version: 3.13.2-r3
+@version: 3.19
 
 options {
     use_dns(no);
+    dns-cache(no);
     keep_hostname(yes);
     create_dirs(yes);
     ts_format(iso);


### PR DESCRIPTION
## what
Update syslog-ng configuration to 3.19

## why
Required to get rid of the warning messages shown below since upgrading to `syslog-ng` version 3.19 in our [release 0.80.0](https://github.com/cloudposse/geodesic/releases/tag/0.80.0)
```
[timestamp] WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.19 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file.;
[timestamp] WARNING: With use-dns(no), dns-cache() will be forced to 'no' too!;
```