### PR TITLE
[draft-release] Fix broken syntax in config file

### DIFF
--- a/.github/draft-release.yml
+++ b/.github/draft-release.yml
@@ -33,20 +33,15 @@ categories:
   - 'bugfix'
   - 'bug'
   - 'hotfix'
-- title: '🤖 Included Tools'
+- title: '🧰 Included Tools'
   labels:
   - 'auto-update'
   - 'packages'
   - 'docker'
-- title: '🤖 Included Tools'
-  labels:
-  - 'auto-update'
-  - 'packages'
-  - 'docker'
-- title '📚️ Documentation'
+- title: '📚️ Documentation'
   labels:
   - 'docs'
-- title '🏗️ Build/Release Maintenance'
+- title: '🏗️ Build/Release Maintenance'
   labels:
   - 'github'
 


### PR DESCRIPTION
## what
- Fix broken syntax in `draft-release` config file

## why
- Action would not execute because of syntax errors 