### PR TITLE
Add iproute2 package for Debian

### DIFF
--- a/os/debian/packages-debian.txt
+++ b/os/debian/packages-debian.txt
@@ -6,6 +6,7 @@ inetutils-ping
 inetutils-telnet
 inetutils-tools
 inetutils-traceroute
+iproute2
 ldnsutils
 # locales end up causing trouble because they change sort order, so best to avoid them
 # locales


### PR DESCRIPTION
## what
- Add iproute2 package for Debian

## why
- Adds `ip` and `nstat`, needed by some other utilities