### PR TITLE
[teleport] Fix permissions on teleport daemon

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -146,7 +146,7 @@ spec:
       https://get.gravitational.com/teleport-ent-v{{- getenv "TELEPORT_VERSION" -}}-linux-amd64-bin.tar.gz && \
       tar  -xzf /tmp/teleport.tar.gz -C /tmp && \
       cp -f /tmp/teleport-ent/teleport /usr/local/bin/teleport && \
-      chmod 550 /usr/local/bin/teleport'
+      chmod 551 /usr/local/bin/teleport'
   fileAssets:
     - name: teleport.yaml
       # path is actually the path plus the filename


### PR DESCRIPTION
## what
Set the correct permissions on the teleport binary installed on the node instances.

## why
Incorrect permissions prohibited non-root users from accomplishing authorized tasks such as `scp`.