### PR TITLE
[prompt] expand search for AWS profile, enhance cluster name shortening

### DIFF
--- a/rootfs/etc/profile.d/geodesic.kube-ps1.sh
+++ b/rootfs/etc/profile.d/geodesic.kube-ps1.sh
@@ -20,10 +20,22 @@ function kube_ps1_helper() {
 	fi
 }
 
-# This shortens the cluster name based on our EKS cluster naming pattern,
-# taking just the characters between the first and second dashes after "cluster/".
+# This shortens the cluster name of EKS clusters.
 # It should not affect other cluster names, so should be safe as default.
+# Users can override it if they want to.
 function short_cluster_name_from_eks() {
-	printf "%s" "$1" | sed -e 's%arn.*:cluster/[^-]\+-\([^-]\+\)-.*$%\1%'
+	# If it is not a cluster ARN, leave it alone
+	if ! [[ $1 =~ ^arn:.*:cluster/ ]]; then
+		printf "%s" "$1"
+		return 0
+	fi
+	local full_name=$(printf "%s" "$1" | cut -d/ -f2)
+	# remove namespace prefix if present
+	full_name=${full_name#${NAMESPACE}-}
+	# remove eks and everything after it, if present
+	full_name=${full_name%-eks-*}
+	printf "%s" "${full_name}"
+	# If NAMESPACE is unset, delete everything before and including the first dash
+	# printf "%s" "$1" | sed -e 's%arn.*:cluster/'"${NAMESPACE:-[^-]\+}"'-\([^-]\+\)-eks-.*$%\1%'
 }
-KUBE_PS1_CLUSTER_FUNCTION=short_cluster_name_from_eks
+[[ -z $KUBE_PS1_CLUSTER_FUNCTION ]] && KUBE_PS1_CLUSTER_FUNCTION=short_cluster_name_from_eks

--- a/rootfs/etc/profile.d/set-cluster.sh
+++ b/rootfs/etc/profile.d/set-cluster.sh
@@ -14,7 +14,7 @@ function _update_cluster_config() {
 	local current_namespace
 	local set_namespace=1
 
-	current_namespace=$(KUBECONFIG="$new_config"kubens -c 2>/dev/null)
+	current_namespace=$(KUBECONFIG="$new_config" kubens -c 2>/dev/null)
 	set_namespace=$?
 	if ! KUBECONFIG="$new_config" kubectl auth can-i -Aq create selfsubjectaccessreviews.authorization.k8s.io >/dev/null 2>&1 </dev/null; then
 		eks-update-kubeconfig "$@"

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -21,7 +21,7 @@ Usage:
 
   With "off", deletes the currently active kubecfg file.
 
-  NOTE: This tool assumes you are using Cloud Posses standard naming conventions:
+  NOTE: This tool assumes you are using Cloud Posse's standard naming conventions:
   * Cluster name "corp" expands to "${NAMESPACE}-corp-eks-cluster"
   * Role name "admin" expands to "${NAMESPACE}-corp-admin"
 


### PR DESCRIPTION
## what

- When trying to convert an AWS role ARN to an AWS profile name, consider the credentials file
- Use heuristics to shorten EKS cluster name

## why

- When using a tool like `saml2aws`, your initial role ARN probably will not be in the AWS config file, but `saml2aws` adds it to the credentials file, so we look there, too
- More flexibility in the shortening algorithm provides better results for unexpected cases

## release note

Geodesic automatically installs a function to shorten the name of the Kubernetes cluster as it appears on the command line prompt. You can install a different function if you do not like the results. Set `KUBE_PS1_CLUSTER_FUNCTION` in your Dockerfile or `~/.geodesic/preferences`. Set `KUBE_PS1_CLUSTER_FUNCTION=echo` to disable shortening. '

## references

- Customizing `kube_ps1`: https://github.com/jonmosco/kube-ps1#customization
- Customizing Geodesic: https://github.com/cloudposse/geodesic/pull/422#issue-263957814