### PR TITLE
Security updates, better EKS cluster support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+[*]
+insert_final_newline = true
+
 # Override for Makefile
 [{Makefile, makefile, GNUmakefile}]
 indent_style = tab
@@ -13,7 +16,7 @@ indent_size = 2
 
 [*.sh]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 
 [*.{tf,tfvars,tpl}]
 indent_size = 2

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,7 @@
     "enabled": false
   },
   "docker": {
-    "ignorePaths": ["rootfs/**"]
+    "ignorePaths": ["rootfs/**"],
+    "matchPaths": ["Dockerfile.alpine", "Dockerfile.debian"]
   }
 }

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,6 +1,6 @@
-ARG ALPINE_VERSION=3.12.1
+ARG ALPINE_VERSION=3.12.4
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=328.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=330.0.0
 #
 # Python Dependencies
 #
@@ -184,6 +184,9 @@ RUN chmod -R a+rwX ${HELM_HOME}
 ARG GEODESIC_AWS_HOME=/localhost/.aws
 ENV AWS_CONFIG_FILE=${GEODESIC_AWS_HOME}/config
 ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
+# Region abbreviation types are "fixed" (always 3 chars), "short" (4-5 chars), or "long" (the full AWS string)
+# See https://github.com/cloudposse/terraform-aws-utils#introduction
+ENV AWS_REGION_ABBREVIATION_TYPE=fixed
 
 #
 # Configure aws-vault to easily assume roles (not related to HashiCorp Vault)
@@ -248,9 +251,6 @@ RUN /usr/local/bin/docs update
 # are in fact available to all users
 RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 	chmod -R a+rwX $dir; done
-
-# Set mode on kubeconfig to suppress some warnings (mode was reset by above "COPY rootfs/ /"
-RUN chmod 600 $KUBECONFIG
 
 WORKDIR /conf
 

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -1,8 +1,8 @@
-ARG DEBIAN_VERSION=10.6-slim
+ARG DEBIAN_VERSION=10.8-slim
 
 FROM debian:$DEBIAN_VERSION as python
 # Find the current version of Python at https://www.python.org/downloads/source/
-ARG PYTHON_VERSION=3.8.6
+ARG PYTHON_VERSION=3.8.8
 
 # Debian comes with minimal Locale support. See https://github.com/docker-library/docs/pull/703/files
 # Recommended: LC_ALL=C.UTF-8
@@ -106,7 +106,7 @@ RUN apt-get update && apt-get install -y \
 # Install Google Cloud SDK
 # This is separate so that updating it does not invalidate the Docker cache layer with all the packages installed above
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=328.0.0-0
+ARG GOOGLE_CLOUD_SDK_VERSION=330.0.0-0
 ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
 
 RUN apt-get update && apt-get install -y google-cloud-sdk=$GOOGLE_CLOUD_SDK_VERSION
@@ -208,6 +208,9 @@ RUN chmod -R a+rwX ${HELM_HOME}
 ARG GEODESIC_AWS_HOME=/localhost/.aws
 ENV AWS_CONFIG_FILE=${GEODESIC_AWS_HOME}/config
 ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
+# Region abbreviation types are "fixed" (always 3 chars), "short" (4-5 chars), or "long" (the full AWS string)
+# See https://github.com/cloudposse/terraform-aws-utils#introduction
+ENV AWS_REGION_ABBREVIATION_TYPE=short
 
 #
 # Disable aws-vault and okta support by default, enable in child Dockerfile or personal configuration if needed
@@ -258,9 +261,6 @@ RUN /usr/local/bin/docs update
 # are in fact available to all users
 RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 	chmod -R a+rwX $dir; done
-
-# Set mode on kubeconfig to suppress some warnings (mode was reset by above "COPY rootfs/ /"
-RUN chmod 600 $KUBECONFIG
 
 WORKDIR /conf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ requests==2.25.1
 # See: https://github.com/Azure/azure-cli/issues/16858
 cryptography==3.3.2
 PyYAML==5.4.1
