### PR TITLE
Add `rootfs/usr/local/bin/git-credential-github`. Update `rootfs/etc/init.d/atlantis.sh` to use `git-credential-github`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build-harness/
 aws-assumed-role/
 .idea/
+*.iml

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -82,6 +82,12 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 	# Do not export these as Terraform environment variables
 	export TFENV_BLACKLIST="^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SECURITY_TOKEN|AWS_SESSION_TOKEN|ATLANTIS_.*|GITHUB_.*)$"
 
+    # Configure Git credentials for atlantis to allow access to GitHub private repos (see rootfs/usr/local/bin/git-credential-github)
+    # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
+    export GITHUB_USER=${ATLANTIS_GH_USER}
+    export GITHUB_TOKEN=${ATLANTIS_GH_TOKEN}
+    git config --global credential.helper 'github'
+
 	# Use a primitive init handler to catch signals and handle them properly
 	# Use gosu to drop privileges
 	# Use env to setup the shell environment for atlantis

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -86,6 +86,7 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
     # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
     export GITHUB_USER=${ATLANTIS_GH_USER}
     export GITHUB_TOKEN=${ATLANTIS_GH_TOKEN}
+    chmod +x /usr/local/bin/git-credential-github
     git config --global credential.helper 'github'
 
 	# Use a primitive init handler to catch signals and handle them properly

--- a/rootfs/usr/local/bin/git-credential-github
+++ b/rootfs/usr/local/bin/git-credential-github
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
+
+echo protocol=https
+echo host=github.com
+echo username="${GITHUB_USER}"
+echo password="${GITHUB_TOKEN}"


### PR DESCRIPTION
## what
* Add `rootfs/usr/local/bin/git-credential-github`
* Update `rootfs/etc/init.d/atlantis.sh` to use `git-credential-github`

## why
* `git-credential-github` is useful for adding GitHub credentials to `git` to allow access to private GitHub repos
* When the `atlantis` server starts, execute `git-credential-github` to configure `git` with `atlantis` user and GitHub token to allow access to private repos

## references
* https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage

