### PR TITLE
Move python requirements to alpine packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 #
 FROM alpine:3.9.2 as python
 
-RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories
+#RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories
+
 RUN apk add python python-dev libffi-dev gcc py-pip py-virtualenv linux-headers musl-dev openssl-dev make
 
 COPY requirements.txt /requirements.txt

--- a/packages.txt
+++ b/packages.txt
@@ -1,6 +1,6 @@
 # Essential alpine packages
 ansible
-awscli
+awscli@testing
 awless@cloudposse
 aws-iam-authenticator@cloudposse
 aws-vault@cloudposse

--- a/packages.txt
+++ b/packages.txt
@@ -1,4 +1,6 @@
 # Essential alpine packages
+ansible
+awscli
 awless@cloudposse
 aws-iam-authenticator@cloudposse
 aws-vault@cloudposse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-ansible==2.7.9
-awscli==1.16.138
-awsebcli==3.15.0
-boto==2.49.0
 crudini==0.9
-Jinja2==2.10.1


### PR DESCRIPTION
## what
* deprecate `awsebcli` 
* install `ansible`, `awscli` from apk
* remove pinning on python packages `boto` and `Jinja2`

## why
* Fix broken travis builds due to python deps timing out
* Speed up docker builds