### PR TITLE
[aws] Enhance detection of AWS_PROFILE changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN python3 -m pip install --upgrade pip setuptools wheel && \
 #
 # Google Cloud SDK
 #
-FROM google/cloud-sdk:294.0.0-alpine as google-cloud-sdk
+FROM google/cloud-sdk:299.0.0-alpine as google-cloud-sdk
 
 #
 # Geodesic base image

--- a/codefresh/build.yml
+++ b/codefresh/build.yml
@@ -24,6 +24,7 @@ steps:
     description: Build geodesic
     image_name: ${{CF_REPO_NAME}}
     dockerfile: Dockerfile
+    disable_push: true
 
   run_tests:
     title: "Run Tests"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 PyYAML==5.3.1
-ansible==2.9.9
-awscli==1.18.69
+ansible==2.9.10
+awscli==1.18.91
 boto==2.49.0
-boto3==1.13.19
+boto3==1.14.14
 # crudini 0.9.3 is required for Python3, but not yet released to pypi
 # install the hard way crudini==0.9.3
 # crudini requires python-iniparse version not yet released to pypi


### PR DESCRIPTION
## what

- Enhance detection of AWS_PROFILE changes to keep prompt updated
- bump awscli from 1.18.69 to 1.18.91, closes #596 
- bump boto3 from 1.13.19 to 1.14.14, closes #597 
- bump ansible from 2.9.9 to 2.9.10, closes #598 
- bump google/cloud-sdk from 294.0.0-alpine to 299.0.0-alpine, closes #599

## why

- Previously some changes to the environment would cause the AWS tools to use a different profile/role without the prompt reflecting the change