### PR TITLE
[build-kops-manifest] Support using remote templates for kops manifest and kubecfg

### DIFF
--- a/rootfs/etc/direnv/rc.d/terraform
+++ b/rootfs/etc/direnv/rc.d/terraform
@@ -32,6 +32,15 @@ function use_terraform() {
 	fi
 	
 	# Translate environment variables to terraform arguments
+	# Note: Setting TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT to "true" does not work due to quirks:
+	#   https://github.com/cloudposse/tfenv/issues/10
+	# Set to 1 to enable.
+	if [[ $TF_BUCKET_ENCRYPT == false ]]; then
+		export TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT=false
+	else
+		export TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT=1
+	fi
+
 	[ -z "${TF_FROM_MODULE}" ] || export TF_CLI_INIT_FROM_MODULE="${TF_FROM_MODULE}"
 	[ -z "${TF_STATE_FILE}" ] || export TF_CLI_INIT_BACKEND_CONFIG_KEY="${TF_BUCKET_PREFIX}/${TF_STATE_FILE}"
 	[ -z "${TF_BUCKET}" ] || export TF_CLI_INIT_BACKEND_CONFIG_BUCKET="${TF_BUCKET}"

--- a/rootfs/templates/kops/default.yaml
+++ b/rootfs/templates/kops/default.yaml
@@ -192,6 +192,10 @@ spec:
           --query 'Tags[*].{tag:Key,value:Value}' \
           --output text | sed 's/\t/=/' | grep k8s.io/role | sed 's%k8s.io/role/%%' | cut -f1 -d=
 {{- end }}
+{{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
+  kubelet:
+    anonymousAuth: false
+{{- end }}
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: {{ getenv "KUBERNETES_VERSION" }}

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -46,15 +46,15 @@ if [ "${AWS_SOURCE_PROFILE}" == "${AWS_DEFAULT_PROFILE}" ]; then
 fi
 
 # Define empty source profile
-crudini --set ${AWS_CONFIG_FILE} "profile ${AWS_SOURCE_PROFILE}"
+crudini --set --inplace ${AWS_CONFIG_FILE} "profile ${AWS_SOURCE_PROFILE}"
 
 # Define default profile
-crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AWS_REGION}"
+crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AWS_REGION}"
 
 if [ "${AWS_ACCOUNT_ID}" == "${AWS_ROOT_ACCOUNT_ID}" ]; then
-	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
+	crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
 else
-	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/OrganizationAccountAccessRole"
+	crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/OrganizationAccountAccessRole"
 fi
 
 # Prompt the user to setup MFA
@@ -63,13 +63,13 @@ read -p "Use MFA? [y/n] " SETUP_MFA
 if [ "${SETUP_MFA}" == "y" ]; then
 	read -p "AWS IAM Username: " AWS_USERNAME
 	export AWS_MFA_SERIAL="arn:aws:iam::${AWS_ROOT_ACCOUNT_ID}:mfa/${AWS_USERNAME}"
-	crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial "${AWS_MFA_SERIAL}"
+	crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial "${AWS_MFA_SERIAL}"
 else
 	crudini --del "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial
 fi
 
 # Reference the source profile settings
-crudini --set "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
+crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
 
 # Prompt the user to setup their AWS credentials in aws-vault
 read -p "Setup AWS Credentials (aws-vault)? [y/n] " SETUP_VAULT

--- a/rootfs/usr/local/bin/build-kops-manifest
+++ b/rootfs/usr/local/bin/build-kops-manifest
@@ -1,5 +1,5 @@
 #!/bin/bash
-KOPS_TEMPLATE="${1:-$KOPS_TEMPLATE}"
+KOPS_TEMPLATE_URL="${1:-$KOPS_TEMPLATE}"
 KOPS_MANIFEST="${2:-$KOPS_MANIFEST}"
 KOPS_CONF_DIR="$(dirname "$KOPS_MANIFEST")"
 EXTRA_ARGS=${@:3}
@@ -7,6 +7,8 @@ GOMPLATE_EXTRA_ARGS=${EXTRA_ARGS:-$GOMPLATE_EXTRA_ARGS}
 
 mkdir -p ${KOPS_CONF_DIR}
 
-direnv exec ${KOPS_CONF_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} -f ${KOPS_TEMPLATE} >${KOPS_MANIFEST}
+[[ $KOPS_TEMPLATE_URL =~ ^https?:// ]] || KOPS_TEMPLATE_URL="file://$(realpath "$KOPS_TEMPLATE_URL")"
+direnv exec ${KOPS_CONF_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} \
+  -d "data=${KOPS_TEMPLATE_URL}?type=text/plain" -i '{{ (ds "data") | tpl}}' >${KOPS_MANIFEST}
 
 echo "Wrote manifest to ${KOPS_MANIFEST}..."

--- a/rootfs/usr/local/bin/build-kops-manifest
+++ b/rootfs/usr/local/bin/build-kops-manifest
@@ -9,6 +9,6 @@ mkdir -p ${KOPS_CONF_DIR}
 
 [[ $KOPS_TEMPLATE_URL =~ ^https?:// ]] || KOPS_TEMPLATE_URL="file://$(realpath "$KOPS_TEMPLATE_URL")"
 direnv exec ${KOPS_CONF_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} \
-  -d "data=${KOPS_TEMPLATE_URL}?type=text/plain" -i '{{ (ds "data") | tpl}}' >${KOPS_MANIFEST}
+	-d "data=${KOPS_TEMPLATE_URL}?type=text/plain" -i '{{ (ds "data") | tpl}}' >${KOPS_MANIFEST}
 
 echo "Wrote manifest to ${KOPS_MANIFEST}..."

--- a/rootfs/usr/local/bin/build-kubecfg
+++ b/rootfs/usr/local/bin/build-kubecfg
@@ -33,7 +33,7 @@ function write_kube_config() {
 	[[ $kubeconfig_template_url =~ ^https?:// ]] || kubeconfig_template_url="file://$(realpath "$kubeconfig_template_url")"
 
 	direnv exec ${KUBECONFIG_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} \
- 		-d "data=${kubeconfig_template_url}?type=text/plain" -i '{{ (ds "data") | tpl}}' >${KUBECONFIG}
+		-d "data=${kubeconfig_template_url}?type=text/plain" -i '{{ (ds "data") | tpl}}' >${KUBECONFIG}
 }
 
 ensure_env_vars

--- a/rootfs/usr/local/bin/build-kubecfg
+++ b/rootfs/usr/local/bin/build-kubecfg
@@ -29,7 +29,11 @@ function cluster_ca() {
 }
 
 function write_kube_config() {
-	direnv exec ${KUBECONFIG_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} -f ${KUBECONFIG_TEMPLATE} >${KUBECONFIG}
+	local kubeconfig_template_url="$KUBECONFIG_TEMPLATE"
+	[[ $kubeconfig_template_url =~ ^https?:// ]] || kubeconfig_template_url="file://$(realpath "$kubeconfig_template_url")"
+
+	direnv exec ${KUBECONFIG_DIR} gomplate ${GOMPLATE_EXTRA_ARGS} \
+ 		-d "data=${kubeconfig_template_url}?type=text/plain" -i '{{ (ds "data") | tpl}}' >${KUBECONFIG}
 }
 
 ensure_env_vars


### PR DESCRIPTION
## what
- [build-kops-manifest] Support using remote templates for kops manifest 
- [build-kubecfg] Support using remote templates for kubecfg 
## why
Move templates to cloudposse/reference-architectures. (Templates left in Geodesic for backwards compatibility and transitional support.)