### PR TITLE
Tag running Docker container with APP_NAME when set

### DIFF
--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -61,7 +61,7 @@ fi
 # Sometimes docker might not exit cleanly
 docker rm -f "${INSTALLER_NAME}" >/dev/null 2>&1
 
-(docker run --name "${INSTALLER_NAME}" --rm -e DOCKER_IMAGE -e DOCKER_TAG "${DOCKER_IMAGE}:${DOCKER_TAG}" -c wrapper | tee "${INSTALL_PATH}/${APP_NAME}" >${OUTPUT}) &&
+(docker run --name "${INSTALLER_NAME}" --rm -e DOCKER_IMAGE -e DOCKER_TAG -e APP_NAME "${DOCKER_IMAGE}:${DOCKER_TAG}" -c wrapper | tee "${INSTALL_PATH}/${APP_NAME}" >${OUTPUT}) &&
 	chmod 755 "${INSTALL_PATH}/${APP_NAME}"
 
 if [ $? -eq 0 ]; then

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -264,7 +264,7 @@ options_to_env
 # Docker settings
 export DOCKER_IMAGE="{{getenv "DOCKER_IMAGE" "cloudposse/geodesic"}}"
 export DOCKER_TAG="{{getenv "DOCKER_TAG" "${DOCKER_TAG:-dev}"}}"
-export DOCKER_NAME=${DOCKER_NAME:-$(basename $DOCKER_IMAGE)}
+export DOCKER_NAME="{{getenv "APP_NAME" "${DOCKER_NAME:-$(basename $DOCKER_IMAGE)}"}}"
 
 if [ -n "${NAME}" ]; then
 	export DOCKER_NAME=$(basename "${NAME:-}")


### PR DESCRIPTION
## what
- If `APP_NAME` is set when Geodesic is installed, tag the running Docker container with `APP_NAME` instead of the Docker image name

## why
- `APP_NAME` can be set to distinguish different forks of the same image. The distinction needs to be carried over to the container name, otherwise one fork's execution script will attach to the other fork's running container even though the `APP_NAME` is different.