### PR TITLE
[tsh] Use official tsh environment variables for port, proxy, & ssh login

### DIFF
--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -88,10 +88,10 @@ function sync_clocks() {
 		let diff=$(date '+%s')-$(date -d "${hwclock_time}" '+%s')
 		echo "* Docker clock is ${diff} seconds behind Host clock"
 		if [ $diff -gt 10 ]; then
-			hwclock -w > /dev/null 2>&1 || echo "* $(yellow Failed to set Docker clock from Host clock)"
+			hwclock -w >/dev/null 2>&1 || echo "* $(yellow Failed to set Docker clock from Host clock)"
 		elif [ $diff -lt -10 ]; then
 			# (Only works in privileged mode)
-			hwclock -s > /dev/null 2>&1 || echo "* $(yellow Failed to set Host clock from Docker clock)"
+			hwclock -s >/dev/null 2>&1 || echo "* $(yellow Failed to set Host clock from Docker clock)"
 		fi
 	else
 		echo "* $(yellow Unable to read hardware clock)"

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -76,6 +76,28 @@ function _assume_active_aws_role() {
 	fi
 }
 
+function sync_clocks() {
+	# Use a timeout due to slow clock reads on EC2 (10 seconds).
+	# Fixes: hwclock: select() to /dev/rtc0 to wait for clock tick timed out
+	hwclock_time=$(timeout 1.5 hwclock -r)
+
+	# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift.
+	# Assume whichever clock is behind by more than 10 seconds is wrong, since virtual clocks
+	# almost never gain time.
+	if [ -n "${hwclock_time}" ]; then
+		let diff=$(date '+%s')-$(date -d "${hwclock_time}" '+%s')
+		echo "* Docker clock is ${diff} seconds behind Host clock"
+		if [ $diff -gt 10 ]; then
+			hwclock -w > /dev/null 2>&1 || echo "* $(yellow Failed to set Docker clock from Host clock)"
+		elif [ $diff -lt -10 ]; then
+			# (Only works in privileged mode)
+			hwclock -s > /dev/null 2>&1 || echo "* $(yellow Failed to set Host clock from Docker clock)"
+		fi
+	else
+		echo "* $(yellow Unable to read hardware clock)"
+	fi
+}
+
 if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 	if ! which aws-vault >/dev/null; then
 		echo "aws-vault not installed"
@@ -167,25 +189,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 		fi
 
 		if [ "${DOCKER_TIME_DRIFT_FIX:-true}" == "true" ]; then
-			# Use a timeout due to slow clock reads on EC2 (10 seconds).
-			# Fixes: hwclock: select() to /dev/rtc0 to wait for clock tick timed out
-			hwclock_time=$(timeout 1.5 hwclock -r)
-
-			# Sync the clock in the Docker Virtual Machine to the system's hardware clock to avoid time drift.
-			# Assume whichever clock is behind by more than 10 seconds is wrong, since virtual clocks
-			# almost never gain time.
-			if [ -n "${hwclock_time}" ]; then
-				let diff=$(date '+%s')-$(date -d "${hwclock_time}" '+%s')
-				if [ $diff -gt 10 ]; then
-					hwclock -w >/dev/null 2>&1
-				elif [ $diff -lt -10 ]; then
-					# (Only works in privileged mode)
-					hwclock -s >/dev/null 2>&1
-				fi
-				if [ $? -ne 0 ]; then
-					echo "* $(yellow Failed to sync system time from hardware clock)"
-				fi
-			fi
+			sync_clocks
 		fi
 
 		shift

--- a/rootfs/etc/profile.d/tsh-login.sh
+++ b/rootfs/etc/profile.d/tsh-login.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function tsh-login() {
-	if (( $# == 0 )); then
+	if (($# == 0)); then
 		tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_LOGIN_PROXY:-tele.${DOCKER_IMAGE#*.}} $STAGE
 	else
 		tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_LOGIN_PROXY:-tele.${DOCKER_IMAGE#*.}} $*

--- a/rootfs/etc/profile.d/tsh-login.sh
+++ b/rootfs/etc/profile.d/tsh-login.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-function tsh-login() {
-	if (($# == 0)); then
-		tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_LOGIN_PROXY:-tele.${DOCKER_IMAGE#*.}} $STAGE
-	else
-		tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_LOGIN_PROXY:-tele.${DOCKER_IMAGE#*.}} $*
-	fi
-}

--- a/rootfs/etc/profile.d/tsh-login.sh
+++ b/rootfs/etc/profile.d/tsh-login.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 function tsh-login() {
-	tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_PROXY_DOMAIN_NAME:-tele.${DOCKER_IMAGE#*.}} $*
+	if (( $# == 0 )); then
+		tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_LOGIN_PROXY:-tele.${DOCKER_IMAGE#*.}} $STAGE
+	else
+		tsh login --bind-addr=:${GEODESIC_PORT} --proxy=${TELEPORT_LOGIN_PROXY:-tele.${DOCKER_IMAGE#*.}} $*
+	fi
 }

--- a/rootfs/etc/profile.d/tsh.sh
+++ b/rootfs/etc/profile.d/tsh.sh
@@ -1,0 +1,10 @@
+# Tell `tsh` to use our open port for SAML authentication
+# See https://github.com/gravitational/teleport/blob/92e5bf508121360b9151357817a5ac1ea43ebb17/tool/tsh/tsh.go#L175
+export TELEPORT_LOGIN_BIND_ADDR=":${GEODESIC_PORT}"
+
+# Fill in a default value for TELEPORT_PROXY. Do not change if it is set, even if it is empty.
+export TELEPORT_PROXY="${TELEPORT_PROXY-tele.${DOCKER_IMAGE#*.}}"
+
+# Fill in a default value for TELEPORT_LOGIN, which is the user name part of the ssh destination
+# Do not change if it is set, even if it is empty.
+export TELEPORT_LOGIN="${TELEPORT_LOGIN-admin}"


### PR DESCRIPTION
## what
[tsh-login] Distinguish login proxy name from local cluster name
## why
There are 2 relevant proxy names for trusting clusters and they are used differently