### PR TITLE
Aws vault

### DIFF
--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -173,9 +173,11 @@ RUN chmod -R a+rwX ${HELM_HOME}
 #
 # Configure host AWS configuration to be available from inside Docker image
 #
-ENV AWS_DATA_PATH=/localhost/.aws
-ENV AWS_CONFIG_FILE=${AWS_DATA_PATH}/config
-ENV AWS_SHARED_CREDENTIALS_FILE=${AWS_DATA_PATH}/credentials
+# AWS_DATA_PATH is a PATH-like variable for configuring the AWS botocore library to
+# load additional modules. Do not set it. ENV AWS_DATA_PATH=/localhost/.aws
+ARG GEODESIC_AWS_HOME=/localhost/.aws
+ENV AWS_CONFIG_FILE=${GEODESIC_AWS_HOME}/config
+ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
 
 #
 # Configure aws-vault to easily assume roles (not related to HashiCorp Vault)

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -193,9 +193,11 @@ RUN chmod -R a+rwX ${HELM_HOME}
 #
 # Configure host AWS configuration to be available from inside Docker image
 #
-ENV AWS_DATA_PATH=/localhost/.aws
-ENV AWS_CONFIG_FILE=${AWS_DATA_PATH}/config
-ENV AWS_SHARED_CREDENTIALS_FILE=${AWS_DATA_PATH}/credentials
+# AWS_DATA_PATH is a PATH-like variable for configuring the AWS botocore library to
+# load additional modules. Do not set it. ENV AWS_DATA_PATH=/localhost/.aws
+ARG GEODESIC_AWS_HOME=/localhost/.aws
+ENV AWS_CONFIG_FILE=${GEODESIC_AWS_HOME}/config
+ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
 
 #
 # Disable aws-vault and okta support by default, enable in child Dockerfile or personal configuration if needed

--- a/rootfs/etc/profile.d/_colors.sh
+++ b/rootfs/etc/profile.d/_colors.sh
@@ -2,17 +2,34 @@
 # This file is named _colors.sh. The leading underscore is needed to ensure this file executes before
 # other files that depend on the functions defined here. This file has no dependencies and should come first.
 function red() {
-	echo "$(tput setaf 1)$*$(tput sgr0)"
+	echo "$(tput setaf 1)$*$(tput setaf 0)"
 }
 
 function green() {
-	echo "$(tput setaf 2)$*$(tput sgr0)"
+	echo "$(tput setaf 2)$*$(tput setaf 0)"
 }
 
 function yellow() {
-	echo "$(tput setaf 3)$*$(tput sgr0)"
+	echo "$(tput setaf 3)$*$(tput setaf 0)"
 }
 
 function cyan() {
-	echo "$(tput setaf 6)$*$(tput sgr0)"
+	echo "$(tput setaf 6)$*$(tput setaf 0)"
+}
+
+# Turning on bold is a standard `tput` attribute, but turning it off is not.
+# However, turning off bold is an ECMA standard (SGR 22), so it is not
+# unreasonable for us to use it. If it causes problems, people can set
+#   export TERM_BOLD_OFF=$(tput sgr0)
+# http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf
+function bold() {
+	local bold=$(tput bold)
+	local boldoff=${TERM_BOLD_OFF:-$'\033[22m'}
+	# If the terminal supports color
+	if [[ -n $bold ]]; then
+		printf "%s%s%s\n" "$bold" "$*" "$boldoff"
+	else
+		# The terminal does not support color
+		printf "%s\n" "$*"
+	fi
 }

--- a/rootfs/etc/profile.d/aws-saml2aws.sh
+++ b/rootfs/etc/profile.d/aws-saml2aws.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ $GEODESIC_TRACE =~ saml ]]; then
+	export _GEODESIC_TRACE_SAML=true
+else
+	unset _GEODESIC_TRACE_SAML
+fi
+
+if [ "${AWS_SAML2AWS_ENABLED}" == "true" ]; then
+	[[ -n $_GEODESIC_TRACE_SAML ]] && echo "trace: Executing aws-saml2aws.sh"
+	if command -v saml2aws >/dev/null; then
+		[[ -n $_GEODESIC_TRACE_SAML ]] && green "trace: saml2aws installed"
+	else
+		[[ -n $_GEODESIC_TRACE_SAML ]] && red "trace: saml2aws not installed"
+		exit 1
+	fi
+
+	ln -sf /localhost/.saml2aws ${HOME}
+fi


### PR DESCRIPTION
## what
- Add support for [saml2aws](https://github.com/Versent/saml2aws)
- Fix improper use of `AWS_DATA_PATH`
- Support aws-vault used in combination with AWS SSO
- Add support for bold terminal output 

## why
- Popular tool for bridging gap between SAML web signon and `aws` CLI use
- We were using `AWS_DATA_PATH` for our own purposes, but it is reserved by the `aws` SDK for use as a `PATH`-like variable giving a list of directories to search for Python extension modules
- Support use of AWS SSO in conjunction with Cloud Posse Reference Architecture "hub-and-spoke" role provisioning
- Add flexibility to display of console messages

## references
- [AWS `botocore` documentation](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/loaders.html#the-search-path)