### PR TITLE
Publish version number, freeze cryptography version, update Google Cloud SDK

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,8 @@ jobs:
           VERSION=pr-${{ github.event.pull_request.number }}
           COMMIT_SHA=${{ github.event.pull_request.head.sha }}
         fi
+        printf "Version resolved to %s\n" "${VERSION}"
+        echo ::set-output name=version::${VERSION}
         TAGS="${{ github.repository }}:sha-${COMMIT_SHA:0:7}-${BASE_OS}"
         if [[ -n $VERSION ]]; then
           TAGS="$TAGS,${{ github.repository }}:${VERSION}-${BASE_OS}"
@@ -68,3 +70,5 @@ jobs:
         push: ${{ steps.prepare.outputs.publish == 'true' }}
         tags: ${{ steps.prepare.outputs.tags }}
         file: ./os/${{matrix.os}}/Dockerfile.${{matrix.os}}
+        build-args: |
+          VERSION=${{ steps.prepare.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export DOCKER_TAG ?= $(DOCKER_BASE_TAG)-$(DOCKER_BASE_OS)
 export DOCKER_IMAGE_NAME_BASE ?= $(DOCKER_IMAGE):$(DOCKER_BASE_TAG)
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_FILE ?= os/$(DOCKER_BASE_OS)/Dockerfile.$(DOCKER_BASE_OS)
-export DOCKER_BUILD_FLAGS =
+export DOCKER_BUILD_FLAGS = --build-arg VERSION=$(shell printf "%s/%s" $$(git describe --tags 2>/dev/null || echo "unk") $$(git branch --no-color --show-current || echo "unk"))
 export INSTALL_PATH ?= /usr/local/bin
 
 include $(shell curl --silent -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,5 +1,6 @@
 ARG ALPINE_VERSION=3.12.1
-ARG GOOGLE_CLOUD_SDK_VERSION=316.0.0
+# https://cloud.google.com/sdk/docs/release-notes
+ARG GOOGLE_CLOUD_SDK_VERSION=328.0.0
 #
 # Python Dependencies
 #
@@ -32,6 +33,9 @@ FROM google/cloud-sdk:$GOOGLE_CLOUD_SDK_VERSION-alpine as google-cloud-sdk
 # Geodesic base image
 #
 FROM alpine:$ALPINE_VERSION
+
+ARG VERSION
+ENV GEODESIC_VERSION=$VERSION
 
 # Set XDG environment variables per https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 # This is not a "multi-user" system, so we'll use special directories under
@@ -71,16 +75,18 @@ RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net
 
 # Install alpine package manifest
 COPY packages.txt os/alpine/packages-alpine.txt /etc/apk/
-# Install repo checksum in an attempt to ensure updates bust the Docker build cache
-COPY os/alpine/geodesic_apkindex.md5 /tmp/geodesic_apkindex.md5
-COPY os/alpine/rootfs/usr/local/bin/geodesic-apkindex-md5 /usr/local/bin/
+# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
+## Install repo checksum in an attempt to ensure updates bust the Docker build cache
+#COPY os/alpine/geodesic_apkindex.md5 /tmp/geodesic_apkindex.md5
+#COPY os/alpine/rootfs/usr/local/bin/geodesic-apkindex-md5 /usr/local/bin/
 
 RUN apk add --update $(grep -h -v '^#' /etc/apk/packages.txt /etc/apk/packages-alpine.txt) && \
     mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
     touch /conf/.gitconfig
 
-RUN ["/bin/bash", "-c", "[[ $(geodesic-apkindex-md5) == $(cat /tmp/geodesic_apkindex.md5) ]] || echo \"WARNING: apk package repos mismatch: '$(geodesic-apkindex-md5)' != '$(cat /tmp/geodesic_apkindex.md5)'\" 1>&2"]
-RUN rm -f /tmp/geodesic-apkindex.md5
+# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
+# RUN ["/bin/bash", "-c", "[[ $(geodesic-apkindex-md5) == $(cat /tmp/geodesic_apkindex.md5) ]] || echo \"WARNING: apk package repos mismatch: '$(geodesic-apkindex-md5)' != '$(cat /tmp/geodesic_apkindex.md5)'\" 1>&2"]
+# UN rm -f /tmp/geodesic-apkindex.md5
 
 RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf
 
@@ -150,7 +156,7 @@ RUN helm2 completion bash > /etc/bash_completion.d/helm2.sh \
 #
 ENV HELM_DIFF_VERSION 3.1.3
 ENV HELM_GIT_VERSION 0.8.1
-ENV HELM_HELM_2TO3_VERSION 0.7.0
+ENV HELM_HELM_2TO3_VERSION 0.8.1
 
 # Install plugins and then remove cache
 RUN helm2 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -75,18 +75,14 @@ RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net
 
 # Install alpine package manifest
 COPY packages.txt os/alpine/packages-alpine.txt /etc/apk/
-# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
-## Install repo checksum in an attempt to ensure updates bust the Docker build cache
-#COPY os/alpine/geodesic_apkindex.md5 /tmp/geodesic_apkindex.md5
-#COPY os/alpine/rootfs/usr/local/bin/geodesic-apkindex-md5 /usr/local/bin/
+
+## Here is where we would copy in the repo checksum in an attempt to ensure updates bust the Docker build cache
 
 RUN apk add --update $(grep -h -v '^#' /etc/apk/packages.txt /etc/apk/packages-alpine.txt) && \
     mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
     touch /conf/.gitconfig
 
-# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
-# RUN ["/bin/bash", "-c", "[[ $(geodesic-apkindex-md5) == $(cat /tmp/geodesic_apkindex.md5) ]] || echo \"WARNING: apk package repos mismatch: '$(geodesic-apkindex-md5)' != '$(cat /tmp/geodesic_apkindex.md5)'\" 1>&2"]
-# UN rm -f /tmp/geodesic-apkindex.md5
+# Here is where we would confirm that the package repo checksum is what we expect (not mismatched due to Docker layer cache)
 
 RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf
 
@@ -120,7 +116,7 @@ RUN { gcloud config set core/disable_usage_reporting true --installation && \
 ENV KUBECONFIG=/conf/.kube/config
 # Install an empty kubeconfig to suppress some warnings
 COPY rootfs/conf/.kube/config /conf/.kube/config
-# Set mode on kubeconfig to suppress some warnings
+# Set mode on kubeconfig to suppress some warnings while installing tools
 RUN chmod 600 $KUBECONFIG
 
 #
@@ -252,6 +248,9 @@ RUN /usr/local/bin/docs update
 # are in fact available to all users
 RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 	chmod -R a+rwX $dir; done
+
+# Set mode on kubeconfig to suppress some warnings (mode was reset by above "COPY rootfs/ /"
+RUN chmod 600 $KUBECONFIG
 
 WORKDIR /conf
 

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -86,10 +86,8 @@ USER root
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 COPY packages.txt os/debian/packages-debian.txt /etc/apt/
-# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
-## Install repo checksum in an attempt to ensure updates bust the Docker build cache
-#COPY os/debian/geodesic_aptindex.md5 /var/cache/apt/
-#COPY os/debian/rootfs/usr/local/bin/geodesic-aptindex-md5 /usr/local/bin/
+
+## Here is where we would copy in the repo checksum in an attempt to ensure updates bust the Docker build cache
 
 # Add CloudPosse package repo
 RUN apt-get update && apt-get install -y apt-utils && apt-get install -y curl
@@ -119,8 +117,7 @@ RUN { gcloud config set core/disable_usage_reporting true --installation && \
       gcloud config set component_manager/disable_update_check true --installation && \
       gcloud config set metrics/environment github_docker_image --installation; } 2>&1
 
-# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
-# RUN ["/bin/bash", "-c", "[[ $(/usr/local/bin/geodesic-aptindex-md5) == $(cat /var/cache/apt/geodesic_aptindex.md5) ]] || echo \"WARNING: apt package repos mismatch: '$(/usr/local/bin/geodesic-aptindex-md5)' != '$(cat /var/cache/apt/geodesic_aptindex.md5)'\" 1>&2"]
+# Here is where we would confirm that the package repo checksum is what we expect (not mismatched due to Docker layer cache)
 
 # Using the en_US.UTF-8 local breaks our login setup because it changes the sort order,
 # and therefore the order of execution, of our profile files. We use locale C.UTF-8 instead,
@@ -143,7 +140,7 @@ COPY --from=python /dist/ /usr/local/
 ENV KUBECONFIG=/conf/.kube/config
 # Install an empty kubeconfig to suppress some warnings
 COPY rootfs/conf/.kube/config /conf/.kube/config
-# Set mode on kubeconfig to suppress some warnings
+# Set mode on kubeconfig to suppress some warnings while installing tools
 RUN chmod 600 $KUBECONFIG
 
 #
@@ -261,6 +258,9 @@ RUN /usr/local/bin/docs update
 # are in fact available to all users
 RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 	chmod -R a+rwX $dir; done
+
+# Set mode on kubeconfig to suppress some warnings (mode was reset by above "COPY rootfs/ /"
+RUN chmod 600 $KUBECONFIG
 
 WORKDIR /conf
 

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -43,6 +43,9 @@ RUN ./configure --enable-optimizations --prefix=/dist && make install
 #
 FROM debian:$DEBIAN_VERSION
 
+ARG VERSION
+ENV GEODESIC_VERSION=$VERSION
+
 # Set a default terminal to "dumb" (headless) to make `tput` happy when running scripts.
 # When we launch Geodesic for interactive use, we forward the host value of `TERM`
 ENV TERM=dumb
@@ -83,9 +86,10 @@ USER root
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 COPY packages.txt os/debian/packages-debian.txt /etc/apt/
-# Install repo checksum in an attempt to ensure updates bust the Docker build cache
-COPY os/debian/geodesic_aptindex.md5 /var/cache/apt/
-COPY os/debian/rootfs/usr/local/bin/geodesic-aptindex-md5 /usr/local/bin/
+# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
+## Install repo checksum in an attempt to ensure updates bust the Docker build cache
+#COPY os/debian/geodesic_aptindex.md5 /var/cache/apt/
+#COPY os/debian/rootfs/usr/local/bin/geodesic-aptindex-md5 /usr/local/bin/
 
 # Add CloudPosse package repo
 RUN apt-get update && apt-get install -y apt-utils && apt-get install -y curl
@@ -103,8 +107,8 @@ RUN apt-get update && apt-get install -y \
 #
 # Install Google Cloud SDK
 # This is separate so that updating it does not invalidate the Docker cache layer with all the packages installed above
-#
-ARG GOOGLE_CLOUD_SDK_VERSION=316.0.0-0
+# https://cloud.google.com/sdk/docs/release-notes
+ARG GOOGLE_CLOUD_SDK_VERSION=328.0.0-0
 ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
 
 RUN apt-get update && apt-get install -y google-cloud-sdk=$GOOGLE_CLOUD_SDK_VERSION
@@ -115,7 +119,8 @@ RUN { gcloud config set core/disable_usage_reporting true --installation && \
       gcloud config set component_manager/disable_update_check true --installation && \
       gcloud config set metrics/environment github_docker_image --installation; } 2>&1
 
-RUN ["/bin/bash", "-c", "[[ $(/usr/local/bin/geodesic-aptindex-md5) == $(cat /var/cache/apt/geodesic_aptindex.md5) ]] || echo \"WARNING: apt package repos mismatch: '$(/usr/local/bin/geodesic-aptindex-md5)' != '$(cat /var/cache/apt/geodesic_aptindex.md5)'\" 1>&2"]
+# Now that we have GEODESIC_VERSION, we should not need to bust the package cache
+# RUN ["/bin/bash", "-c", "[[ $(/usr/local/bin/geodesic-aptindex-md5) == $(cat /var/cache/apt/geodesic_aptindex.md5) ]] || echo \"WARNING: apt package repos mismatch: '$(/usr/local/bin/geodesic-aptindex-md5)' != '$(cat /var/cache/apt/geodesic_aptindex.md5)'\" 1>&2"]
 
 # Using the en_US.UTF-8 local breaks our login setup because it changes the sort order,
 # and therefore the order of execution, of our profile files. We use locale C.UTF-8 instead,
@@ -147,13 +152,15 @@ RUN chmod 600 $KUBECONFIG
 # Set KUBERNETES_VERSION and KOPS_BASE_IMAGE in /conf/kops/kops.envrc
 #
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
+
+# https://github.com/ahmetb/kubectx/releases
 ENV KUBECTX_COMPLETION_VERSION 0.9.1
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubens.bash /etc/bash_completion.d/kubens.sh
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubectx.bash /etc/bash_completion.d/kubectx.sh
 
 #
 # Install fancy Kube PS1 Prompt
-#
+# https://github.com/jonmosco/kube-ps1/releases
 ENV KUBE_PS1_VERSION 0.7.0
 ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/v${KUBE_PS1_VERSION}/kube-ps1.sh /etc/profile.d/prompt:kube-ps1.sh
 
@@ -172,10 +179,13 @@ RUN helm2 completion bash > /etc/bash_completion.d/helm2.sh \
 
 #
 # Install minimal helm plugins
-#
+# https://github.com/databus23/helm-diff/releases
 ENV HELM_DIFF_VERSION 3.1.3
+# https://github.com/aslafy-z/helm-git/releases
+# We had issues with helm-diff + helm-git 0.9.0, so keeping it at 0.8.1
 ENV HELM_GIT_VERSION 0.8.1
-ENV HELM_HELM_2TO3_VERSION 0.7.0
+# https://github.com/helm/helm-2to3/releases
+ENV HELM_HELM_2TO3_VERSION 0.8.1
 
 # Install plugins and then remove cache
 RUN helm2 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \

--- a/os/debian/packages-debian.txt
+++ b/os/debian/packages-debian.txt
@@ -10,6 +10,7 @@ iproute2
 ldnsutils
 # locales end up causing trouble because they change sort order, so best to avoid them
 # locales
+net-tools
 netcat
 oathtool
 procps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # Pin requests because it creates dependency conflicts with urllib3
 requests==2.25.1
+# Pin crypography because later version require `setuptools_rust` which is not available for Alpine
+# See: https://github.com/Azure/azure-cli/issues/16858
+cryptography==3.3.2
 PyYAML==5.3.1
 ansible==2.10.7
 awscli==1.19.7

--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -2,18 +2,24 @@ COLOR_RESET="[0m"
 BANNER_COMMAND="${BANNER_COMMAND:-figurine}"
 BANNER_COLOR="${BANNER_COLOR:-[36m}"
 BANNER_INDENT="${BANNER_INDENT:-    }"
-BANNER_FONT="${BANNER_FONT:-Nancyj.flf}"
+BANNER_FONT="${BANNER_FONT:-Nancyj.flf}" # " IDE parser fix
 
 if [ "${SHLVL}" == "1" ]; then
-	# Display a banner message for interactive shells (if we're not in aws-vault or aws-okta)
-	(source /etc/os-release && printf "# Geodeisc based on %s\n\n" "$PRETTY_NAME")
-	if [ -n "${BANNER}" ]; then
-		if [ "$BANNER_COMMAND" == "figlet" ]; then
-			echo "${BANNER_COLOR}"
-			${BANNER_COMMAND} -w 200 "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
-			echo "${COLOR_RESET}"
-		elif [ "$BANNER_COMMAND" == "figurine" ]; then
-			${BANNER_COMMAND} -f "${BANNER_FONT}" "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
+	function _header() {
+		local vstring
+		# Display a banner message for interactive shells (if we're not in aws-vault or aws-okta)
+		[ -n "${GEODESIC_VERSION}" ] && vstring=" version ${GEODESIC_VERSION}"
+		(source /etc/os-release && printf "# Geodesic${vstring} based on %s\n\n" "$PRETTY_NAME")
+		if [ -n "${BANNER}" ]; then
+			if [ "$BANNER_COMMAND" == "figlet" ]; then
+				echo "${BANNER_COLOR}"
+				${BANNER_COMMAND} -w 200 "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
+				echo "${COLOR_RESET}"
+			elif [ "$BANNER_COMMAND" == "figurine" ]; then
+				${BANNER_COMMAND} -f "${BANNER_FONT}" "${BANNER}" | sed "s/^/${BANNER_INDENT}/"
+			fi
 		fi
-	fi
+	}
+	_header
+	unset _header
 fi


### PR DESCRIPTION
## what
- Include version number in Docker image
- Update Google Cloud SDK 316.0.0 -> 328.0.0
- Update `helm-2to3` 0.7.0 -> 0.8.1
- Pin Python `cryptography` package to 3.3.2 
- Add `net-tools` package do Debian
- Disable package repo hash check

## why
- Show which version of Geodesic you are running
- Stay current
- Stay current
- Current version of `cryptography` does not build on Alpine: `No module named 'setuptools_rust'`
- Feature parity with Alpine image
- Purpose of hash check was to invalidate caches, but now that is done with Geodesic version number
