### PR TITLE
[destroy-namespace] Use --purge with helm2 delete but not with helm3

### DIFF
--- a/rootfs/usr/local/bin/destroy-namespace
+++ b/rootfs/usr/local/bin/destroy-namespace
@@ -10,7 +10,6 @@ if ((${#@} != 1)); then
 	exit 1
 fi
 
-
 [[ -n $HELM_BINARY ]] || HELM_BINARY=helm
 
 ${HELM_BINARY} delete --help | grep -q -- --purge && _HELM_USE_PURGE=--purge || unset _HELM_USE_PURGE

--- a/rootfs/usr/local/bin/destroy-namespace
+++ b/rootfs/usr/local/bin/destroy-namespace
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-[[ -n $HELM_BINARY ]] || HELM_BINARY=helm
-
 if ((${#@} != 1)); then
 	echo Deletes a Kubernetes namespace and everything in it or managed by it,
 	echo first using helm to delete the things it can delete.
@@ -12,5 +10,10 @@ if ((${#@} != 1)); then
 	exit 1
 fi
 
-${HELM_BINARY} list --namespace "${1}" --short --all | xargs -r ${HELM_BINARY} delete --purge
+
+[[ -n $HELM_BINARY ]] || HELM_BINARY=helm
+
+${HELM_BINARY} delete --help | grep -q -- --purge && _HELM_USE_PURGE=--purge || unset _HELM_USE_PURGE
+
+${HELM_BINARY} list --namespace "${1}" --short --all | xargs -r ${HELM_BINARY} delete ${_HELM_USE_PURGE}
 kubectl delete namespace "${1}" --ignore-not-found --cascade=true


### PR DESCRIPTION
## what
[destroy-namespace] Use `--purge` with `helm` v2 `delete` but not with `helm` v3

## why
`helm` v2 requires the `--purge` flag, but that flag was removed and the behavior made the default in `helm` v3.