### PR TITLE
Update Debian to AWS CLI v2

### DIFF
--- a/Dockerfile.options
+++ b/Dockerfile.options
@@ -68,3 +68,64 @@ ENV NODE_MIN_SIZE 2
 
 # end of kops support section
 ####################################################################################
+
+#### ALPINE ONLY ####
+# Alpine does not include the very common `glibc` GNU C Standard Library, which
+# causes compatibility problems. Among other things, AWS CLI v2 does not work
+# out of the box with Alpine. The following recipe installs `glibc` , and has to be run
+# before installing other packages, particularly `libc6-compat`, and then,
+# because it conflicts, you have to tweak a bit and then install `libc6-compat`.
+# So put this in Dockerfile.alpine after setting up the package repositories
+# but before installing any packages https://github.com/cloudposse/geodesic/blob/91336bf56fb7ff0d9812e01ceacc40ca59a17cce/os/alpine/Dockerfile.alpine#L81
+# (Not verified)
+
+# Install glibc and glibc-bin and the C.UTF-8 locale
+ENV LANG=C.UTF-8
+ARG ALPINE_GLIBC_PACKAGE_VERSION=2.33-r0
+RUN apk update && apk add -u curl && \
+  ALPINE_GLIBC_PACKAGE_VERSION="${ALPINE_GLIBC_PACKAGE_VERSION}" && \
+  curl -sSLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${ALPINE_GLIBC_PACKAGE_VERSION}/glibc-${ALPINE_GLIBC_PACKAGE_VERSION}.apk &&
+  apk add --allow-untrusted glibc-${ALPINE_GLIBC_PACKAGE_VERSION}.apk && rm glibc-${ALPINE_GLIBC_PACKAGE_VERSION}.apk && \
+  curl -sSLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${ALPINE_GLIBC_PACKAGE_VERSION}/glibc-bin-${ALPINE_GLIBC_PACKAGE_VERSION}.apk &&
+  apk add --allow-untrusted glibc-bin-${ALPINE_GLIBC_PACKAGE_VERSION}.apk && rm glibc-bin-${ALPINE_GLIBC_PACKAGE_VERSION}.apk && \
+  curl -sSLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${ALPINE_GLIBC_PACKAGE_VERSION}/glibc-i18n-${ALPINE_GLIBC_PACKAGE_VERSION}.apk &&
+  apk add --allow-untrusted glibc-i18n-${ALPINE_GLIBC_PACKAGE_VERSION}.apk && rm glibc-i18n-${ALPINE_GLIBC_PACKAGE_VERSION}.apk && \
+  /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true && \
+  printf "export LANG=%s\n" "$LANG" > /etc/profile.d/locale.sh && \
+  apk del glibc-i18n && \
+  rm -f /usr/glibc-compat/lib/ld-linux-x86-64.so.2 && \
+  /usr/glibc-compat/sbin/ldconfig
+
+
+# Remove conflicting link, install libc6-compat, restore link to glibc
+RUN mv /lib64/ld-linux-x86-64.so.2 /lib64/glibc-ld-linux-x86-64.so.2 && \
+  apk add --force-overwrite libc6-compat && \
+  rm -f /lib64/ld-linux-x86-64.so.2 && \
+  mv /lib64/glibc-ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2  && \
+  /usr/glibc-compat/sbin/ldconfig
+
+
+# Now you can install packages
+# https://github.com/cloudposse/geodesic/blob/91336bf56fb7ff0d9812e01ceacc40ca59a17cce/os/alpine/Dockerfile.alpine#L81-L88
+
+
+# Now you can move AWS CLI v1 aside, keep it as an alternative, and install AWS CLI v2
+
+# Move AWS CLI v1 to aws1 and set up alternatives
+RUN mv /usr/bin/aws /usr/local/bin/aws1 && \
+    update-alternatives --install /usr/local/bin/aws aws /usr/local/bin/aws1 1
+
+
+# Install AWS CLI 2
+# Get version from https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
+# We cannot automatically track the release versions, so we just install the latest
+# ARG AWS_CLI_VERSION=2.1.34
+RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
+    curl -sSsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
+    cd $AWSTMPDIR && \
+    unzip -qq awscliv2.zip && \
+    ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
+    update-alternatives --install /usr/local/bin/aws aws /usr/share/aws/v2/bin/aws 2 && \
+    rm -rf $AWSTMPDIR
+
+

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,6 +1,9 @@
-ARG ALPINE_VERSION=3.13.4
+ARG ALPINE_VERSION=3.13.5
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=334.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=342.0.0
+# https://github.com/ahmetb/kubectx/releases
+ARG KUBECTX_COMPLETION_VERSION=0.9.3
+
 #
 # Python Dependencies
 #
@@ -78,6 +81,13 @@ RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net
     echo "@testing https://alpine.global.ssl.fastly.net/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "@community https://alpine.global.ssl.fastly.net/alpine/edge/community" >> /etc/apk/repositories
 
+##########################################################################################
+# See Dockerfile.options for how to install `glibc` for greater compatibility, including #
+# being able to use AWS CLI v2. You would install `glibc` and `libc6-compat` here, then  #
+# install the packages below, then the Python stuff, then move AWS CLI v1 aside, and     #
+# then install the AWS CLI v2                                                            #
+##########################################################################################
+
 # Install alpine package manifest
 COPY packages.txt os/alpine/packages-alpine.txt /etc/apk/
 
