### PR TITLE
Limit AWS CLI updates to once a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,14 @@
 {
+  "timezone": "America/Los_Angeles",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "packageNames": ["awscli","boto3"],
+      "groupName": ["AWS CLI packages"],
+      "schedule": ["after 4pm on friday"]
+    }
   ],
   "github-actions": {
     "enabled": false


### PR DESCRIPTION
## what
- Limit `aws` CLI and `boto3` updates to once a week and group them together

## why
- Reduce the noise. In general these are updated several times a week but the updates are not urgent.
- Group them because they are typically released together (since `aws` depends on `boto3`) and `aws` pins `boto3` in such a way that the `boto3` update would break `aws` if `aws` is not updated at the same time.