### PR TITLE
[prompt] Enhance shell prompt to indicate presence of chamber secrets

### DIFF
--- a/geodesic_apkindex.md5
+++ b/geodesic_apkindex.md5
@@ -1,0 +1,1 @@
+7b7682ed95935a145df2d4bac8ff88cd

--- a/packages.txt
+++ b/packages.txt
@@ -43,7 +43,7 @@ libltdl
 make
 musl-dev
 ncurses
-oath-toolkit-oathtool@testing
+oath-toolkit-oathtool@community
 openssh-client
 openssl
 pwgen

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -206,7 +206,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 			exit 99
 		fi
 
-		AWS_VAULT_ARGS+=("--debug")
+		[[ ${AWS_VAULT_ARGS[*]} =~ --debug ]] || AWS_VAULT_ARGS+=("--debug")
 		_aws_vault_assume_role "${1:-$(choose_role)}" sleep 7d
 	}
 

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -207,7 +207,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 		fi
 
 		[[ ${AWS_VAULT_ARGS[*]} =~ --debug ]] || AWS_VAULT_ARGS+=("--debug")
-		_aws_vault_assume_role "${1:-$(choose_role)}" sleep 7d
+		_aws_vault_assume_role "${1:-$(choose_role)}" sleep inf
 	}
 
 fi

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -102,22 +102,22 @@ function geodesic_prompt() {
 
 	if [ -n "$ASSUME_ROLE" ]; then
 		STATUS=${ASSUME_ROLE_ACTIVE_MARK}
-	else
-		STATUS=${ASSUME_ROLE_INACTIVE_MARK}
-	fi
-
-	if [ -n "${ASSUME_ROLE}" ]; then
 		ROLE_PROMPT="(${ASSUME_ROLE})"
 	else
+		STATUS=${ASSUME_ROLE_INACTIVE_MARK}
 		ROLE_PROMPT="(none)"
 	fi
+
+	local kops_root=""
+	[[ -n $KOPS_SSH_PRIVATE_KEY ]] && kops_root="+"
+
 
 	PS1="${STATUS}${level_prompt} "
 	PS1+="${ROLE_PROMPT} \W "
 	PS1+=$'${GEODISIC_PROMPT_GLYPHS-$BLACK_RIGHTWARDS_ARROWHEAD}'
 
 	if [ -n "${BANNER}" ]; then
-		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)\n"${PS1}
+		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)${kops_root}\n"${PS1}
 	fi
 	export PS1
 }

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Allow bash to check the window size to keep prompt with relative to window size
 shopt -s checkwinsize
 
@@ -108,15 +108,25 @@ function geodesic_prompt() {
 		ROLE_PROMPT="(none)"
 	fi
 
-	local kops_root=""
-	[[ -n $KOPS_SSH_PRIVATE_KEY ]] && kops_root="+"
+	local secrets_active=""
+	local secrets="${PROMPT_SECRET_ENVS:-GITHUB_TOKEN;KOPS_SSH_PRIVATE_KEY}"
+	for secret_name in $(echo "$secrets" | tr ';' ' '); do
+		if [[ -z $secret_name ]] || ! local -n ref=$secret_name; then
+			echo $(red Error parsing PROMPT_SECRET_ENVS \'"${PROMPT_SECRET_ENVS}"\')
+			break
+		fi
+		if [[ -n $ref ]]; then
+			secrets_active="+"
+			break
+		fi
+	done
 
 	PS1="${STATUS}${level_prompt} "
 	PS1+="${ROLE_PROMPT} \W "
 	PS1+=$'${GEODISIC_PROMPT_GLYPHS-$BLACK_RIGHTWARDS_ARROWHEAD}'
 
 	if [ -n "${BANNER}" ]; then
-		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)${kops_root}\n"${PS1}
+		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)${secrets_active}\n"${PS1}
 	fi
 	export PS1
 }

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -111,7 +111,6 @@ function geodesic_prompt() {
 	local kops_root=""
 	[[ -n $KOPS_SSH_PRIVATE_KEY ]] && kops_root="+"
 
-
 	PS1="${STATUS}${level_prompt} "
 	PS1+="${ROLE_PROMPT} \W "
 	PS1+=$'${GEODISIC_PROMPT_GLYPHS-$BLACK_RIGHTWARDS_ARROWHEAD}'


### PR DESCRIPTION
## what
Enhance shell prompt to indicate the presence of `kops` secrets in your shell environment
```
 ⧉  data 
 √ . (cpco-prod-admin) kops ⨠ make kops/shell 
chamber exec kops -- bash -l
* Assumed role arn:aws:iam::00000000000000:role/OrganizationAccountAccessRole
 ⧉  data +
 √ ⋮ (cpco-prod-admin) kops ⨠ kops export kubecfg 
kops has set your kubectl context to us-west-2.prod.cpco.io
 ⧉  data (us-west-2.prod.cpco.io:default)+
 √ ⋮ (cpco-prod-admin) kops ⨠ exit
logout
 ⧉  data (us-west-2.prod.cpco.io:default)
 √ . (cpcp-prod-admin) kops ⨠ 
```
## why
Provide awareness of whether or not secrets are available to commands you are running

## usage notes
Use in  conjunction with environment altering commands:
```
# Run chamber to put secrets for given sevice(s) in the environment             
function chdo() {
    source <(chamber export -f dotenv "$@" | sed "s/^/export /" | perl -pe s/\\\\n/\\n/g)
}

# Remove secrets chamber put in the environment for given service(s)            
function chundo() {
    source <(chamber export -f dotenv "$@" | cut -f 1 -d= | sed "s/^/unset /")
}

# Import kops secrets into the environment                                      
alias kudo='chdo kops'
# Remove kops secrets from the environment                                      
alias kundo='chundo kops'
```