### PR TITLE
[Makefile]  Fix broken "make install", [preferences] Fix search for preferences in base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	@make --no-print-directory docker:build
 
 install:
-	@docker run --rm -e $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG) || (echo "Try: sudo make install"; exit 1)
+	@docker run --rm $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG) || (echo "Try: sudo make install"; exit 1)
 
 run:
 	@geodesic

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -150,7 +150,10 @@ function use() {
 		--publish ${GEODESIC_PORT}:${GEODESIC_PORT}
 		--name "${DOCKER_NAME}"
 		--rm
-		--env GEODESIC_PORT=${GEODESIC_PORT})
+		--env GEODESIC_PORT=${GEODESIC_PORT}
+		--env DOCKER_IMAGE="${DOCKER_IMAGE%:*}"
+		--env DOCKER_NAME="${DOCKER_NAME}"
+		--env DOCKER_TAG="${DOCKER_TAG}")
 
 	trap run_exit_hooks EXIT
 	# the extra curly braces around .ID are because this file goes through go template substitution local before being installed as a shell script


### PR DESCRIPTION
## what
- Fix `make install`
- Pass `DOCKER_IMAGE` into running container via `wrapper` script
## why
- `make install` was broken by #447
- `DOCKER_IMAGE` is use by "preferences" mechanisms to locate image-specific preferences. 