### PR TITLE
Force git to use HTTPS instead of SSH for atlantis

### DIFF
--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -82,11 +82,17 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 	# Do not export these as Terraform environment variables
 	export TFENV_BLACKLIST="^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SECURITY_TOKEN|AWS_SESSION_TOKEN|ATLANTIS_.*|GITHUB_.*)$"
 
-    # Configure Git credentials for atlantis to allow access to GitHub private repos (see rootfs/usr/local/bin/git-credential-github)
-    # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
+    # Configure git credentials for atlantis to allow access to GitHub private repos
     export GITHUB_USER=${ATLANTIS_GH_USER}
     export GITHUB_TOKEN=${ATLANTIS_GH_TOKEN}
     chmod +x /usr/local/bin/git-credential-github
+
+    # Force git to use HTTPS instead of SSH. With HTTPS, git will use the `GITHUB_TOKEN` to authenticate with GitHub (with SSH it won't)
+    # https://ricostacruz.com/til/github-always-ssh
+    git config --global url."https://github".insteadOf git://github
+
+    # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
+    # see rootfs/usr/local/bin/git-credential-github
     git config --global credential.helper 'github'
 
 	# Use a primitive init handler to catch signals and handle them properly

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -87,7 +87,7 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
     export GITHUB_TOKEN=${ATLANTIS_GH_TOKEN}
     chmod +x /usr/local/bin/git-credential-github
 
-    # Force git to use HTTPS instead of SSH. With HTTPS, git will use the `GITHUB_TOKEN` to authenticate with GitHub (with SSH it won't)
+    # Force `git` to use HTTPS instead of SSH. With HTTPS, `git` will use the `GITHUB_TOKEN` to authenticate with GitHub (with SSH it won't)
     # https://ricostacruz.com/til/github-always-ssh
     # https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
     # https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -89,7 +89,9 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 
     # Force git to use HTTPS instead of SSH. With HTTPS, git will use the `GITHUB_TOKEN` to authenticate with GitHub (with SSH it won't)
     # https://ricostacruz.com/til/github-always-ssh
-    git config --global url."https://github".insteadOf git://github
+    # https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
+    # https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a
+    git config --global url."https://github.com/".insteadOf git@github.com:
 
     # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
     # see rootfs/usr/local/bin/git-credential-github

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -91,7 +91,7 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
     # https://ricostacruz.com/til/github-always-ssh
     # https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
     # https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a
-    git config --global url."https://github.com/".insteadOf git@github.com:
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
 
     # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
     # see rootfs/usr/local/bin/git-credential-github


### PR DESCRIPTION
## what
* Force `git` to use HTTPS instead of SSH for `atlantis`

## why
* Even when `git@github.com:` protocol is specified for private GitHub repos, `git` will rewrite the URLs to use HTTPS protocol, for which we can use `GITHUB_TOKEN` (instead of SSH keys) to authenticate with GitHub when accessing private repos from `atlantis`

## references
* https://ricostacruz.com/til/github-always-ssh
