### PR TITLE
WIP: Enable non-root users to use the geodesic shell

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -171,7 +171,7 @@ ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSI
 # https://github.com/jonmosco/kube-ps1/releases
 ENV KUBE_PS1_VERSION 0.7.0
 ADD https://raw.githubusercontent.com/jonmosco/kube-ps1/v${KUBE_PS1_VERSION}/kube-ps1.sh /etc/profile.d/prompt:kube-ps1.sh
-
+RUN chmod a+r /etc/profile.d/prompt:kube-ps1.sh
 
 #
 # Install helm

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -16,7 +16,7 @@ fi
 # Detect root user in order to run as non-root users with the sudo command
 function _root_detection() {
   [ ! "${SUDO_CMD+1}" ] || return 0 # SUDO_CMD already set
-  if [ "$(echo "$UID")" = "0" ]; then
+  if [ "$UID" == "0" ]; then
     SUDO_CMD=''
   else
     SUDO_CMD='sudo'

--- a/rootfs/etc/profile.d/_preferences.sh
+++ b/rootfs/etc/profile.d/_preferences.sh
@@ -13,9 +13,20 @@ fi
 
 [[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: GEODESIC_CONFIG_HOME is found to be "${GEODESIC_CONFIG_HOME:-<unset>}"
 
+# Detect root user in order to run as non-root users with the sudo command
+function _root_detection() {
+  [ ! "${SUDO_CMD+1}" ] || return 0 # SUDO_CMD already set
+  if [ "$(echo "$UID")" = "0" ]; then
+    SUDO_CMD=''
+  else
+    SUDO_CMD='sudo'
+  fi
+}
+_root_detection
+
 # If LOCAL_HOME is set, create a symbolic link so host pathnames (at least the ones under $HOME) work inside the shell
 if [[ -n $LOCAL_HOME && ! -e $LOCAL_HOME ]]; then
-	mkdir -p $(dirname "${LOCAL_HOME}") && ln -s /localhost "${LOCAL_HOME}" ||
+	$SUDO_CMD mkdir -p $(dirname "${LOCAL_HOME}") && $SUDO_CMD ln -s /localhost "${LOCAL_HOME}" ||
 		echo $(red Unable to create symbolic link $LOCAL_HOME '->' /localhost)
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: linked $LOCAL_HOME '->' /localhost
 fi

--- a/rootfs/etc/profile.d/syslog-ng.sh
+++ b/rootfs/etc/profile.d/syslog-ng.sh
@@ -1,3 +1,6 @@
-if ! pidof syslog-ng >/dev/null; then
-	syslog-ng -f /etc/syslog-ng/syslog-ng.conf --no-caps
+# Root detection function defined in _preferences.sh
+_root_detection
+
+if ! $SUDO_CMD pidof syslog-ng >/dev/null; then
+	$SUDO_CMD syslog-ng -f /etc/syslog-ng/syslog-ng.conf --no-caps
 fi


### PR DESCRIPTION
## Work In Progress

This is part of a larger push to help create a `geodesic` non-root user with which to run the geodesic.

- This can be seen as the initial PoC since there are, without doubt, other areas which still need adjustment. e.g.
    - The central use `/conf` directory would need to be looked at
    - The alpine distribution would need to include the `sudo` package. 

## what

- add a `_root_detection` function to enable a conditional `sudo` prefix for non-root users
- ensure `/etc/profile.dprompt:kube-ps1.sh` is readable by non-root users

## POC - Testing purposes only

Place the following `Dockerfile.non-root-example` in the PR's root directory.

The Dockerfile adds the geodesic user. See `NOTE:` sections for explanations and context.

<details>
<summary>Dockerfile.non-root-example</summary>

```dockerfile
# NOTE: using 0.142.0 in this example since the naming convention for EKS clusters changed after this.
ARG VERSION=0.142.0
ARG OS=debian
FROM cloudposse/geodesic:$VERSION-$OS

ENV BANNER="non-root"

# NOTE: TEMPORARY
# - install docker for tests later
RUN export DOCKER_VERSION="20.10.5" && \
    export DOCKER_SHA256SUM="3f18edc66e1faae607d428349e77f9800bdea554528521f0f6c49fc3f1de6abf" && \
    echo "Installing Docker ${DOCKER_VERSION}..." && \
    curl -SsL -o "docker-${DOCKER_VERSION}.tgz" "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" && \
    echo "Verifying docker-${DOCKER_VERSION}.tgz checksum..." && \
    sha256sum "docker-${DOCKER_VERSION}.tgz" && \
    echo "${DOCKER_SHA256SUM} *docker-${DOCKER_VERSION}.tgz" | sha256sum -c - && \
    tar -xzC /usr/local/bin --strip-components=1 -f "docker-${DOCKER_VERSION}.tgz" && \
    rm -f "docker-${DOCKER_VERSION}.tgz"

# NOTE: TEMPORARY
# - adding _root_detection to the necesary files
# - make "/etc/profile.d/prompt:kube_ps1.sh"
# - mentioned in https://github.com/cloudposse/geodesic/pull/710
COPY rootfs/etc/profile.d/_preferences.sh /etc/profile.d/_preferences.sh
COPY rootfs/etc/profile.d/syslog-ng.sh /etc/profile.d/syslog-ng.sh
RUN chmod -R a+r /etc/profile.d/

# NOTE: TEMPORARY
# - installing as root means the bin directories are not readable by mere mortals
# - mentioned in https://github.com/cloudposse/packages/pull/1320
RUN find /usr/share/ -maxdepth 3 -type d -name bin | xargs sudo chmod a+rX

# NOTE: Add geodesic user to replace root usage
# - uses https://github.com/boxboat/fixuid
# - this needs to be integrated in the geodesic image
# - UID/GID = 1001
#   - is simply for testing alternate UID's since my own UID already 1000
#   - ideally the UID/GID would be 1000 and things would work automatically for most users.
# For debian / ubuntu
ARG GEODESIC_UID=1001
ARG GEODESIC_GID=1001
RUN USER=geodesic && \
    GROUP=geodesic && \
    [ $(getent group docker) ] || addgroup --gid 999 docker && \
    addgroup --gid ${GEODESIC_GID} $GROUP && \
    adduser --uid ${GEODESIC_UID} --ingroup $GROUP --home /home/$USER --shell /bin/bash --disabled-password --gecos "Geodesic User" $USER && \
    usermod $USER -G sudo,docker && \
    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
    id $USER && \
    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.5/fixuid-0.5-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
    chown root:root /usr/local/bin/fixuid && \
    chmod 4755 /usr/local/bin/fixuid && \
    mkdir -p /etc/fixuid && \
    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml

# NOTE: TEMPORARY
# - this should not be needed after
#   - the above is integrated into the geodesic shell
#   - the new HOME would point to /home/geodesic instead of /conf
# copy /conf to the geodesic users new home
RUN cp -r /conf/.[^.]* /home/geodesic && \
    chown -R geodesic:geodesic /home/geodesic

# NOTE: become the geodesic user
ENV HOME="/home/geodesic"
USER geodesic
WORKDIR /home/geodesic
ENV KUBECONFIG="/home/geodesic/.kube/config"

ENTRYPOINT ["fixuid", "-q", "/bin/bash"]

# custom envs which are not part of the main geodesic shell
ENV NAMESPACE="nbo"
ENV AWS_PROFILE="nbo-identity"
ENV AWS_REGION="us-east-2"
ENV AWS_DEFAULT_REGION="us-east-2"
```

</details>


Minimal steps to test:

```shell

# set initial variables
{
	TEST_IMAGE=cloudposse/non-root
	INSTALL_PREFIX=
	[ -z "${GEODESIC_INSTALL_PATH:-}" ] || INSTALL_PREFIX="INSTALL_PATH=${GEODESIC_INSTALL_PATH}"
}

# create initial geodesic init script with
{
    docker run --rm cloudposse/geodesic:latest init | $INSTALL_PREFIX bash
}

# print the geodesic binary
{
    command -v geodesic
}

# build custom image
{
    docker build -t cloudposse/non-root -f Dockerfile.non-root-example .
}

# enter shell with...
{
    WITH_DOCKER=true GEODESIC_IMAGE=cloudposse/non-root GEODESIC_DOCKER_EXTRA_ARGS="-u $(id -u):$(id -g) --group-add sudo --group-add docker" geodesic
}

# Finally, in the new shell
# - use the normal 'assume-role', 'set-cluster', etc
# - touch a new file in the /localhost - check that the permissions are correct, etc

```