### PR TITLE
Add destroy-namespace command

### DIFF
--- a/rootfs/etc/profile.d/_geodesic-config.sh
+++ b/rootfs/etc/profile.d/_geodesic-config.sh
@@ -82,7 +82,7 @@ function _expand_dir_or_file() {
 
 	for item in "${dir}/$resource" "${dir}/${resource}.d"/*; do
 		if [[ -f $item ]]; then
-			[[ $item =~ $exclude ]] && continue
+			[[ $item =~ $exclude ]] && ([[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: excluding "$item" || true) && continue
 			expand_list+=($item)
 			[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: found "$item"
 		fi

--- a/rootfs/usr/local/bin/annotate-namespace
+++ b/rootfs/usr/local/bin/annotate-namespace
@@ -9,7 +9,7 @@ if ((${#@} != 2)); then
 	exit 1
 fi
 
-kubectl get namespace "$1" || kubectl create namespace "$1"
+kubectl get namespace "$1" >/dev/null 2>&1 || kubectl create namespace "$1"
 kubectl annotate --overwrite namespace "$1" "$2"
 
 echo Annotated namespace "$1" with annotation \""$2"\"

--- a/rootfs/usr/local/bin/destroy-namespace
+++ b/rootfs/usr/local/bin/destroy-namespace
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if ((${#@} != 1)); then
+    echo Deletes a Kubernetes namespace and everything in it or managed by it,
+	echo first using helm to delete the things it can delete.
+	echo
+	echo Usage:
+	echo '   destroy-namespace namespace'
+	echo
+	exit 1
+fi
+
+helm list --namespace "${1}" --short --all | xargs -r helm delete --purge
+kubectl delete namespace "${1}" --ignore-not-found --cascade=true

--- a/rootfs/usr/local/bin/destroy-namespace
+++ b/rootfs/usr/local/bin/destroy-namespace
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if ((${#@} != 1)); then
-    echo Deletes a Kubernetes namespace and everything in it or managed by it,
+	echo Deletes a Kubernetes namespace and everything in it or managed by it,
 	echo first using helm to delete the things it can delete.
 	echo
 	echo Usage:

--- a/rootfs/usr/local/bin/helmctl
+++ b/rootfs/usr/local/bin/helmctl
@@ -57,3 +57,25 @@ tasks:
           kubectl -n {{ get "namespace" }} delete deployment tiller-deploy
           kubectl delete clusterrolebinding tiller --ignore-not-found
           kubectl -n {{ get "namespace" }} delete serviceaccount tiller --ignore-not-found
+  namespace:
+    # namespace is a work in progress. For now, use /usr/local/bin/annotate-namespace and destroy-namespace instead
+    description: "Commands that operate on a Kubernetes namespace"
+    tasks:
+      annotate:
+        description: "Annotate a Kubernetes namespace, creating it if needed"
+        parameters:
+          - name: namespace
+            description: "Namespace to annotate"
+            type: string
+            required: true
+          - name: annotation
+            description: "Annotation to add"
+            type: string
+            required: true
+        script:
+        - *exit_on_errors
+        - |
+          kubectl get namespace {{ get "namespace" }} >/dev/null 2>&1 || kubectl create namespace {{ get "namespace" }}
+          kubectl annotate --overwrite namespace {{ get "namespace" }} {{ get "annotation" }}
+          echo Annotated namespace {{ get "namespace" }} with annotation \"{{ get "annotation" }}\"
+


### PR DESCRIPTION
## what 
1. Add `destroy-namespace` command
1. Enhance customization trace to show excluded files as well as included files
1. Add `namespace annotate` to `helmctl` (_alpha quality_)
## why
1. Support CI/CD cleanup of resources no longer needed
1. Provide visibility as to why even though some files in a directory are being loaded, others are not
1. Consolidate functions into fewer files/commands