### PR TITLE
Tool and Alpine Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Python Dependencies
 #
-FROM alpine:3.10.0 as python
+FROM alpine:3.10.1 as python
 
 RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories
 RUN apk add python python-dev libffi-dev gcc py-pip py-virtualenv linux-headers musl-dev openssl-dev make
@@ -13,12 +13,12 @@ RUN pip install -r /requirements.txt --install-option="--prefix=/dist" --no-buil
 #
 # Google Cloud SDK
 #
-FROM google/cloud-sdk:244.0.0-alpine as google-cloud-sdk
+FROM google/cloud-sdk:257.0.0-alpine as google-cloud-sdk
 
 #
 # Cloud Posse Package Distribution
 #
-FROM cloudposse/packages:0.90.0 as packages
+FROM cloudposse/packages:0.116.0 as packages
 
 WORKDIR /packages
 
@@ -35,7 +35,7 @@ RUN make dist
 #
 # Geodesic base image
 #
-FROM alpine:3.10.0
+FROM alpine:3.10.1
 
 ENV BANNER "geodesic"
 

--- a/codefresh/release.yml
+++ b/codefresh/release.yml
@@ -30,3 +30,16 @@ steps:
       condition:
         all:
           executeForTag: "'${{CF_RELEASE_TAG}}' != ''"
+
+  push_image_tag_latest:
+    title: Push image with latest TAG
+    type: push
+    stage: Promote
+    candidate: "${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}:${{CF_REVISION}}"
+    image_name: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
+    registry: dockerhub
+    tag: latest
+    when:
+      condition:
+        all:
+          executeForTag: "'${{CF_RELEASE_TAG}}' != ''"

--- a/codefresh/release.yml
+++ b/codefresh/release.yml
@@ -30,6 +30,8 @@ steps:
       condition:
         all:
           executeForTag: "'${{CF_RELEASE_TAG}}' != ''"
+          tag_set: 'includes("${{CF_RELEASE_TAG}}", "CF_RELEASE_TAG") == false'
+
 
   push_image_tag_latest:
     title: Push image with latest TAG
@@ -43,3 +45,4 @@ steps:
       condition:
         all:
           executeForTag: "'${{CF_RELEASE_TAG}}' != ''"
+          tag_set: 'includes("${{CF_RELEASE_TAG}}", "CF_RELEASE_TAG") == false'

--- a/geodesic_apkindex.md5
+++ b/geodesic_apkindex.md5
@@ -1,1 +1,1 @@
-74bf5807e10f643f90de8c0cd56f451a
+fa09cb4694d8cbdf168ffd7abd66b6ec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible==2.7.10
-awscli==1.16.152
-awsebcli==3.15.0
+ansible==2.7.12
+awscli==1.16.209
+awsebcli==3.15.3
 boto==2.49.0
 crudini==0.9
 Jinja2==2.10.1


### PR DESCRIPTION
## what
- Update "latest" tag upon release
- Multiple updates, including updating `cloudposse/packages` from 0.90.0 to 0.116.0

## why
- Ensure "latest" tag tracks latest release
- Bring in current tools
- closes #496
- closes #502 
- closes #504 
- closes #506 
- closes #507 
- closes #509 Security issue
