### PR TITLE
Helm v2 "cache" is actually "data"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,8 +180,7 @@ ENV HELM_HELM_2TO3_VERSION 0.6.0
 
 # Install plugins and then remove cache
 RUN helm2 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \
-    && helm2 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \
-    && rm -rf $HELM_HOME/cache/plugins
+    && helm2 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} 
 
 RUN helm3 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \
     && helm3 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \


### PR DESCRIPTION
## what

- Do not delete Helm v2 plugin cache

## why

- Cache is a misnomer, it is actually the only place Helm v2 plugins are kept