### PR TITLE
Add URL `ssh://git@github.com/` to `git config --global` for `atlantis`

### DIFF
--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -90,7 +90,12 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
     # https://ricostacruz.com/til/github-always-ssh
     # https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
     # https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a
+
+    # The URL "git@github.com:" is used by `git` (e.g. `git clone`)
     gosu ${ATLANTIS_USER} git config --global url."https://github.com/".insteadOf "git@github.com:"
+    # The URL "ssh://git@github.com/" is used by Terraform (e.g. `terraform init --from-module=...`)
+    # NOTE: we use `--add` to append the second URL to the config file
+    gosu ${ATLANTIS_USER} git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" --add
 
     # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
     # see rootfs/usr/local/bin/git-credential-github

--- a/rootfs/etc/init.d/atlantis.sh
+++ b/rootfs/etc/init.d/atlantis.sh
@@ -82,24 +82,24 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
 	# Do not export these as Terraform environment variables
 	export TFENV_BLACKLIST="^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SECURITY_TOKEN|AWS_SESSION_TOKEN|ATLANTIS_.*|GITHUB_.*)$"
 
-    # Configure git credentials for atlantis to allow access to GitHub private repos
-    export GITHUB_USER=${ATLANTIS_GH_USER}
-    export GITHUB_TOKEN=${ATLANTIS_GH_TOKEN}
+	# Configure git credentials for atlantis to allow access to GitHub private repos
+	export GITHUB_USER=${ATLANTIS_GH_USER}
+	export GITHUB_TOKEN=${ATLANTIS_GH_TOKEN}
 
-    # Force `git` to use HTTPS instead of SSH. With HTTPS, `git` will use the `GITHUB_TOKEN` to authenticate with GitHub (with SSH it won't)
-    # https://ricostacruz.com/til/github-always-ssh
-    # https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
-    # https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a
+	# Force `git` to use HTTPS instead of SSH. With HTTPS, `git` will use the `GITHUB_TOKEN` to authenticate with GitHub (with SSH it won't)
+	# https://ricostacruz.com/til/github-always-ssh
+	# https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
+	# https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a
 
-    # The URL "git@github.com:" is used by `git` (e.g. `git clone`)
-    gosu ${ATLANTIS_USER} git config --global url."https://github.com/".insteadOf "git@github.com:"
-    # The URL "ssh://git@github.com/" is used by Terraform (e.g. `terraform init --from-module=...`)
-    # NOTE: we use `--add` to append the second URL to the config file
-    gosu ${ATLANTIS_USER} git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" --add
+	# The URL "git@github.com:" is used by `git` (e.g. `git clone`)
+	gosu ${ATLANTIS_USER} git config --global url."https://github.com/".insteadOf "git@github.com:"
+	# The URL "ssh://git@github.com/" is used by Terraform (e.g. `terraform init --from-module=...`)
+	# NOTE: we use `--add` to append the second URL to the config file
+	gosu ${ATLANTIS_USER} git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" --add
 
-    # https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
-    # see rootfs/usr/local/bin/git-credential-github
-    gosu ${ATLANTIS_USER} git config --global credential.helper 'github'
+	# https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
+	# see rootfs/usr/local/bin/git-credential-github
+	gosu ${ATLANTIS_USER} git config --global credential.helper 'github'
 
 	# Use a primitive init handler to catch signals and handle them properly
 	# Use gosu to drop privileges


### PR DESCRIPTION
## what
* Add URL `ssh://git@github.com/` to `git config --global` for `atlantis`

## why
* The URL "git@github.com:" is used by `git` (e.g. `git clone`)
* The URL "ssh://git@github.com/" is used by Terraform (e.g. `terraform init --from-module=...`)
* We need both
