### PR TITLE
[renovate] Remove invalid matchPaths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "timezone": "America/Los_Angeles",
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:disableMajor"
   ],
   "packageRules": [
     {
@@ -14,7 +15,6 @@
     "enabled": false
   },
   "docker": {
-    "ignorePaths": ["rootfs/**"],
-    "matchPaths": ["Dockerfile.alpine", "Dockerfile.debian"]
+    "ignorePaths": ["rootfs/**"]
   }
 }


### PR DESCRIPTION
## what
- [renovate] Remove invalid matchPaths from `renovate.json`

## why
- #687 attempted to get Renovate to keep our Dockerfiles up-to-date by explicitly including them. The attempt not only failed, it broke the configuration, causing all updates to stop.

## note
Renovate was already finding our Dockerfiles. It was not updating them because it will not update versions containing variables. As a result, we cannot rely on Renovate to keep the Dockerfiles up-to-date with respect to nearly anything in them, since we use variables for all versions (not just `FROM` but also Go SDK, `helm` plugins, etc.).