### PR TITLE
TF_BUCKET_PREFIX: Lowest /conf dir, not highest

### DIFF
--- a/rootfs/etc/direnv/rc.d/terraform
+++ b/rootfs/etc/direnv/rc.d/terraform
@@ -32,7 +32,7 @@ function use_terraform() {
 		pwd|*)
 			# Use full directory path after /conf
 			# (default)
-			export TF_BUCKET_PREFIX=${TF_BUCKET_PREFIX:-${PWD#*/conf/}}
+			export TF_BUCKET_PREFIX=${TF_BUCKET_PREFIX:-${PWD##*/conf/}}
 			;;
 	esac
 	


### PR DESCRIPTION
## what
[direnv] Better detection of TF_BUCKET_PREFIX, use lowest level `/conf` dir, not highest

## why
Atlantis operates under `/conf/atlantis/...`