### PR TITLE
[Dockerfile] Bump google cloud-sdk to 241, fix packages Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ RUN pip install -r /requirements.txt --install-option="--prefix=/dist" --no-buil
 #
 # Google Cloud SDK
 #
-FROM google/cloud-sdk:239.0.0-alpine as google-cloud-sdk
+FROM google/cloud-sdk:241.0.0-alpine as google-cloud-sdk
 
 #
 # Cloud Posse Package Distribution
 #
-FROM cloudposse/packages:0.81.0 as packages
+FROM cloudposse/packages:0.82.0 as packages
 
 WORKDIR /packages
 
@@ -48,7 +48,7 @@ USER root
 
 # Install the cloudposse alpine repository
 ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-RUN echo "@cloudposse https://apk.cloudposse.com/3.8/vendor" >> /etc/apk/repositories
+RUN echo "@cloudposse https://apk.cloudposse.com/3.9/vendor" >> /etc/apk/repositories
 
 # Use TLS for alpine default repos
 RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories && \


### PR DESCRIPTION
## what
- Update packages alpine version from 3.8 to 3.9
- bump cloudposse/packages from 0.81.0 to 0.82.0. Closes #433 
- bump google/cloud-sdk from 239.0.0-alpine to 241.0.0-alpine. Closes #437 
## why
- Maintain consistency between package and Dockerfile Alpine versions
- Track latest google/cloud-sdk