### PR TITLE
[helm] Pin helm to 2.14.0

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -28,7 +28,7 @@ gomplate@cloudposse
 goofys@cloudposse
 gosu@cloudposse
 groff
-helm@cloudposse
+helm@cloudposse==2.14.0
 helmfile@cloudposse
 iputils
 jq

--- a/packages.txt
+++ b/packages.txt
@@ -28,7 +28,7 @@ gomplate@cloudposse
 goofys@cloudposse
 gosu@cloudposse
 groff
-helm@cloudposse==2.14.0
+helm@cloudposse==2.14.0-r0
 helmfile@cloudposse
 iputils
 jq


### PR DESCRIPTION
## What
* Pin helm version to `2.14.0`

## Why
* To be consistent about the packages version
