### PR TITLE
Remove reference to function removed in PR 368

### DIFF
--- a/rootfs/etc/profile.d/use-profile.sh
+++ b/rootfs/etc/profile.d/use-profile.sh
@@ -1,3 +1,0 @@
-if [ -n "${AWS_PROFILE}" ] && [ -f "${AWS_CONFIG_FILE}" ] && [ -f "${AWS_SHARED_CREDENTIALS_FILE}" ]; then
-	use-profile
-fi


### PR DESCRIPTION
## what
- Remove `use-profile.sh`
## why
- Essentially dead code, as it calls a function removed in #368 and therefore emits an error message if it does anything