-ansible==2.10.7
 awscli==1.19.17
 boto==2.49.0
 boto3==1.17.17

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
+export AWS_REGION_ABBREVIATION_TYPE=${AWS_REGION_ABBREVIATION_TYPE:-fixed}
+export AWS_DEFAULT_SHORT_REGION=${AWS_DEFAULT_SHORT_REGION:-$(aws-region --${AWS_REGION_ABBREVIATION_TYPE} ${AWS_DEFAULT_REGION:-us-west-2})}
+export GEODESIC_AWS_HOME="${GEODESIC_AWS_HOME:-/localhost/.aws}"
+
 # `aws configure` does not respect ENVs
 if [ ! -e "${HOME}/.aws" ]; then
-	ln -s "${GEODESIC_AWS_HOME:-/localhost/.aws}" "${HOME}/.aws"
+	# -e fails if the target is a link to a non-existent file, remove dead link if it exists
+	[ -L "${HOME}/.aws" ] && rm -f "${HOME}/.aws"
+	if [ ! -d "${GEODESIC_AWS_HOME}" ]; then
+		mkdir ${GEODESIC_AWS_HOME} && chmod 700 ${GEODESIC_AWS_HOME}
+	fi
+	ln -s "${GEODESIC_AWS_HOME}" "${HOME}/.aws"
 fi
 
-if [ ! -f "${AWS_CONFIG_FILE:=${GEODESIC_AWS_HOME:-/localhost/.aws}/config}" ]; then
+if [ ! -f "${AWS_CONFIG_FILE:=${GEODESIC_AWS_HOME}/config}" ] && [ -d ${GEODESIC_AWS_HOME} ]; then
 	echo "* Initializing ${AWS_CONFIG_FILE}"
 	# Required for AWS_PROFILE=default
 	echo '[default]' >${AWS_CONFIG_FILE}

