### PR TITLE
[chdo] Use `chamber env` instead of `chamber -f dotenv`

### DIFF
--- a/rootfs/etc/profile.d/aliases.sh
+++ b/rootfs/etc/profile.d/aliases.sh
@@ -19,7 +19,9 @@ _alias_if_new kexp 'kops export kubecfg'
 if _cmd_missing chdo; then
 	# Run chamber to put secrets for given service(s) in the environment
 	function chdo() {
-		source <(chamber export -f dotenv "$@" | sed "s/^/export /" | perl -pe s/\\\\n/\\n/g)
+		for service in "$@"; do
+			source <(chamber env "$service")
+		done
 	}
 	# Import kops secrets into the environment
 	_alias_if_new kudo 'chdo kops'


### PR DESCRIPTION
## what

- In helper function `chdo`, use `chamber env` instead of `chamber -f dotenv`

## why

When `chdo` was written, `chamber` did not have the `env` option to export secrets into the environment, the closest thing it had was `chamber -f dotenv`. However, there are differences in how special characters like exclamation point (!) are handled, causing incorrect exporting of secrets when they had these special characters. `chamber` has since [added the `env` feature](https://github.com/segmentio/chamber/pull/184), and this PR uses that to ensure correct handling of special characters. 

