### PR TITLE
Update syslog-ng.conf to current version

### DIFF
--- a/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.19
+@version: 3.22
 
 options {
     use_dns(no);


### PR DESCRIPTION
## what
Update syslog-ng.conf to current version

## why
`syslog-ng` was updated when we updated Alpine to 3.11, but it's config file was not, causing `syslog-ng` to issue warnings on startup. This resolves those warnings. 