--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -7,9 +7,14 @@ BANNER_FONT="${BANNER_FONT:-Nancyj.flf}" # " IDE parser fix
 if [ "${SHLVL}" == "1" ]; then
 	function _header() {
 		local vstring
+		local debian_version="/etc/debian_version"
+
 		# Display a banner message for interactive shells (if we're not in aws-vault or aws-okta)
 		[ -n "${GEODESIC_VERSION}" ] && vstring=" version ${GEODESIC_VERSION}"
-		(source /etc/os-release && printf "# Geodesic${vstring} based on %s\n\n" "$PRETTY_NAME")
+		if source /etc/os-release; then
+			[[ -r $debian_version ]] && VERSION_ID=$(cat $debian_version)
+			printf "# Geodesic${vstring} based on %s (%s)\n\n" "$PRETTY_NAME" "$VERSION_ID"
+		fi
 		if [ -n "${BANNER}" ]; then
 			if [ "$BANNER_COMMAND" == "figlet" ]; then
 				echo "${BANNER_COLOR}"

--- a/rootfs/etc/profile.d/helm.sh
+++ b/rootfs/etc/profile.d/helm.sh
@@ -2,6 +2,7 @@ if command -v helm >/dev/null; then
 	# Initialize auto-completion for whichever helm version is the installed default
 	# Suppress error message about KUBECONFIG not found or being world readable
 	if [[ -r $KUBECONFIG ]]; then
+		chmod 600 $KUBECONFIG
 		source <(helm completion bash)
 	else
 		touch /tmp/kubecfg

--- a/rootfs/usr/local/bin/aws-region
+++ b/rootfs/usr/local/bin/aws-region
@@ -59,6 +59,7 @@ short_map=(
   [ape1]="ap-east-1"
   [apne1]="ap-northeast-1"
   [apne2]="ap-northeast-2"
+  [apne3]="ap-northeast-3"
   [aps1]="ap-south-1"
   [apse1]="ap-southeast-1"
   [apse2]="ap-southeast-2"

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -22,15 +22,15 @@ Usage:
   With "off", deletes the currently active kubecfg file.
 
   NOTE: This tool assumes you are using Cloud Posse's standard naming conventions:
-  * Cluster name "corp" expands to "${NAMESPACE}-corp-eks-cluster"
-  * Role name "admin" expands to "${NAMESPACE}-corp-admin"
+  * Cluster name "uw2-corp" expands to "${NAMESPACE}-uw2-corp-eks-cluster"
+  * Role name "admin" expands to "${NAMESPACE}-gbl-corp-admin"
 
 EOF
 }
 
 function profile_name() {
 	local profile_arg="${2:-${ASSUME_ROLE}}"
-	printf "%s" "${NAMESPACE:+${NAMESPACE}-}${1}-${profile_arg##*-}"
+	printf "%s" "${NAMESPACE}-gbl-${1#*-}-${profile_arg##*-}"
 }
 
 function file_name() {
@@ -45,6 +45,10 @@ function red() {
 }
 
 main() {
+	if [[ -z $NAMESPACE ]]; then
+	  printf "%s: %s\n\n" "$(basename $0)" "$(red Environment variable NAMESPACE is required but not set)"  >&2
+	  return 9
+	fi
 	if (($# == 0)); then
 		usage
 		return 1
@@ -59,18 +63,32 @@ main() {
 		fi
 		return 0
 	fi
-	if [[ -z ${ASSUME_ROLE:-$2} ]]; then
-		printf "%s: %s\n\n" "$(basename $0)" "$(red "* No role specified and \$ASSUME_ROLE unset. Giving up.")" >&2
+	local role
+	if [[ $1 == "set-kubeconfig" ]]; then
+		role="$3"
+	else
+		role="$2"
+	fi
+	if [[ -z $role ]]; then
+		role="$ASSUME_ROLE"
+		if [[ $role =~ identity$ ]]; then
+			role=$(aws sts get-caller-identity --output text --query 'Arn' | cut -d/ -f2)
+		fi
+	fi
+	if [[ -z ${role} ]]; then
+		printf "%s: %s\n\n" "$(basename $0)" "$(red "* No role specified and cannot guess role. Giving up.")" >&2
 		usage
 		return 9
 	fi
 	if [[ $1 == "set-kubeconfig" ]]; then
-		file_name $2 $3
+		file_name $2 $role
 		return 0
 	fi
 
+	local kubecfg="$(file_name $1 $role)"
 	EKS_CLUSTER_NAME_PATTERN="${EKS_CLUSTER_NAME_PATTERN:-${NAMESPACE:+${NAMESPACE}-}%s-eks-cluster}"
-	aws --profile $(profile_name $1 $2) eks update-kubeconfig --name=$(printf "$EKS_CLUSTER_NAME_PATTERN" $1) --kubeconfig="$(file_name $1 $2)"
+	aws --profile $(profile_name $1 $role) eks update-kubeconfig --name=$(printf "$EKS_CLUSTER_NAME_PATTERN" $1) --kubeconfig="$kubecfg" && \
+	chmod 600 "$kubecfg"
 }
 
 main "$@"


### PR DESCRIPTION
## what
- Remove `ansible`
- Add `AWS_REGION_ABBREVIATION_TYPE` to set region abbreviations used in our tools
- Add `AWS_DEFAULT_SHORT_REGION` set to `$AWS_REGION_ABBREVIATION_TYPE` of  `$AWS_DEFAULT_REGION` 
- With that, better support for EKS clusters (`set-cluster`, `eks-update-kubeconfig` should not work out-of-the box for most users)
- Better error handling in `set-cluster` and `eks-update-kubeconfig` 
- Add support for region `ap-northeast-3` made available 2020-03-01
- Ensure `$KUBECONFIG` has mode `rw-------` before referencing it
- Updated support for initializing AWS configuration
- Configure Renovatebot to update Geodesic Dockerfiles
- Include Alpine patch version and Debian minor version in startup messages
- Updates:
   - Alpine 3.12.1 -> 3.12.4
   - Debian 10.6 -> 10.8
   - Python (Debian only) 3.8.6 -> 3.8.8
   - Google Cloud SDK 328.0.0 -> 330.0.0

## why
- Installed version of `ansible` superseded by new 3.x version, but Cloud Posse clients not using it. Closes #684 
- Bring scripted tools in line with [`atmos`](https://github.com/cloudposse/atmos) and Cloud Posse reference architecture
- Better support for using Geodesic derivatives as pseudo-bastions inside Kubernetes clusters
- Keep up-to-date