### PR TITLE
[prompt], [fzf] Slightly better support for Unicode-challenged terminals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ install:
 - make init
 - make travis/docker-login
 - make packages/reinstall/shfmt
-- make bash/fmt/check
 
 script:
 - make deps
 - make lint
+- make bash/fmt/check
 - make docker/build
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ install:
 - make init
 - make travis/docker-login
 - make packages/reinstall/shfmt
-
-script:
+- make bash/fmt/check
 - make deps
 - make lint
-- make bash/fmt/check
+
+script:
 - make docker/build
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ lint:
 	@LINT=true \
 	 find rootfs/usr/local/include -type f '!' -name '*.sample' -exec \
 			 /bin/sh -c 'echo "==> {}">/dev/stderr; make --include-dir=rootfs/usr/local/include/ --just-print --dry-run --recon --no-print-directory --quiet --silent -f {}' \; > /dev/null
-	@make bash:lint
 
 deps:
 	@exit 0
@@ -27,7 +26,7 @@ run:
 	@geodesic
 
 bash/fmt:
-	shfmt -l -w $(PWD)
+	shfmt -l -w $(PWD)/rootfs
 
 bash/fmt/check:
 	shfmt -d $(PWD)/rootfs

--- a/packages.txt
+++ b/packages.txt
@@ -19,7 +19,7 @@ figlet
 figurine@cloudposse
 file
 fuse
-fzf
+fzf@cloudposse
 gettext
 git
 github-commenter@cloudposse

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -80,6 +80,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 			awk -F ' ' '{print $2}' |
 			fzf \
 				--height 30% \
+				--preview-window right:70% \
 				--reverse \
 				--select-1 \
 				--prompt='-> ' \

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -38,19 +38,19 @@ function _set_fzf_default_opts() {
 
 	local fzf_default_opts
 	case "$1" in
-	solar_24|solarized_24|solarized_light_24)
+	solar_24 | solarized_24 | solarized_light_24)
 		# Solarized colors from https://ethanschoonover.com/solarized/ according to fzf site
 		fzf_default_opts='--color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
 			--color=fg:#839496,header:#586e75,info:#cb4b16,pointer:#719e07
 			--color=marker:#719e07,fg+:#839496,prompt:#719e07,hl+:#719e07'
 		;;
-	solar_light|solarized_light)
+	solar_light | solarized_light)
 		## Solarized Light color scheme for fzf, approximated with ANSI 256 colors, preserving foreground and background
 		fzf_default_opts="--border
 			--color fg:$keep,bg:$keep,hl:$blue,fg+:$gray4,bg+:$grayE,hl+:$blue
 			--color info:$burntOrange,prompt:$burntOrange,pointer:$gray3,marker:$gray3,spinner:$burntOrange"
 		;;
-	solar_dark|solarized_dark)
+	solar_dark | solarized_dark)
 		# Solarized Dark color scheme for fzf, approximated with ANSI 256 colors, preserving foreground and background
 		fzf_default_opts="--border
 			--color fg:$keep,bg:$keep,hl:$blue,fg+:$grayE,bg+:$gray4,hl+:$blue

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -36,37 +36,43 @@ function _set_fzf_default_opts() {
 	local olive="3"
 	local keep="-1" # Keep the exsiting terminal setting for this field
 
+	local fzf_default_opts
 	case "$1" in
-	solar_24)
-		export FZF_DEFAULT_OPTS='--color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
+	solar_24|solarized_24|solarized_light_24)
+		# Solarized colors from https://ethanschoonover.com/solarized/ according to fzf site
+		fzf_default_opts='--color=bg+:#073642,bg:#002b36,spinner:#719e07,hl:#586e75
 			--color=fg:#839496,header:#586e75,info:#cb4b16,pointer:#719e07
 			--color=marker:#719e07,fg+:#839496,prompt:#719e07,hl+:#719e07'
 		;;
-	solar_light)
-		## Solarized Light color scheme for fzf
-		export FZF_DEFAULT_OPTS="--border
+	solar_light|solarized_light)
+		## Solarized Light color scheme for fzf, approximated with ANSI 256 colors, preserving foreground and background
+		fzf_default_opts="--border
 			--color fg:$keep,bg:$keep,hl:$blue,fg+:$gray4,bg+:$grayE,hl+:$blue
 			--color info:$burntOrange,prompt:$burntOrange,pointer:$gray3,marker:$gray3,spinner:$burntOrange"
 		;;
-	solar_dark)
-		# Solarized Dark color scheme for fzf
-		export FZF_DEFAULT_OPTS="--border
+	solar_dark|solarized_dark)
+		# Solarized Dark color scheme for fzf, approximated with ANSI 256 colors, preserving foreground and background
+		fzf_default_opts="--border
 			--color fg:$keep,bg:$keep,hl:$blue,fg+:$grayE,bg+:$gray4,hl+:$blue
 			--color info:$burntOrange,prompt:$burntOrange,pointer:$veryPaleYellow
 			--color marker:$veryPaleYellow,spinner:$burntOrange"
 		;;
 	dark | light | 16 | bw)
 		# Built-in basic color schemes
