### PR TITLE
Use release-drafter to draft release notes

### DIFF
--- a/.github/draft-release.yml
+++ b/.github/draft-release.yml
@@ -1,0 +1,61 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+    - 'enhancement'
+  patch:
+    labels:
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
+  default: 'minor'
+
+categories:
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+  - 'shell'
+  - 'scripts'
+  - 'terraform'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Included Tools'
+  labels:
+  - 'auto-update'
+  - 'packages'
+  - 'docker'
+- title: '🤖 Included Tools'
+  labels:
+  - 'auto-update'
+  - 'packages'
+  - 'docker'
+- title '📚️ Documentation'
+  labels:
+  - 'docs'
+- title '🏗️ Build/Release Maintenance'
+  labels:
+  - 'github'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
+    $BODY
+  </details>
+
+template: |
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,19 @@
+name: draft-release
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: false
+        prerelease: false
+        config-name: draft-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/rootfs/etc/profile.d/aws-okta.sh
+++ b/rootfs/etc/profile.d/aws-okta.sh
@@ -20,7 +20,7 @@ if [ "${AWS_OKTA_ENABLED}" == "true" ]; then
 
 	PROMPT_HOOKS+=("aws_okta_prompt")
 	function aws_okta_prompt() {
-		if [ -z "${AWS_OKTA_PROFILE}" ]; then
+		if [[  -z "${AWS_OKTA_PROFILE}" && -z "${ASSUME_ROLE}" ]]; then
 			echo -e "-> Run '$(green assume-role)' to login to AWS with aws-okta"
 		fi
 	}

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -204,7 +204,7 @@ if [ "${AWS_VAULT_ENABLED:-true}" == "true" ]; then
 
 	PROMPT_HOOKS+=("aws_vault_prompt")
 	function aws_vault_prompt() {
-		if [ -z "${AWS_VAULT}" ]; then
+		if [[ -z "${AWS_VAULT}" && -z "${ASSUME_ROLE}" ]]; then
 			echo -e "-> Run '$(green assume-role)' to login to AWS with aws-vault"
 		fi
 	}


### PR DESCRIPTION
## what
- Use release-drafter to automatically generate release notes combining multiple automatic upgrades and manual changes

## why
- More consistent release notes more easily including all automated updates in a single release

## notes
- This does not automatically create a release, just draft the release notes. Releases are still done manually, and release notes and version numbers can be edited before release.