### PR TITLE
Prefix Wrapper Environment Variables with GEODESIC_

### DIFF
--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -267,22 +267,18 @@ export DOCKER_IMAGE="{{getenv "DOCKER_IMAGE" "cloudposse/geodesic"}}"
 export DOCKER_TAG="{{getenv "DOCKER_TAG" "${DOCKER_TAG:-dev}"}}"
 export DOCKER_NAME="{{getenv "APP_NAME" "${DOCKER_NAME:-$(basename $DOCKER_IMAGE)}"}}"
 
-if [ -n "${NAME}" ]; then
-	export DOCKER_NAME=$(basename "${NAME:-}")
+if [ -n "${GEODESIC_NAME}" ]; then
+	export DOCKER_NAME=$(basename "${GEODESIC_NAME:-}")
 fi
 
-if [ -n "${TAG}" ]; then
-	export DOCKER_TAG=${TAG}
+if [ -n "${GEODESIC_TAG}" ]; then
+	export DOCKER_TAG=${GEODESIC_TAG}
 fi
 
-if [ -n "${IMAGE}" ]; then
-	export DOCKER_IMAGE=${IMAGE:-${DOCKER_IMAGE}:${DOCKER_TAG}}
+if [ -n "${GEODESIC_IMAGE}" ]; then
+	export DOCKER_IMAGE=${GEODESIC_IMAGE:-${DOCKER_IMAGE}:${DOCKER_TAG}}
 else
 	export DOCKER_IMAGE=${DOCKER_IMAGE}:${DOCKER_TAG}
-fi
-
-if [ -n "${PORT}" ]; then
-	export GEODESIC_PORT=${PORT}
 fi
 
 export DOCKER_DNS=${DNS:-${DOCKER_DNS}}


### PR DESCRIPTION
## what
* Prefix `NAME`, `IMAGE` and `TAG` with `GEODESIC_`

## why
* In some WSL2 instances at least, `NAME` seems to be a default variable that has the hostname, preventing the isolation of containers by their name as you'd normally expect from geodesic.  This allows situations where you can be running a container for one environment, say prod, and need to pop in to a staging container, but you will instead be added to a new shell in the existing prod variable.
* Namespacing these overly generic variable names will hopefully prevent some of that confusion
* Also, `GEODESIC_PORT` was already defaulted to the environment variable previously in the script, so it had two levels of overrides before.  Now just the one commonly namespaced one.