### PR TITLE
[aws-vault] Fix startup hang and other misc problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ FROM alpine:3.9.2
 
 ENV BANNER "geodesic"
 
-ENV GEODESIC_PATH=/usr/local/include/toolbox
 ENV MOTD_URL=http://geodesic.sh/motd
 ENV HOME=/conf
 ENV KOPS_CLUSTER_NAME=example.foo.bar

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,16 +96,6 @@ RUN ln -s /usr/local/google-cloud-sdk/completion.bash.inc /etc/bash_completion.d
     gcloud config set metrics/environment github_docker_image --installation
 
 #
-# Configure aws-vault to easily assume roles (not related to HashiCorp Vault)
-#
-ENV AWS_VAULT_ENABLED=true
-ENV AWS_VAULT_SERVER_ENABLED=false
-ENV AWS_VAULT_BACKEND=file
-ENV AWS_VAULT_ASSUME_ROLE_TTL=1h
-ENV AWS_VAULT_SESSION_TTL=12h
-#ENV AWS_VAULT_FILE_PASSPHRASE=
-
-#
 # Configure aws-okta to easily assume roles
 #
 ENV AWS_OKTA_ENABLED=false
@@ -203,6 +193,16 @@ ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/${KUBE_PS1_VERSION}/kube
 ENV AWS_DATA_PATH=/localhost/.aws
 ENV AWS_CONFIG_FILE=${AWS_DATA_PATH}/config
 ENV AWS_SHARED_CREDENTIALS_FILE=${AWS_DATA_PATH}/credentials
+
+#
+# Configure aws-vault to easily assume roles (not related to HashiCorp Vault)
+#
+ENV AWS_VAULT_ENABLED=true
+ENV AWS_VAULT_SERVER_ENABLED=false
+ENV AWS_VAULT_BACKEND=file
+ENV AWS_VAULT_ASSUME_ROLE_TTL=1h
+ENV AWS_VAULT_SESSION_TTL=12h
+#ENV AWS_VAULT_FILE_PASSPHRASE=
 
 #
 # Shell

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	@make --no-print-directory docker:build
 
 install:
-	@docker run --rm -e CLUSTER=galaxy $(DOCKER_IMAGE_NAME) | sudo -E bash -s $(DOCKER_TAG)
+	@docker run --rm -e CLUSTER=galaxy $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG) || (echo "Try: sudo make install"; exit 1)
 
 run:
 	@geodesic

--- a/packages.txt
+++ b/packages.txt
@@ -20,6 +20,7 @@ figurine@cloudposse
 file
 fuse
 fzf@cloudposse
+fzf-bash-completion
 gettext
 git
 github-commenter@cloudposse

