### PR TITLE
[prompt] protect against multiple inclusions of same role ARN

### DIFF
--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -34,7 +34,7 @@ function export_current_aws_role() {
 	# Default values from https://awscli.amazonaws.com/v2/documentation/api/latest/topic/config-vars.html
 	local creds_file="${AWS_SHARED_CREDENTIALS_FILE:-\~/.aws/credentials}"
 	if [[ -r $creds_file ]]; then
-		role_name=$(crudini --get --format=lines "${creds_file}" | grep "$current_role" | cut -d' ' -f 2)
+		role_name=$(crudini --get --format=lines "${creds_file}" | grep "$current_role" | head -1 | cut -d' ' -f 2)
 	fi
 
 	# Assumed roles are normally found in AWS config file, but using the role ARN,
@@ -42,7 +42,7 @@ function export_current_aws_role() {
 	local config_file="${AWS_CONFIG_FILE:-\~/.aws/config}"
 	if [[ -z $role_name ]] && [[ -r $config_file ]]; then
 		local role_arn=$(printf "%s" "$current_role" | sed 's/:sts:/:iam:/g' | sed 's,:assumed-role/,:role/,')
-		role_name=$(crudini --get --format=lines "$config_file" | grep "$role_arn" | cut -d' ' -f 3)
+		role_name=$(crudini --get --format=lines "$config_file" | grep "$role_arn" | head -1 | cut -d' ' -f 3)
 	fi
 
 	if [[ -z $role_name ]]; then


### PR DESCRIPTION
## what
- [prompt] protect against multiple inclusions of same role ARN

## why

- The prompt code scans for the current AWS IAM role (`aws sts get-current-identity`) in various files in order to map it to a friendly profile name. However, prior to this change, if it found it in more than one place, it would cause breakage. This fixes it so it only uses the first value found. 