### PR TITLE
[templates/kops] Install iptable entry required by kiam

### DIFF
--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -113,12 +113,27 @@ spec:
     {{- end }}
     name: events
   hooks:
+  # Mitigate CVE-2019-5736
   - before:
     - docker.service
     manifest: |
       Type=oneshot
       ExecStart=/usr/bin/chattr +i /usr/bin/docker-runc
     name: cve-2019-5736.service
+{{- if bool (getenv "KIAM_INSTALLED" "true") }}
+  # Install iptable entry for kiam which, when kiam is not present, will prevent any access to EC2 metadata
+  # NOTE: the interface name (after -i) must be the same as the interface name passed to kiam
+  #       and if kiam is not listening on the default 8181 port, you must replace 8181 with the correct port number
+  - after:
+    - network.target
+    manifest: |
+      Type=oneshot
+      ExecStart=/bin/sh -c '/sbin/iptables -t nat -A PREROUTING -d 169.254.169.254/32 \
+          -i cali+ -p tcp -m tcp --dport 80 -j DNAT \
+          --to-destination $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):8181'
+    name: kiam-iptables.service
+    roles: [Node]
+{{- end }}
 {{- if getenv "TELEPORT_PROXY_DOMAIN_NAME" }}
   - name: teleport-node.service
     roles: [Node, Master, Bastion]


### PR DESCRIPTION
## what
Install iptable entry required by `kiam`. 

WARNING: With this `kops` Cluster configuration, pods (on nodes) will have **_no_** access to the AWS metadata server unless `kiam` is installed. To ensure continued access to the metadata server in the absence of `kiam`, set the environment variable `KIAM_INSTALLED` to `"false"` before running `make kops/build-manifest`.

## why
Support rolling update of `kiam` agents required by https://github.com/cloudposse/helmfiles/pull/109 and included in  helmfiles release 0.26.0 in light of https://github.com/uswitch/kiam/issues/202