### PR TITLE
[codefresh/build] Use the normalized branch name

### DIFF
--- a/codefresh/build.yml
+++ b/codefresh/build.yml
@@ -42,7 +42,7 @@ steps:
     image_name: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
     registry: dockerhub
     tags:
-      - "${{CF_BRANCH}}"
+      - "${{CF_BRANCH_TAG_NORMALIZED}}"
     when:
       condition:
         all:


### PR DESCRIPTION
## what
* Use the normalized branch name

## why
* Sometimes branches contain slashes or other bad characters for docker tags