--- a/rootfs/etc/profile.d/_geodesic-config.sh
+++ b/rootfs/etc/profile.d/_geodesic-config.sh
@@ -73,13 +73,14 @@ function _search_geodesic_dirs() {
 #   the exclusion pattern in GEODESIC_AUTO_LOAD_EXCLUSIONS, in the directory to the array-ref
 function _expand_dir_or_file() {
 	local -n expand_list=$1
+	local resource=$2
 	local dir=${3-${PWD}}
 	local default_exclusion_pattern="(~|.bak|.log|.old|.orig|.disabled)$"
 	local exclude="${GEODESIC_AUTO_LOAD_EXCLUSIONS:-$default_exclusion_pattern}"
 
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: looking for resources of type "$resource" in "$dir"
 
-	for item in "${dir}/$2" "${dir}/${2}.d"/*; do
+	for item in "${dir}/$resource" "${dir}/${resource}.d"/*; do
 		if [[ -f $item ]]; then
 			[[ $item =~ $exclude ]] && continue
 			expand_list+=($item)

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -39,14 +39,21 @@ elif [[ ! -d $GEODESIC_CONFIG_HOME ]]; then
 	fi
 fi
 
+if [[ ! -d $GEODESIC_CONFIG_HOME ]]; then
+	if mkdir -p $GEODESIC_CONFIG_HOME; then
+		echo $(yellow Created directory "$GEODESIC_CONFIG_HOME" '(GEODESIC_CONFIG_HOME)')
+	else
+		echo $(red Cannot create directory "$GEODESIC_CONFIG_HOME" '(GEODESIC_CONFIG_HOME)')
+	fi
+fi
+
 unset _GEODESIC_CONFIG_HOME_DEFAULT
 
 [[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_CONFIG_HOME is ultimately set to "${GEODESIC_CONFIG_HOME}"
 
-# Search for and find the history file most specificly targeted to this DOCKER_IMAGE
+# Search for and find the history file most specifically targeted to this DOCKER_IMAGE
 function _geodesic_set_histfile() {
 	## Save shell history in the most specific place
-	local histfile_at_start="${HISTFILE}"
 	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
 	_search_geodesic_dirs histfile_list history
 	export HISTFILE="${histfile_list[-1]}"

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -11,7 +11,7 @@ function _validate_aws_vault_server() {
 	if [[ $instance == "aws-vault" ]]; then
 		_assume_active_aws_role
 	elif (($curl_exit_code == 0)); then
-		echo $(green force-starting aws-vault server because real AWS meta-data server is reachable)
+		echo "* $(green force-starting aws-vault server because real AWS meta-data server is reachable)"
 		_force_start_aws_vault_server
 	elif (($curl_exit_code == 7)) || (($curl_exit_code == 28)); then
 		echo "* $(green assume-role) will start EC2 metadata service at $(green http://169.254.169.254/latest)"
@@ -141,7 +141,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 				# this function returns, regardless of how it returns (e.g. in case of errors).
 				trap 'export AWS_VAULT="$aws_vault" && export AWS_VAULT_SERVER_ENABLED="$aws_vault_server_enabled"' RETURN
 				unset AWS_VAULT
-				AWS_VAULT_SERVER_ENABLED=false
+				AWS_VAULT_SERVER_ENABLED="false: server serving other role"
 			else
 				echo "Type '$(green exit)' before attempting to assume another role"
 				return 1

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -3,13 +3,10 @@
 function _validate_aws_vault_server() {
 	[[ ${AWS_VAULT_SERVER_ENABLED:-true} == "true" ]] || return 0
 
-	# For some reason, the obvious way did not work, and curl_exit_code was always 0
-	# local instance=$(curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/)
-	# local curl_exit_code=$? # was always 0
-
-	curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/ >/tmp/instance
-	local curl_exit_code=$?
-	local instance=$(cat /tmp/instance)
+	local instance
+	local curl_exit_code
+	instance=$(curl -m 2 --connect-timeout 0.3 -s -f http://169.254.169.254/latest/meta-data/instance-id/)
+	curl_exit_code=$?
 
 	if [[ $instance == "aws-vault" ]]; then
 		_assume_active_aws_role

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 function _validate_aws_vault_server() {
 	[[ ${AWS_VAULT_SERVER_ENABLED:-true} == "true" ]] || return 0
 
@@ -8,7 +7,7 @@ function _validate_aws_vault_server() {
 	# local instance=$(curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/)
 	# local curl_exit_code=$? # was always 0
 
-	curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/ > /tmp/instance
+	curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/ >/tmp/instance
 	local curl_exit_code=$?
 	local instance=$(cat /tmp/instance)
 
@@ -22,15 +21,17 @@ function _validate_aws_vault_server() {
 		AWS_VAULT_ARGS+=("--server")
 	else
 		echo "* $(red Unexpected status code $curl_exit_code while probing for meta-data server. Disabling aws-vault server.)"
-	 	export AWS_VAULT_SERVER_ENABLED="probe returned $curl_exit_code"
+		export AWS_VAULT_SERVER_ENABLED="probe returned $curl_exit_code"
 	fi
 }
 
 function _force_start_aws_vault_server() {
-	{ aws-vault server >/dev/null & } 2>/dev/null
+	{
+		aws-vault server >/dev/null &
+	} 2>/dev/null
 	local aws_vault_server_pid=$!
 	sleep 1
-	if disown $aws_vault_server_pid 2> /dev/null; then
+	if disown $aws_vault_server_pid 2>/dev/null; then
 		echo $(green aws-vault server started at PID $aws_vault_server_pid)
 		AWS_VAULT_ARGS+=("--server")
 	else
@@ -51,7 +52,7 @@ function _assume_active_aws_role() {
 		export AWS_VAULT_SERVER_EXTERNAL=true
 		local aws_vault=$(crudini --get --format=lines "$AWS_CONFIG_FILE" | grep "$TF_VAR_aws_assume_role_arn" | cut -d' ' -f 3)
 		if [[ -z $aws_vault ]]; then
-			echo "* $(red Could not find role name for $TF_VAR_aws_assume_role_arn; calling it \"instance-role\")"
+			echo "* $(red Could not find role name for ${TF_VAR_aws_assume_role_arn}\; calling it \"instance-role\")"
 			aws-vault="instance-role"
 		fi
 		if [[ -z $AWS_VAULT || $AWS_VAULT == $aws_vault ]]; then

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -1,30 +1,69 @@
 #!/bin/bash
 
-function assume_active_role() {
-	if [ "${AWS_VAULT_SERVER_ENABLED:-true}" != "true" ]; then
-		return 0
+
+function _validate_aws_vault_server() {
+	[[ ${AWS_VAULT_SERVER_ENABLED:-true} == "true" ]] || return 0
+
+	# For some reason, the obvious way did not work, and curl_exit_code was always 0
+	# local instance=$(curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/)
+	# local curl_exit_code=$? # was always 0
+
+	curl -m 2 --connect-timeout 0.3 -sS -f http://169.254.169.254/latest/meta-data/instance-id/ > /tmp/instance
+	local curl_exit_code=$?
+	local instance=$(cat /tmp/instance)
+
+	if [[ $instance == "aws-vault" ]]; then
+		_assume_active_aws_role
+	elif (($curl_exit_code == 0)); then
+		echo $(green force-starting aws-vault server because real AWS meta-data server is reachable)
+		_force_start_aws_vault_server
+	elif (($curl_exit_code == 7)) || (($curl_exit_code == 28)); then
+		echo "* $(green assume-role) will start EC2 metadata service at $(green http://169.254.169.254/latest)"
+		AWS_VAULT_ARGS+=("--server")
+	else
+		echo "* $(red Unexpected status code $curl_exit_code while probing for meta-data server. Disabling aws-vault server.)"
+	 	export AWS_VAULT_SERVER_ENABLED="probe returned $curl_exit_code"
 	fi
+}
+
+function _force_start_aws_vault_server() {
+	{ aws-vault server >/dev/null & } 2>/dev/null
+	local aws_vault_server_pid=$!
+	sleep 1
+	if disown $aws_vault_server_pid 2> /dev/null; then
+		echo $(green aws-vault server started at PID $aws_vault_server_pid)
+		AWS_VAULT_ARGS+=("--server")
+	else
+		echo $(red Failed to start aws-vault server, forcing non-sever mode)
+		export AWS_VAULT_SERVER_ENABLED=unavailable
+	fi
+}
+
+function _assume_active_aws_role() {
+	[[ ${AWS_VAULT_SERVER_ENABLED:-true} == "true" ]] || return 0
 
 	local aws_default_profile="$AWS_DEFAULT_PROFILE"
+	trap 'AWS_DEFAULT_PROFILE=${AWS_DEFAULT_PROFILE:-$aws_default_profile}' RETURN
 	unset AWS_DEFAULT_PROFILE
 
-	curl -sSL --connect-timeout 0.1 --fail -o /dev/null --stderr /dev/null 'http://169.254.169.254/latest/meta-data/iam/security-credentials/local-credentials'
-	if [ $? -eq 0 ]; then
-		export TF_VAR_aws_assume_role_arn=$(aws sts get-caller-identity --output text --query 'Arn' | sed 's/:sts:/:iam:/g' | sed 's,:assumed-role/,:role/,' | cut -d/ -f1-2)
-		if [ -n "${TF_VAR_aws_assume_role_arn}" ]; then
-			local aws_vault=$(crudini --get --format=lines "$AWS_CONFIG_FILE" | grep "$TF_VAR_aws_assume_role_arn" | cut -d' ' -f 3)
-			if [ -z "$AWS_VAULT" ] || [ "$AWS_VAULT" == "$aws_vault" ]; then
-				echo "* $(green Attaching to exising aws-vault session and assuming role) $(cyan ${aws_vault})"
-				export AWS_VAULT="$aws_vault"
-				export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION-${AWS_REGION}}"
-				export AWS_VAULT_SERVER_EXTERNAL=true
-			fi
-		else
-			unset TF_VAR_aws_assume_role_arn
-			AWS_DEFAULT_PROFILE=${aws_default_profile}
+	export TF_VAR_aws_assume_role_arn=$(aws sts get-caller-identity --output text --query 'Arn' | sed 's/:sts:/:iam:/g' | sed 's,:assumed-role/,:role/,' | cut -d/ -f1-2)
+	if [ -n "${TF_VAR_aws_assume_role_arn}" ]; then
+		export AWS_VAULT_SERVER_EXTERNAL=true
+		local aws_vault=$(crudini --get --format=lines "$AWS_CONFIG_FILE" | grep "$TF_VAR_aws_assume_role_arn" | cut -d' ' -f 3)
+		if [[ -z $aws_vault ]]; then
+			echo "* $(red Could not find role name for $TF_VAR_aws_assume_role_arn; calling it \"instance-role\")"
+			aws-vault="instance-role"
+		fi
+		if [[ -z $AWS_VAULT || $AWS_VAULT == $aws_vault ]]; then
+			echo "* $(green Attaching to exising aws-vault session and assuming role) $(cyan ${aws_vault})"
+			export AWS_VAULT="$aws_vault"
+			export ASSUME_ROLE=${AWS_VAULT}
+			export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION-${AWS_REGION}}"
 		fi
 	else
-		AWS_DEFAULT_PROFILE=$aws_default_profile
+		unset TF_VAR_aws_assume_role_arn
+		AWS_DEFAULT_PROFILE=${aws_default_profile}
+		AWS_VAULT_SERVER_ENABLED="get-caller-identity failed"
 	fi
 }
 
@@ -32,10 +71,6 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 	if ! which aws-vault >/dev/null; then
 		echo "aws-vault not installed"
 		exit 1
-	fi
-
-	if [ "$SHLVL" -eq 1 ]; then
-		assume_active_role
 	fi
 
 	if [ -n "${AWS_VAULT}" ]; then
@@ -56,14 +91,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 		[ -d /localhost/.awsvault ] || mkdir -p /localhost/.awsvault
 		ln -sf /localhost/.awsvault ${HOME}
 		if [ "${AWS_VAULT_SERVER_ENABLED:-true}" == "true" ]; then
-			curl -sSL --connect-timeout 0.1 -o /dev/null --stderr /dev/null http://169.254.169.254/latest/meta-data/iam/security-credentials
-			result=$?
-			if [ $result -ne 0 ]; then
-				echo "* $(green assume-role) will start EC2 metadata service at $(green http://169.254.169.254/latest)"
-				AWS_VAULT_ARGS+=("--server")
-			else
-				echo "* $(red EC2 metadata server already running)"
-			fi
+			_validate_aws_vault_server
 		fi
 	fi
 

--- a/rootfs/etc/profile.d/fzf.sh
+++ b/rootfs/etc/profile.d/fzf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Install fzf shell completion when an interactive shell is enabled
 # This is a fix for: `/etc/bash_completion.d/fzf.sh: line 34: bind: warning: line editing not enabled`
-if [ -t 1 ] && ! [ -e '/etc/bash_completion.d/fzf.sh' ]; then
+if [ -t 1 ] && ! [ -e '/etc/bash_completion.d/fzf.sh' ] && [ -e '/usr/share/bash-completion/completions/fzf' ]; then
 	ln -s /usr/share/bash-completion/completions/fzf /etc/bash_completion.d/fzf.sh
 fi
 

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -26,7 +26,7 @@ if [ ! -d "/localhost/.awsvault/" ] || [ ! -w "/localhost/.awsvault/" ]; then
 	exit 1
 fi
 
-if [ -d "/localhost/.awsvault/keys/" ] && [ ! -w "/localhost/.awsvault/" ]; then
+if [ -d "/localhost/.awsvault/keys/" ] && [ ! -w "/localhost/.awsvault/keys/" ]; then
 	echo "/localhost/.awsvault/keys/ is not writable"
 	exit 1
 fi
@@ -35,11 +35,6 @@ if [ "${AWS_VAULT_BACKEND}" != "file" ]; then
 	echo "*"
 	echo "* WARNING: AWS_VAULT_BACKEND is \"${AWS_VAULT_BACKEND}\". Geodesic only supports AWS_VAULT_BACKEND=\"file\"."
 	echo "*"
-fi
-
-if [ ! -d "/localhost/.awsvault/" ] || [ ! -w "/localhost/.awsvault/" ]; then
-	echo "WARNING: /localhost/.awsvault/ is not writable"
-	exit 1
 fi
 
 # Derive the source profile from the prefix of the default profile

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -59,7 +59,7 @@ crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profi
 read -p "Setup AWS Credentials (aws-vault)? [y/n] " SETUP_VAULT
 
 if [ "${SETUP_VAULT}" == "y" ]; then
-	aws-vault add "${AWS_SOURCE_PROFILE}"
+	aws-vault --backend=file add "${AWS_SOURCE_PROFILE}"
 fi
 
 echo "Configured AWS ${AWS_DEFAULT_PROFILE} profile for ${AWS_REGION} region in the ${AWS_ACCOUNT_ID} account"

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -21,6 +21,27 @@ if [ -z "${AWS_ROOT_ACCOUNT_ID}" ]; then
 	exit 1
 fi
 
+if [ ! -d "/localhost/.awsvault/" ] || [ ! -w "/localhost/.awsvault/" ]; then
+	echo "/localhost/.awsvault/ is not writable"
+	exit 1
+fi
+
+if [ -d "/localhost/.awsvault/keys/" ] && [ ! -w "/localhost/.awsvault/" ]; then
+	echo "/localhost/.awsvault/keys/ is not writable"
+	exit 1
+fi
+
+if [ "${AWS_VAULT_BACKEND}" != "file" ]; then
+    echo "*"
+	echo "* WARNING: AWS_VAULT_BACKEND is \"${AWS_VAULT_BACKEND}\". Geodesic only supports AWS_VAULT_BACKEND=\"file\"."
+	echo "*"
+fi
+
+if [ ! -d "/localhost/.awsvault/" ] || [ ! -w "/localhost/.awsvault/" ]; then
+	echo "WARNING: /localhost/.awsvault/ is not writable"
+	exit 1
+fi
+
 # Derive the source profile from the prefix of the default profile
 export AWS_SOURCE_PROFILE=$(echo ${AWS_DEFAULT_PROFILE} | cut -d- -f1)
 
@@ -59,7 +80,7 @@ crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profi
 read -p "Setup AWS Credentials (aws-vault)? [y/n] " SETUP_VAULT
 
 if [ "${SETUP_VAULT}" == "y" ]; then
-	aws-vault --backend=file add "${AWS_SOURCE_PROFILE}"
+	aws-vault add "${AWS_SOURCE_PROFILE}"
 fi
 
 echo "Configured AWS ${AWS_DEFAULT_PROFILE} profile for ${AWS_REGION} region in the ${AWS_ACCOUNT_ID} account"

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -32,7 +32,7 @@ if [ -d "/localhost/.awsvault/keys/" ] && [ ! -w "/localhost/.awsvault/" ]; then
 fi
 
 if [ "${AWS_VAULT_BACKEND}" != "file" ]; then
-    echo "*"
+	echo "*"
 	echo "* WARNING: AWS_VAULT_BACKEND is \"${AWS_VAULT_BACKEND}\". Geodesic only supports AWS_VAULT_BACKEND=\"file\"."
 	echo "*"
 fi


### PR DESCRIPTION
## what
- Fix long delay at startup when opening TCP SYN packet is not rejected
- Fix use of `aws-vault` server when Docker is running on AWS and has a default route to the instance meta-data server
- Create `GEODESIC_CONFIG_HOME` directory if it does not exist
- Remove `sudo` from install recipe
- Add back missing bash completion script for `fzf`
- Do not create symbolic link for `fzf` bash completion if the file does not exist
- Fix trace message for config file search
- Remove GEODESIC_PATH (dead code)

## why
These are bugs that typically only show up on first or early use.