-		export FZF_DEFAULT_OPTS="--color=$1"
+		fzf_default_opts="--color=$1"
 		;;
 	mild | *) # "mild" is redundant with "*", but I want this to have an explicit name in case the default changes later
-		export FZF_DEFAULT_OPTS="--border
+		fzf_default_opts="--border
 			--color fg:$keep,bg:$keep,hl:$burntOrange,fg+:$olive,bg+:$gray2,hl+:$veryPaleYellow
 			--color info:$teal,prompt:$blue,spinner:$teal,pointer:$orange,marker:$salmon,header:$green"
 		;;
 	esac
+	export FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS:+${FZF_DEFAULT_OPTS} }${fzf_default_opts}"
 }
 
-if [[ -z $FZF_DEFAULT_OPTS ]]; then
-	_set_fzf_default_opts "$FZF_COLORS"
+_set_fzf_default_opts "$FZF_COLORS"
+
+# Requires fzf v0.18.0 or later
+if [[ $PROMPT_STYLE == plain && ! $FZF_DEFAULT_OPTS =~ --no-unicode ]]; then
+	FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS:+${FZF_DEFAULT_OPTS} }--no-unicode"
 fi

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -76,8 +76,16 @@ function geodesic_prompt() {
 
 	*)
 		# default
-		ASSUME_ROLE_ACTIVE_MARK=$' \x01'$(tput bold)$(tput setaf 2)$'\x02\u2713 \x01'$(tput sgr0)$'\x02'   # green bold '✓'
+		#	ASSUME_ROLE_ACTIVE_MARK=$' \x01'$(tput bold)$(tput setaf 2)$'\x02\u2713 \x01'$(tput sgr0)$'\x02'   # green bold '✓'
+		ASSUME_ROLE_ACTIVE_MARK=$' \x01'$(tput bold)$(tput setaf 2)$'\x02\u221a \x01'$(tput sgr0)$'\x02'   # green bold '√'
 		ASSUME_ROLE_INACTIVE_MARK=$' \x01'$(tput bold)$(tput setaf 1)$'\x02\u2717 \x01'$(tput sgr0)$'\x02' # red bold '✗'
+		# Options for arrow per https://github.com/cloudposse/geodesic/issues/417#issuecomment-477836676
+		# '»' ($'\u00bb') RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK from the Latin-1 supplement Unicode block
+		# '≫' ($'\u226b') MUCH GREATER-THAN and
+		# '⋙' ($'\u22d9') VERY MUCH GREATER-THAN which are from the Mathematical Operators Unicode block
+		# '➤' ($'\u27a4') BLACK RIGHTWARDS ARROWHEAD from the Dingbats Unicode block
+		# '▶︎' ($'\u25b6\ufe0e') BLACK RIGHT-POINTING TRIANGLE which is sometimes presented as an emoji (as GitHub likes to) '▶️'
+		# '⏩︎' ($'\u23e9\ufe0e') BLACK RIGHT-POINTING DOUBLE TRIANGLE
 		BLACK_RIGHTWARDS_ARROWHEAD=$'\u2a20 '                                                              # '⨠'
 		BANNER_MARK='⧉ '
 		;;
@@ -97,7 +105,7 @@ function geodesic_prompt() {
 
 	PS1="${STATUS}"
 	PS1+="  ${ROLE_PROMPT} \W "
-	PS1+=$'${BLACK_RIGHTWARDS_ARROWHEAD}'
+	PS1+=$'${GEODISIC_PROMPT_GLYPHS-$BLACK_RIGHTWARDS_ARROWHEAD}'
 
 	if [ -n "${BANNER}" ]; then
 		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)\n"${PS1}

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -86,7 +86,7 @@ function geodesic_prompt() {
 		# '➤' ($'\u27a4') BLACK RIGHTWARDS ARROWHEAD from the Dingbats Unicode block
 		# '▶︎' ($'\u25b6\ufe0e') BLACK RIGHT-POINTING TRIANGLE which is sometimes presented as an emoji (as GitHub likes to) '▶️'
 		# '⏩︎' ($'\u23e9\ufe0e') BLACK RIGHT-POINTING DOUBLE TRIANGLE
-		BLACK_RIGHTWARDS_ARROWHEAD=$'\u2a20 '                                                              # '⨠'
+		BLACK_RIGHTWARDS_ARROWHEAD=$'\u2a20 ' # '⨠' Z NOTATION SCHEMA PIPING
 		BANNER_MARK='⧉ '
 		;;
 	esac


### PR DESCRIPTION
## what
- Add option to set `GEODISIC_PROMPT_GLYPHS` to set (or remove) glyphs at end of command line prompt
- Set `fzf` to use plain ASCII when `PROMPT_STYLE` is set to `plain`.

## why
Partly address issues such as #417 