### PR TITLE
[history] Fix bash history file initialization

### DIFF
--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -46,9 +46,11 @@ unset _GEODESIC_CONFIG_HOME_DEFAULT
 # Search for and find the history file most specificly targeted to this DOCKER_IMAGE
 function _geodesic_set_histfile() {
 	## Save shell history in the most specific place
+	local histfile_at_start="${HISTFILE}"
 	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
-	_search_geodesic_dirs HISTFILE_LIST history
+	_search_geodesic_dirs histfile_list history
 	HISTFILE="${histfile_list[-1]}"
+	[[ ${HISTFILE} == $histfile_at_start ]] || histfile -r
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"
 }
 _geodesic_set_histfile

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -49,8 +49,7 @@ function _geodesic_set_histfile() {
 	local histfile_at_start="${HISTFILE}"
 	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
 	_search_geodesic_dirs histfile_list history
-	HISTFILE="${histfile_list[-1]}"
-	[[ ${HISTFILE} == $histfile_at_start ]] || history -r
+	export HISTFILE="${histfile_list[-1]}"
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"
 }
 _geodesic_set_histfile

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -50,7 +50,7 @@ function _geodesic_set_histfile() {
 	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
 	_search_geodesic_dirs histfile_list history
 	HISTFILE="${histfile_list[-1]}"
-	[[ ${HISTFILE} == $histfile_at_start ]] || histfile -r
+	[[ ${HISTFILE} == $histfile_at_start ]] || history -r
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"
 }
 _geodesic_set_histfile


### PR DESCRIPTION
## what
Due to a programming error, the `bash` history file was not being properly found and loaded. This fixes that so that the history file is found as described in #422 and loaded.

## why
Fix bug.