### PR TITLE
Create docker image when release is published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, synchronize, reopened]
   release:
     types:
+    # "released" excludes pre-releases
+    # "published" is either a release or a pre-release
     - published
 jobs:
   build-and-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened]
   release:
     types:
-    - created
+    - published
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
         LATEST_TAG_OS: 'alpine'
         BASE_OS: ${{matrix.os}} 
       run: |
-        echo ::set-output name=publish::${{ (github.event_name == 'release' && github.event.action == 'created') || (github.event.pull_request.head.repo.full_name == github.repository) }}
+        echo ::set-output name=publish::${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event.pull_request.head.repo.full_name == github.repository) }}
         COMMIT_SHA="${GITHUB_SHA}"
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
## what
- Create docker image when release is "published"

## why
- We had been creating the image when the release was "created" but we are now creating release drafts, and want to create the image when we finally publish the release. Use "release" type "published" instead of "release" so that images are built for published "pre-release" versions, too. 