### PR TITLE
Fix stty error for non-interactive sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,9 @@ ENV SHELL=/bin/bash
 ENV LESS=R
 ENV SSH_AGENT_CONFIG=/var/tmp/.ssh-agent
 
+# Set a default terminal to "dumb" (headless) to make `tput` happy
+ENV TERM=dumb
+
 # Reduce `make` verbosity
 ENV MAKEFLAGS="--no-print-directory"
 ENV MAKE_INCLUDES="Makefile Makefile.*"

--- a/rootfs/etc/profile.d/iterm.sh
+++ b/rootfs/etc/profile.d/iterm.sh
@@ -1,5 +1,7 @@
+# A badge is a large text label that appears in the top right of a terminal session to provide dynamic status
 set_badge() {
 	if [ "${TERM_PROGRAM}" == "iTerm.app" ]; then
+		# https://www.iterm2.com/documentation-badges.html
 		printf "\e]1337;SetBadgeFormat=%s\a" $(echo "$1" | base64)
 	fi
 }
@@ -11,6 +13,9 @@ function _exit() {
 	echo 'Goodbye'
 	exit $status
 }
-trap _exit EXIT
 
-set_badge "${SHELL_NAME}"
+# Friendly exit greeting for interactive terminals
+if [ -t 1 ]; then
+	trap _exit EXIT
+	set_badge "${SHELL_NAME}"
+fi

--- a/rootfs/etc/profile.d/stty.sh
+++ b/rootfs/etc/profile.d/stty.sh
@@ -5,4 +5,4 @@
 # Mapping a different key to stop terminal output is one possibility, but most of the control keys are already
 # mapped to something somewhere, so instead we just turn off the flow control altogether.
 
-stty -ixon
+[ -t 1 ] && stty -ixon


### PR DESCRIPTION
## what
* Fix error `stty: 'standard input': Not a tty` caused by calling `stty` when no tty attached
* Fix error `tput: No value for $TERM and no -T specified`

## why
* Running `geodesic` based containers in CI/CD contexts (e.g. codefresh) often means there won't be a tty attached

>  The terminal type "dumb" may be needed when an application program can't figure out what type of terminal you are using. 