@@ -130,7 +140,7 @@ RUN chmod 600 $KUBECONFIG
 # Set KUBERNETES_VERSION and KOPS_BASE_IMAGE in /conf/kops/kops.envrc
 #
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
-ENV KUBECTX_COMPLETION_VERSION 0.9.1
+ARG KUBECTX_COMPLETION_VERSION
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubens.bash /etc/bash_completion.d/kubens.sh
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubectx.bash /etc/bash_completion.d/kubectx.sh
 #

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -1,4 +1,8 @@
 ARG DEBIAN_VERSION=10.9-slim
+# https://cloud.google.com/sdk/docs/release-notes
+ARG GOOGLE_CLOUD_SDK_VERSION=342.0.0-0
+# https://github.com/ahmetb/kubectx/releases
+ARG KUBECTX_COMPLETION_VERSION=0.9.3
 
 FROM debian:$DEBIAN_VERSION as python
 # Find the current version of Python at https://www.python.org/downloads/source/
@@ -117,7 +121,7 @@ RUN apt-get update && apt-get install -y \
 # Install Google Cloud SDK
 # This is separate so that updating it does not invalidate the Docker cache layer with all the packages installed above
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=334.0.0-0
+ARG GOOGLE_CLOUD_SDK_VERSION
 ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
 
 RUN apt-get update && apt-get install -y google-cloud-sdk=$GOOGLE_CLOUD_SDK_VERSION
@@ -162,7 +166,7 @@ RUN chmod 600 $KUBECONFIG
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
 
 # https://github.com/ahmetb/kubectx/releases
-ENV KUBECTX_COMPLETION_VERSION 0.9.1
+ARG KUBECTX_COMPLETION_VERSION
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubens.bash /etc/bash_completion.d/kubens.sh
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubectx.bash /etc/bash_completion.d/kubectx.sh
 
@@ -261,6 +265,37 @@ ENV MAKEFLAGS="--no-print-directory"
 # Install "root" filesystem
 COPY rootfs/ /
 COPY os/debian/rootfs/ /
+
+# Move AWS CLI v1 aside and install AWS CLI v2 as default, leaving both available as alternatives.
+# We do this at the end because we need cache busting from above to get us the latest AWS CLI v2
+
+RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
+    update-alternatives --install /usr/local/bin/aws aws /usr/local/bin/aws1 1
+
+# Install AWS CLI 2
+# Get AWS CLI V2 version from https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst if you want
+# but it is updated several times a week, so we choose to just get the latest.
+# ARG AWS_CLI_VERSION=2.2.8
+RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
+    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
+    cd $AWSTMPDIR && \
+    unzip -qq awscliv2.zip && \
+    ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
+    update-alternatives --install /usr/local/bin/aws aws /usr/share/aws/v2/bin/aws 2 && \
+    update-alternatives --set aws /usr/share/aws/v2/bin/aws && ln -s /usr/share/aws/v2/bin/aws /usr/local/bin/aws2 && \
+    rm -rf $AWSTMPDIR
+
+# We recommend AWS_PAGER="less -FRX" but you can override it in your Dockerfile
+# or in your Geodesic preferences (see `man customization`).
+# FRX acts like it does not invoke the pager unless the output would be
+# more than can fit on one scree, while preserving text color/bold.
+# FRX is actually the AWS default, except we overrode the default above by setting ENV LESS.
+# options to `less`:
+#  F = Quit if output fits on one screen, so short output remains visible after the command finishes
+#  R = Output "raw" control characters, so that text treatment like "bold" text is retained as "bold" text rather than quoted escapes
+#  X = Disable termcap init/de-init sequences, keeps the pager from clearing the screen when it finishes
+ENV AWS_PAGER="less -FRX"
+
 
 # Install documentation
 COPY docs/ /usr/share/docs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ awscli==1.19.84
 boto==2.49.0
 boto3==1.17.84
 crudini==0.9.3
-Jinja2==2.11.3


### PR DESCRIPTION
## what
- Update Debian to use AWS CLI v2 by default. 
- Remove Jinja2. Supersedes and closes #705.
- Update Alpine 3.13.4 -> 3.13.5
- Update Google Cloud SDK 334.0.0 -> 342.0.0

## why
- AWS now recommends using CLI v2, and v2 is required when using AWS SSO for authentication, which Cloud Posse now recommends
- Jinja2 released a new major version (3.0), potentially causing problems. We believe the only thing using Jinja2 was `ansible`, which we dropped a while back, so we are removing it completely to save space and maintenance. Users can, of course, add it back in their derived Docker images.
- Update Alpine and Google Cloud SDK to current versions (updates not handled by Renovate)

## notes

Alpine was not updated to use AWS CLI v2 because the official distribution does not support Alpine, because Alpine does not ship with `glibc`.  Instructions have been added to `Dockerfile.options` for how to install `glibc` in Alpine and how to install AWS CLI v2 after that. The instructions have been tested, but the resulting configuration has only had limited testing and may have undiscovered issues. At this time, we are not supporting `glibc` or AWS CLI v2 on Alpine, and we encourage everyone to switch to the Debian Geodesic distribution.