### PR TITLE
Better user experience when running via docker CLI

### DIFF
--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -255,4 +255,4 @@ RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 WORKDIR /conf
 
 ENTRYPOINT ["/bin/bash"]
-CMD ["-c", "init"]
+CMD ["-c", "boot"]

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -265,4 +265,4 @@ RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 WORKDIR /conf
 
 ENTRYPOINT ["/bin/bash"]
-CMD ["-c", "init"]
+CMD ["-c", "boot"]

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -47,7 +47,16 @@ elif [[ ! -d $GEODESIC_CONFIG_HOME ]]; then
 fi
 
 if [[ ! -d $GEODESIC_CONFIG_HOME ]]; then
-	if mkdir -p $GEODESIC_CONFIG_HOME; then
+	if ! df | grep -q /localhost; then
+		if [[ -z $KUBERNETES_PORT ]]; then
+			echo $(red "########################################################################################")
+			echo $(red \* No filesystem is mounted at $(bold /localhost) which limits Geodesic functionality.)
+			boot install
+		else
+			echo $(green Kubernetes host detected, Geodesic customization disabled.)
+		fi
+		export GEODESIC_CUSTOMIZATION_DISABLED="/localhost not a volume"
+	elif mkdir -p $GEODESIC_CONFIG_HOME; then
 		echo $(yellow Created directory "$GEODESIC_CONFIG_HOME" '(GEODESIC_CONFIG_HOME)')
 	else
 		echo $(red Cannot create directory "$GEODESIC_CONFIG_HOME" '(GEODESIC_CONFIG_HOME)')
@@ -70,7 +79,7 @@ function _load_geodesic_preferences() {
 }
 
 if [[ ${GEODESIC_CUSTOMIZATION_DISABLED-false} != false ]]; then
-	echo $(yellow Disabling user customizations: GEODESIC_CUSTOMIZATION_DISABLED is set and not 'false')
+	echo $(red Disabling user customizations: GEODESIC_CUSTOMIZATION_DISABLED is \'"${GEODESIC_CUSTOMIZATION_DISABLED}"\')
 else
 	_load_geodesic_preferences
 fi

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -100,10 +100,10 @@ function export_current_aws_role() {
 	if [[ -z $role_name ]]; then
 		if [[ "$role_arn" =~ "role/OrganizationAccountAccessRole" ]]; then
 			role_name="$(printf "%s" "$role_arn" | cut -d: -f 5):OrgAccess"
-			echo "* $(red "Could not find profile name for ${role_arn}\; calling it \"${role_name}\"")" >&2
+			echo "* $(red "Could not find profile name for ${role_arn} ; calling it \"${role_name}\"")" >&2
 		else
 			role_name="$(printf "%s" "$role_arn" | cut -d/ -f 2)"
-			echo "* $(green "Could not find profile name for ${role_arn}\; calling it \"${role_name}\"")" >&2
+			echo "* $(green "Could not find profile name for ${role_arn} ; calling it \"${role_name}\"")" >&2
 		fi
 	fi
 	export ASSUME_ROLE="$role_name"

--- a/rootfs/usr/local/bin/boot
+++ b/rootfs/usr/local/bin/boot
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+[[ -t 1 ]] && (($# == 0)) && exec bash --login
+
+source /etc/os-release
+
+if [[ $1 == "install" ]]; then
+  function color() { echo "$(tput setaf 1)$*$(tput setaf 0)" >&2; }
+  color "# EXIT THIS SHELL and on your host computer,"
+elif [[ -n $DOCKER_IMAGE ]] && [[ -n $DOCKER_TAG ]]; then
+  exec /usr/local/bin/init
+else
+  function color() { echo "$*"  >&2; }
+  color "########################################################################################"
+  color "# Attach a terminal (docker run --rm --it ...) if you want to run a shell."
+fi
+
+color "# Run the following to install a script with that runs "
+color "# Geodesic with all its features (the recommended way to use Geodesic):"
+color "#   docker run --rm cloudposse/geodesic:latest-${ID} init | bash"
+color "# (On a Linux workstation, you might need to use \"sudo bash\" instead of just \"bash\")"
+color "########################################################################################"
+echo
+echo


### PR DESCRIPTION
## what
- Better user experience when running via docker CLI
- No change to `make install` behavior

## why
- Current experience when user naïvely runs Geodesic is that it outputs a script to generate a launch wrapper, which is very confusing
- Backwards compatibility

## examples

#### run with terminal and volume attached

```
$ docker run -it --rm -v $HOME:/localhost cloudposse/geodesic:latest

# starts up and runs shell relatively normally, but without 
# some features dependent on wrapper setup

 ⧉  geodesic 
 ✗ . [none] ~ ⨠ 
```

#### basic run

```
$ docker run --rm cloudposse/geodesic:latest
########################################################################################
# Attach a terminal (docker run --rm --it ...) if you want to run a shell.
# Run the following to install a script with that runs 
# Geodesic with all its features (the recommended way to use Geodesic):
#   docker run --rm cloudposse/geodesic:latest-alpine init | bash
# (On a Linux workstation, you might need to use "sudo bash" instead of just "bash")
########################################################################################
```

#### run with terminal attached

```
$ docker run -it --rm cloudposse/geodesic:latest
########################################################################################
* No filesystem is mounted at /localhost which limits Geodesic functionality.
# EXIT THIS SHELL and on your host computer,
# Run the following to install a script with that runs 
# Geodesic with all its features (the recommended way to use Geodesic):
#   docker run --rm cloudposse/geodesic:latest-alpine init | bash
# (On a Linux workstation, you might need to use "sudo bash" instead of just "bash")
########################################################################################


Disabling user customizations: GEODESIC_CUSTOMIZATION_DISABLED is '/localhost not a volume'

...

 ⧉  geodesic 
 ✗ . [none] ~ ⨠ 
```
