### PR TITLE
[direnv/codefresh] add initializer

### DIFF
--- a/rootfs/etc/direnv/codefresh
+++ b/rootfs/etc/direnv/codefresh
@@ -1,0 +1,16 @@
+# This is a `BASH_ENV` script to load `direnv` configuration inside of codefresh pipelines
+# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html
+
+set -e
+
+# Prevent recursion
+unset BASH_ENV
+
+# Disable `direnv` output for scripts
+export DIRENV_LOG_FORMAT=
+
+# Allow current working directory
+direnv allow .
+
+# Process the `.envrc` and map it to `cf_export` commands
+direnv export json  | jq -r '. | to_entries[] | select (.key|test("DIRENV")|not) | "cf_export " + .key + "=" + (.value|tojson)' | bash -e


### PR DESCRIPTION
## what
* Add a script to initialize codefresh environment from direnv (`cf_export`)

## why
* We use `direnv` consistent across multiple platforms
* This allows us to use our `use ...` stdlib helpers in codefresh to facilitate terraform usage