### PR TITLE
Create tools for mananging Codefresh pipelines

### DIFF
--- a/docs/codefresh-pipeline.md
+++ b/docs/codefresh-pipeline.md
@@ -1,0 +1,119 @@
+## Operating on Codefresh Pipelines via Command Line Tools
+
+This Readme describes how to operate on Codefresh Pipelines using 
+command line tools. Familiarity with Codefresh Pipelines is assumed.
+
+Prerequisites:
+- You must have an account with `admin` access on Codefresh
+- You must have created a project on Codefresh
+
+You will also need to have an API key, which you can create as
+explained [below](#setting-up-api-key).
+
+### Pipeline Spec Files
+
+Pipelines can be defined by "pipeline spec files", which are YAML files
+containing [pipeline specs](https://codefresh-io.github.io/cli/pipelines/spec/).
+Note, however, that the documentation is likely out of date (by Codefresh's
+own admission) and the best reference for the current pipeline spec is
+what is downloaded by `codefresh get pipeline`.
+
+This Readme uses YAML-format pipeline specs stored in files with `.yaml`
+extensions. It is possible to use other formats, such as JSON, but that
+is beyond our scope.
+
+### Setting up an API key
+
+To interact with Codefresh remotely, you need an API key. You can get one from
+the Codefresh web UI under [User Settings](https://g.codefresh.io/user/settings).
+
+There are different ways to install and use it, as explained via
+`codefresh auth help`. Probably the most secure way is to store
+the key in a password manager like 1Password or in `chamber` and 
+set the environment variable `CF_API_KEY` with it as needed.
+
+
+### Pipeline and Trigger secrets
+
+Codefresh allows you to set "secrets" at the Pipeline and Trigger level. 
+Secrets are encrypted and not displayed. However, if you are defining your
+pipelines and their associated triggers using files that will be checked
+into Git, you should not use pipeline or trigger secrets, because you risk
+either deleting them during an update or exposing them by checking them
+into Git by mistake. 
+
+You can, instead, use Project secrets, which are available to the pipelines
+by default, or you can import secrets via [Shared Configurations](https://g.codefresh.io/account-admin/account-conf/shared-config)
+defined under Account Settings. Simply add the name of the Shared Configuration
+to the `spec.contexts` array of the pipeline.
+
+### Downloading Codefresh Pipelines
+
+##### **Using `codefresh` CLI tool**
+
+You can download pipeline specs from Codefresh using the [Codefresh CLI](https://codefresh-io.github.io/cli/pipelines/)
+```
+codefresh get pipelines -o yaml [id..]
+```
+where `id` is a pipeline name or ID string. Generally you will use a full
+pipeline name, which is of the form `project/pipeline`. So for the `build`
+pipeline in the `Geodesic` project, the pipeline name should be 
+`Geodesic/build`. It will display on the web UI as the "build" pipeline under
+the "Geodesic" project
+
+##### **Using `codefresh-pipeline` CLI tool**
+
+The `codefresh-pipeline` tool in Geodesic provides some helpful enhancements 
+to the Codefresh CLI tool. 
+
+The primary enhancement is that `codefresh-pipeline` automatically removes
+any read-only parameters from downloaded pipeline specs so that the resulting
+pipeline file can easily be used as the basis for future uploads, and 
+so that comparisons between installed and proposed pipelines do not show
+meaningless (to developers) changes.
+
+By default, `codefresh-pipeline` saves downloaded pipelines in YAML files with
+`.pip` extensions ("pip" is Codefresh's abbreviation for "pipeline"). 
+Downloaded files are given ".pip" extensions so as not to accidentally overwrite 
+definition files for uploading, which should have `.yaml` extensions. 
+
+See the `codefresh-pipeline` usage (available by executing `codefresh-pipeline`
+with no arguments) for the best documentation. 
+
+### Uploading Codefresh Pipelines
+
+Use the `codefresh` CLI tool to create or modify pipelines from a pipeline
+spec, which should be in a file with a `.yml` or `yaml` filename extension.
+
+Codefresh enforces a distinction between creating and modifying pipelines.
+- If a pipeline exists, you must use `replace` to modify it.
+    ```
+    codefresh replace -f pipeline.yaml
+    ```
+
+- If a pipeline does not exist, you must use `create` to create it.
+    ```
+    codefresh create -f pipeline.yaml
+    ```
+
+### Comparing Codefresh Pipelines
+
+You can compare the current pipeline spec in use by Codefresh with a local
+spec file, to see if one or the other is out of date and to see what would
+change if you replaced the pipeline in use with the one defined in the 
+spec file. 
+
+```text
+codefresh-pipeline compare pipeline.yaml
+```
+
+If there are no changes, the tool will output
+```text
+* No changes
+```
+
+If there are changes, the existing and proposed pipeline specs will be
+displayed side-by-side, with change indicators between the two sides.
+Sometimes the changes can be hard to see in the side-by-side output. Look
+for the `<`, `>`, and `|` characters in between the two sides, and if that
+does not work, try piping the output through `grep '[<>|]'`

--- a/rootfs/usr/local/bin/codefresh-pipeline
+++ b/rootfs/usr/local/bin/codefresh-pipeline
@@ -56,10 +56,10 @@ function download_pipelines() {
 	local arg1="$1"
 	local subdirs="true"
 
-  if [[ -n "$arg1" ]] && [[ ! "$arg" =~ / ]]; then
-    arg1=(--project "$1")
-    subdirs="false"
-  fi
+	if [[ -n "$arg1" ]] && [[ ! "$arg" =~ / ]]; then
+		arg1=(--project "$1")
+		subdirs="false"
+	fi
 
 	while IFS= read -r line; do
 		files+=("${tmpdir}/${count}.json")
@@ -89,7 +89,7 @@ function convert_to_yaml() {
 			yq r "$1" >"$2"
 		fi
 	else
-    local subdirs="$3"
+		local subdirs="$3"
 		local pipeline=$(jq -rc '.metadata.name' <"$1")
 		# You could get project from jq .metadata.project, but we care more about the name embeded in the pipeline name
 		local project=$(dirname $pipeline)
@@ -100,9 +100,9 @@ function convert_to_yaml() {
 
 		local target="${pipeline##*/}.pip"
 		if [[ "$subdirs" == "true" ]]; then
-		  [[ -d "$project" ]] || mkdir -p "$project"
-		  target="${project}/${target}"
-    fi
+			[[ -d "$project" ]] || mkdir -p "$project"
+			target="${project}/${target}"
+		fi
 		yq r "$1" >"$target"
 		green "* Wrote  ${target}"
 	fi
@@ -116,18 +116,18 @@ function filter_pipeline() {
 }
 
 function compare_pipeline() {
-  # Check that the pipeline file exists and is parseable
-  local status
-  yq r "$1" >/dev/null 2>&1
-  status=$?
+	# Check that the pipeline file exists and is parseable
+	local status
+	yq r "$1" >/dev/null 2>&1
+	status=$?
 
-  if (( $status == 1 )); then
-    red "! File "$1" not found"
-    return 1
-  elif (( $status == 2 )); then
-    red "! File "$1" appears to not be a YAML file"
-    return 2
-  fi
+	if (($status == 1)); then
+		red "! File "$1" not found"
+		return 1
+	elif (($status == 2)); then
+		red "! File "$1" appears to not be a YAML file"
+		return 2
+	fi
 
 	local name
 	name=$(yq r -j "$1" | jq -r .metadata.name) || {

--- a/rootfs/usr/local/bin/codefresh-pipeline
+++ b/rootfs/usr/local/bin/codefresh-pipeline
@@ -1,0 +1,190 @@
+#!/bin/bash
+#  ## Download Codefresh pipelines from Codefresh and save to YAML files.
+
+function _usage() {
+	cat <<EOF
+$(basename $0): Download pipelines specs from Codefresh, removing read-only fields
+
+Usage:
+  $(basename $0) download
+  $(basename $0) download <project-name>
+  $(basename $0) download <pipeline-name> [<output-file>]
+
+  $(basename $0) compare <pipeline-spec-file>
+
+Downlaod:
+  With no parameters, all pipelines will be downloaded and written to files
+  named based on the pipeline name. For example, a pipeline named "foo/bar"
+  will be written to a YAML file named "bar.pip" in directory "./foo".
+
+  With 1 parameter:
+  * If the parameter does not contain a / (slash), it is taken as a
+    project name and all the pipelines for that project will be downloaded
+    into the current directory.
+  * If the parameter contains a / (slash), it is taken as a
+    pipeline name and only the named pipeline will be downloaded.
+  In both cases, files will be named after the name of the pipeline, using
+  the part of the name after the slash, and will be given a ".pip" extension
+
+  With 2 parameters, the named pipeline will be downloaded and saved in the
+  file with the given name. If <output-file> is - (dash) then the
+  pipeline YAML will be sent to stdout.
+
+Compare:
+  Given a pipeline spec file, show the changes the file would make to the
+  existing pipeline if used to replace it.
+
+  Exits with status 0 if the pipelines are the same, status 1 if different.
+
+Note on Authentication:
+  $(basename $0) requires that Codefresh authentication be already set up.
+  Run "codefresh auth help" for more information.
+
+EOF
+	return 1
+}
+
+function download_pipelines() {
+	local tmpdir=$(mktemp -d)
+	# echo rm -rf $tmpdir
+	trap "rm -rf $tmpdir" RETURN EXIT
+
+	local count=0
+	local limit=1000
+	local files=()
+
+	local arg1="$1"
+	local subdirs="true"
+
+  if [[ -n "$arg1" ]] && [[ ! "$arg" =~ / ]]; then
+    arg1=(--project "$1")
+    subdirs="false"
+  fi
+
+	while IFS= read -r line; do
+		files+=("${tmpdir}/${count}.json")
+		printf "%s" "$line" >"${files[-1]}"
+		((count += 1))
+	done < <(codefresh get pipeline --limit $limit -o json "${arg1[@]}" | filter_pipeline)
+
+	if (($count == 0)); then
+		red "! Failed to find a pipeline" 1>&2
+		exit 1
+	elif (($count > $limit)); then
+		red "! Download created $count pipelines, which is too many. Probably parsed the output incorrectly. Aborting." 1>&2
+		exit 99
+	else
+		green "* Downloaded $count pipelines from Codefresh" 1>&2
+	fi
+	for file in "${files[@]}"; do
+		convert_to_yaml "$file" "$2" $subdirs
+	done
+}
+
+function convert_to_yaml() {
+	if [[ -n "$2" ]]; then
+		if [[ $2 == "-" ]]; then
+			yq r "$1"
+		else
+			yq r "$1" >"$2"
+		fi
+	else
+    local subdirs="$3"
+		local pipeline=$(jq -rc '.metadata.name' <"$1")
+		# You could get project from jq .metadata.project, but we care more about the name embeded in the pipeline name
+		local project=$(dirname $pipeline)
+		if [[ -z "$pipeline" ]] || [[ -z "$project" ]]; then
+			red "* Unable to find project and pipeline name from file $1"
+			reutrn 5
+		fi
+
+		local target="${pipeline##*/}.pip"
+		if [[ "$subdirs" == "true" ]]; then
+		  [[ -d "$project" ]] || mkdir -p "$project"
+		  target="${project}/${target}"
+    fi
+		yq r "$1" >"$target"
+		green "* Wrote  ${target}"
+	fi
+}
+
+function filter_pipeline() {
+	jq -rc 'if (try .metadata catch false) then . else .[]  end |
+    del(.metadata| .projectId, .revision, .accountId, .created_at, .updated_at, .deprecate, .id, .originalYamlString)
+    | del(.spec | .stages, .packId,
+      (.triggers[] | .verified, .lastExecutionDate, .packId, .id, .endpoint, .secret)) | (.spec.steps |= {})'
+}
+
+function compare_pipeline() {
+  # Check that the pipeline file exists and is parseable
+  local status
+  yq r "$1" >/dev/null 2>&1
+  status=$?
+
+  if (( $status == 1 )); then
+    red "! File "$1" not found"
+    return 1
+  elif (( $status == 2 )); then
+    red "! File "$1" appears to not be a YAML file"
+    return 2
+  fi
+
+	local name
+	name=$(yq r -j "$1" | jq -r .metadata.name) || {
+		red "! Cannot find pipeline name in $1"
+		return 1
+	}
+	local old=$(mktemp)
+	trap "rm -f $old" RETURN EXIT
+
+	if (
+		set -o pipefail
+		codefresh get pipeline --limit 1 -o json "$name" | filter_pipeline | yq r - >"$old"
+	); then
+		yaml-diff "$old" "$1"
+	else
+		red "! Error downloading pipeline $name"
+	fi
+}
+
+function red() {
+	echo "$(tput setaf 1)$*$(tput sgr0)" 1>&2
+}
+
+function green() {
+	echo "$(tput setaf 2)$*$(tput sgr0)" 1>&2
+}
+
+# Keep us from exiting the shell if this file is sourced by using return instead of exit
+function _main() {
+	case "$1" in
+	d | down | download)
+		if (($# < 2 || $# > 3)); then
+			_usage
+		else
+			shift
+			download_pipelines "$@"
+		fi
+		;;
+	c | comp | compare)
+		if (($# != 2)); then
+			_usage
+		else
+			shift
+			compare_pipeline "$@"
+		fi
+		;;
+	*)
+		_usage
+		;;
+	esac
+}
+
+if (($# == 0)); then
+	## Allow script to be sourced without complaint
+	if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+		_usage
+	fi
+else
+	_main "$@"
+fi

--- a/rootfs/usr/local/bin/codefresh-pipeline
+++ b/rootfs/usr/local/bin/codefresh-pipeline
@@ -12,7 +12,7 @@ Usage:
 
   $(basename $0) compare <pipeline-spec-file>
 
-Downlaod:
+Download:
   With no parameters, all pipelines will be downloaded and written to files
   named based on the pipeline name. For example, a pipeline named "foo/bar"
   will be written to a YAML file named "bar.pip" in directory "./foo".

--- a/rootfs/usr/local/bin/codefresh-pipeline
+++ b/rootfs/usr/local/bin/codefresh-pipeline
@@ -56,7 +56,7 @@ function download_pipelines() {
 	local arg1="$1"
 	local subdirs="true"
 
-	if [[ -n "$arg1" ]] && [[ ! "$arg" =~ / ]]; then
+	if [[ -n "$arg1" ]] && [[ ! "$arg1" =~ / ]]; then
 		arg1=(--project "$1")
 		subdirs="false"
 	fi
@@ -68,13 +68,13 @@ function download_pipelines() {
 	done < <(codefresh get pipeline --limit $limit -o json "${arg1[@]}" | filter_pipeline)
 
 	if (($count == 0)); then
-		red "! Failed to find a pipeline" 1>&2
+		red "! Failed to find a pipeline"
 		exit 1
 	elif (($count > $limit)); then
-		red "! Download created $count pipelines, which is too many. Probably parsed the output incorrectly. Aborting." 1>&2
+		red "! Download created $count pipelines, which is too many. Probably parsed the output incorrectly. Aborting."
 		exit 99
 	else
-		green "* Downloaded $count pipelines from Codefresh" 1>&2
+		green "* Downloaded $count pipelines from Codefresh"
 	fi
 	for file in "${files[@]}"; do
 		convert_to_yaml "$file" "$2" $subdirs

--- a/rootfs/usr/local/bin/grafana-db
+++ b/rootfs/usr/local/bin/grafana-db
@@ -6,7 +6,7 @@
 #  PROMETHEUS_GRAFANA_ROOT_URL or GRAFANA_ROOT_URL: URL to which '/api/dashboards...' will be appended
 #
 
-function usage() {
+function _usage() {
 	cat <<EOF
 Usage:
   grafana-db <URL, gnetId, or file>
@@ -33,26 +33,6 @@ Example:
 
 EOF
 }
-# Usage:
-#    grafana-db <URL, gnetId, or file>
-#
-#    URL is URL to (raw) ConfigMap or ConfigMapList containing Grafana dashboards as for Prometheus Operator
-#    gnetId is ID (typically a 4 digit number) for the dashaboard on Grafana.com
-#    file is a local file. It must have the .json extension if contains only a JSON dashboard
-#
-# Example:
-#    # Load the CoreOS standard Kubernetes Grafana dashboards
-#    grafana-db https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
-#
-#    # Load the Kubernetes Capacity dashboard with gnetId 5228 from Grafana.com
-#    grafana-db 5228
-#
-#    # Load a dashboard from a local file containing a dashboard in a Grafana ConfigMap
-#    grafana-db dashboard.yaml
-#
-#    # Load a dashboard from a local file downloaded from your local Grafana.
-#    # Note: you may first need to change the "uid" field in the file.
-#    grafana-db dashboard.json
 
 ## DONE
 ## - Allow uploading a local file. Main thing is determining, detecting, and parsing format of file
@@ -70,7 +50,7 @@ EOF
 ##   - Optional suppression of default input specifications
 ## - Allow the ability to upload dashboards to a designated folder
 
-function download() {
+function download_dashboard() {
 	local grafana_com="https://grafana.com/api/dashboards"
 	local tmpdir=$(mktemp -d)
 	trap "rm -rf $tmpdir" RETURN EXIT
@@ -105,12 +85,12 @@ function download() {
 		green "* Downloaded $count dashboards from ${url}" 1>&2
 	fi
 	for file in "${files[@]}"; do
-		upload "$file"
+		upload_dashboard "$file"
 		echo
 	done
 }
 
-function upload() {
+function upload_dashboard() {
 	local host="${GRAFANA_ROOT_URL:-$PROMETHEUS_GRAFANA_ROOT_URL}"
 	local ds_inputs='[
     {
@@ -192,18 +172,30 @@ function green() {
 	echo "$(tput setaf 2)$*$(tput sgr0)"
 }
 
-if [[ -z "$GRAFANA_API_KEY" ]]; then
-	red GRAFANA_API_KEY must be set to a valid API key for accessing Grafana
-	exit 3
-fi
+# Keep us from exiting the shell if this file is sourced by using return instead of exit
+function _main() {
+	if [[ -z "$GRAFANA_API_KEY" ]]; then
+		red GRAFANA_API_KEY must be set to a valid API key for accessing Grafana
+		return 3
+	fi
 
-if [[ -z "${GRAFANA_ROOT_URL:-$PROMETHEUS_GRAFANA_ROOT_URL}" ]]; then
-	red either GRAFANA_ROOT_URL or PROMETHEUS_GRAFANA_ROOT_URL must be set to Grafana hostname
-	exit 3
-fi
+	if [[ -z "${GRAFANA_ROOT_URL:-$PROMETHEUS_GRAFANA_ROOT_URL}" ]]; then
+		red either GRAFANA_ROOT_URL or PROMETHEUS_GRAFANA_ROOT_URL must be set to Grafana hostname
+		return 4
+	fi
 
-if (($# != 1)); then
-	usage
+	if (($# != 1)); then
+		_usage && return 1
+	else
+		download_dashboard "$1"
+	fi
+}
+
+if (($# == 0)); then
+	## Allow script to be sourced without complaint
+	if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+		_usage
+	fi
 else
-	download "$1"
+	_main "$@"
 fi

--- a/rootfs/usr/local/bin/yaml-diff
+++ b/rootfs/usr/local/bin/yaml-diff
@@ -16,8 +16,8 @@ EOF
 }
 
 function yaml-diff() {
-  local old=$(mktemp)
-  local new=$(mktemp)
+	local old=$(mktemp)
+	local new=$(mktemp)
 	trap "rm -rf $old $new" RETURN EXIT
 
 	local sort_array_filter='walk( if type == "array" then sort else . end )'
@@ -26,16 +26,16 @@ function yaml-diff() {
 	# TODO add a switch for this
 	false && filter="$sort_array_filter"
 
-  yq  r -j "$1" | jq -S "$filter" | yq r - > "$old"
-  yq  r -j "$2" | jq -S "$filter" | yq r - > "$new"
+	yq r -j "$1" | jq -S "$filter" | yq r - >"$old"
+	yq r -j "$2" | jq -S "$filter" | yq r - >"$new"
 
-  local color=never
-  [[ -t 1 ]] && color=always
-  if diff -q "$old" "$new" >/dev/null; then
-    green "* No changes"
-  else
-    diff -y --color=$color -W 120 "$old" "$new"
-  fi
+	local color=never
+	[[ -t 1 ]] && color=always
+	if diff -q "$old" "$new" >/dev/null; then
+		green "* No changes"
+	else
+		diff -y --color=$color -W 120 "$old" "$new"
+	fi
 }
 
 function red() {

--- a/rootfs/usr/local/bin/yaml-diff
+++ b/rootfs/usr/local/bin/yaml-diff
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+function _usage() {
+	cat <<EOF
+$(basename $0): Compare 2 YAML file for semantic equivalency
+
+Both files are converted to a canonical format before comparing, so the
+output may not resemble the input even if the files are identical.
+
+Assumes the order of items in an array is semantically important.
+
+Usage:
+  $(basename $0) old.yaml new.yaml
+
+EOF
+}
+
+function yaml-diff() {
+  local old=$(mktemp)
+  local new=$(mktemp)
+	trap "rm -rf $old $new" RETURN EXIT
+
+	local sort_array_filter='walk( if type == "array" then sort else . end )'
+	local filter="."
+
+	# TODO add a switch for this
+	false && filter="$sort_array_filter"
+
+  yq  r -j "$1" | jq -S "$filter" | yq r - > "$old"
+  yq  r -j "$2" | jq -S "$filter" | yq r - > "$new"
+
+  local color=never
+  [[ -t 1 ]] && color=always
+  if diff -q "$old" "$new" >/dev/null; then
+    green "* No changes"
+  else
+    diff -y --color=$color -W 120 "$old" "$new"
+  fi
+}
+
+function red() {
+	echo "$(tput setaf 1)$*$(tput sgr0)" 1>&2
+}
+
+function green() {
+	echo "$(tput setaf 2)$*$(tput sgr0)" 1>&2
+}
+
+function _main() {
+	if (($# != 2)); then
+		_usage && return 1
+	else
+		yaml-diff "$@"
+	fi
+}
+
+if (($# == 0)); then
+	## Allow script to be sourced without complaint
+	if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+		_usage
+	fi
+else
+	_main "$@"
+fi


### PR DESCRIPTION
## what
1. Create `yaml-diff`
1. Create `codefresh-pipeline`

## why
1. YAML files can vary wildly in textual representation but represent the same JSON data. The `yaml-diff` tools allows two YAML file to be compared for meaning, not textual representation.
1. Codefresh has a CLI tool, but pipeline specs exported by it have lots of information that is read-only, so you cannot directly create a pipeline from an exported pipeline spec. The `codefresh-pipeline` tool helps with that and other issues, providing a more friendly tools for downloading and uploading pipelines.