### PR TITLE
Direnv with Terraform 0.12 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV KOPS_CLUSTER_NAME=example.foo.bar
 USER root
 
 # install the cloudposse alpine repository
-add https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-run echo "@cloudposse https://apk.cloudposse.com/3.9/vendor" >> /etc/apk/repositories
+ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
+RUN echo "@cloudposse https://apk.cloudposse.com/3.10/vendor" >> /etc/apk/repositories
 
 # Use TLS for alpine default repos
 RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN make dist
 #
 # Geodesic base image
 #
-FROM alpine:3.9.3
+FROM alpine:3.10.0
 
 ENV BANNER "geodesic"
 
@@ -46,9 +46,9 @@ ENV KOPS_CLUSTER_NAME=example.foo.bar
 # Install all packages as root
 USER root
 
-# Install the cloudposse alpine repository
-ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-RUN echo "@cloudposse https://apk.cloudposse.com/3.9/vendor" >> /etc/apk/repositories
+# install the cloudposse alpine repository
+add https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
+run echo "@cloudposse https://apk.cloudposse.com/3.9/vendor" >> /etc/apk/repositories
 
 # Use TLS for alpine default repos
 RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories && \

--- a/packages.txt
+++ b/packages.txt
@@ -66,8 +66,8 @@ teleport@cloudposse
 terraform@cloudposse
 terragrunt@cloudposse
 terrahelp@cloudposse
-tfenv@cloudposse==0.3.0-r0
-tfmask@cloudposse==0.2.0-r0
+tfenv@cloudposse
+tfmask@cloudposse
 unzip
 util-linux
 variant@cloudposse

--- a/rootfs/etc/direnv/rc.d/terraform
+++ b/rootfs/etc/direnv/rc.d/terraform
@@ -42,13 +42,11 @@ function use_terraform() {
 	fi
 	
 	# Translate environment variables to terraform arguments
-	# Note: Setting TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT to "true" does not work due to quirks:
-	#   https://github.com/cloudposse/tfenv/issues/10
-	# Set to 1 to enable.
+	# Set to `true` to enable.
 	if [[ $TF_BUCKET_ENCRYPT == false ]]; then
 		export TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT=false
 	else
-		export TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT=1
+		export TF_CLI_INIT_BACKEND_CONFIG_ENCRYPT=true
 	fi
 
 	[ -z "${TF_FROM_MODULE}" ] || export TF_CLI_INIT_FROM_MODULE="${TF_FROM_MODULE}"
@@ -58,4 +56,14 @@ function use_terraform() {
 	[ -z "${TF_DYNAMODB_TABLE}" ] || export TF_CLI_INIT_BACKEND_CONFIG_DYNAMODB_TABLE="${TF_DYNAMODB_TABLE}"
 	[ -z "${AWS_PROFILE}" ] || export TF_CLI_INIT_BACKEND_CONFIG_PROFILE="${AWS_PROFILE}"
 	[ -z "${AWS_ROLE_ARN}" ] || export TF_CLI_INIT_BACKEND_CONFIG_ROLE_ARN="${AWS_ROLE_ARN}"
+
+	# Starting with Terraform 0.12, you can no longer initialize a directory that contains any files (not even dot files)
+	# To mitigate this, define the `TF_MODULE_CACHE` variable with an empty directory.
+	# This directory will be used for `terraform init -from-module=...`, `terraform plan`, `terraform apply`, and `terraform destroy`
+	if [ -n "${TF_MODULE_CACHE}" ]; then
+		export TF_CLI_PLAN="${TF_MODULE_CACHE}"
+		export TF_CLI_APPLY="${TF_MODULE_CACHE}"
+		export TF_CLI_INIT="${TF_MODULE_CACHE}"
+		export TF_CLI_DESTROY="${TF_MODULE_CACHE}"
+	fi
 }


### PR DESCRIPTION
## what
* Use an empty cache folder to initialize module

## why
* Terraform 0.12 no longer allows initialization of folders with even dot files =(
* Example of how to use direnv with terraform 0.12

## usage

```
export TF_MODULE_CACHE=.module
mkdir -p ${TF_MODULE_CACHE}
```
