### PR TITLE
[aws-vault] Better detection of when aws-vault server needs to be explicitly started

### DIFF
--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -50,17 +50,7 @@ fi
 unset _GEODESIC_CONFIG_HOME_DEFAULT
 
 [[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_CONFIG_HOME is ultimately set to "${GEODESIC_CONFIG_HOME}"
-
-# Search for and find the history file most specifically targeted to this DOCKER_IMAGE
-function _geodesic_set_histfile() {
-	## Save shell history in the most specific place
-	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
-	_search_geodesic_dirs histfile_list history
-	export HISTFILE="${histfile_list[-1]}"
-	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"
-}
-_geodesic_set_histfile
-unset -f _geodesic_set_histfile
+[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE is "${HISTFILE}" before loading preferences
 
 function _load_geodesic_preferences() {
 	local preference_list=()
@@ -79,3 +69,23 @@ else
 fi
 
 unset -f _load_geodesic_preferences
+
+# Search for and find the history file most specifically targeted to this DOCKER_IMAGE
+function _geodesic_set_histfile() {
+	## Save shell history in the most specific place
+	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE is "${HISTFILE}" after loading preferences
+	[[ $HISTFILE == ${HOME}/.bash_history ]] && unset HISTFILE
+	HISTFILESIZE="${HISTFILESIZE:-2500}"
+	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
+	_search_geodesic_dirs histfile_list history
+	export HISTFILE="${histfile_list[-1]}"
+	if [[ ! $HISTFILE =~ ^/localhost/ ]]; then
+		echo "* $(yellow Not allowing \"HISTFILE=${HISTFILE}\".)"
+		mkdir -p "${GEODESIC_CONFIG_HOME}/${DOCKER_IMAGE}/" && HISTFILE="${GEODESIC_CONFIG_HOME}/${DOCKER_IMAGE}/history" &&
+			touch "$HISTFILE" || HISTFILE="${GEODESIC_CONFIG_HOME}/history"
+		echo "* $(yellow HISTFILE forced to \"${HISTFILE}\".)"
+	fi
+	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE set to "${HISTFILE}"
+}
+_geodesic_set_histfile
+unset -f _geodesic_set_histfile

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -70,12 +70,17 @@ fi
 
 unset -f _load_geodesic_preferences
 
+## Append rather than overwrite history file
+shopt -s histappend
+
+## Default to saving 2500 lines of history rather than the bash default of 500
+HISTFILESIZE="${HISTFILESIZE:-2500}"
+
 # Search for and find the history file most specifically targeted to this DOCKER_IMAGE
 function _geodesic_set_histfile() {
 	## Save shell history in the most specific place
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: HISTFILE is "${HISTFILE}" after loading preferences
 	[[ $HISTFILE == ${HOME}/.bash_history ]] && unset HISTFILE
-	HISTFILESIZE="${HISTFILESIZE:-2500}"
 	local histfile_list=(${HISTFILE:-${GEODESIC_CONFIG_HOME}/history})
 	_search_geodesic_dirs histfile_list history
 	export HISTFILE="${histfile_list[-1]}"

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -25,7 +25,7 @@ function _validate_aws_vault_server() {
 		# 22 = HTTP page not retrieved (e.g. status 404), 52 = Empty reply,
 		# 124 = timeout exceeded (implies TCP connection succeeded)
 	elif (($curl_exit_code == 22)) || (($curl_exit_code == 52)) || (($curl_exit_code == 124)); then
-		echo "* $(yellow connected to something at 169.254.169.254 but got status code ${curl_exit_code}. Force-starting aws-vault server)"
+		echo "* $(yellow Connected to something at 169.254.169.254 but got status code ${curl_exit_code}. Force-starting aws-vault server.)"
 		_force_start_aws_vault_server
 	else
 		echo "* $(red Unexpected status code ${curl_exit_code} while probing for meta-data server. Disabling aws-vault server.)"


### PR DESCRIPTION
## what
- Better detection of when aws-vault server needs to be explicitly started
- Proper creation of `HISTFILE` when no existing file can be found

## why
- Anti-virus programs like ESET NOD32 Internet Protection can confuse `aws-vault` into thinking a meta-data server is already running.
- Previously if no default was set and no `history` file was found, history was saved in the ephemeral file system, causing it to be lost on exit.