### PR TITLE
feat: updates mixed prompt to be warning > error

### DIFF
--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -86,13 +86,14 @@ function export_current_aws_role() {
 	local profile_target=${AWS_PROFILE:-${AWS_VAULT}}
 	if [[ -n $profile_target ]]; then
 		profile_arn=$(aws --profile "${profile_target}" sts get-caller-identity --output text --query 'Arn' 2>/dev/null | cut -d/ -f1-2)
-		if [[ $profile_arn == $current_role ]]; then
-			export ASSUME_ROLE="$profile_target"
-			return
+
+		# If the profile name and the role / user we're assuming do not match then warn the user.
+		if [[ $profile_arn != $current_role ]]; then
+			echo "* $(yellow Profile is set to $profile_target but current role does not match:)"
+			echo "*   $(yellow $current_role)"
 		fi
-		echo "* $(red Profile is set to $profile_target but current role does not match:)"
-		echo "*   $(red $current_role)"
-		export ASSUME_ROLE=$(red '!mixed!')
+
+		export ASSUME_ROLE="$profile_target"
 		return
 	fi
 


### PR DESCRIPTION
## What

* Updates aws role prompt to not show `!mixed!` when the `aws-vault` profile name does not match the assumed user or role.
* Updates to use yellow > red as this is a warning and not an actual error

## Why

* The aws-vault profile name not matching up to the assumed user or role is not an error event: For myself (and others I'm sure), it is an expected outcome of utilizing the same AWS IAM user username (e.g. `matt.gowie` in my instance) across many accounts / clients and needing to name those various accounts separately in `aws-vault` so I can differentiate which account I'm utilizing.

## Additional Info

* Previously this looked like: 
![CleanShot 2021-06-30 at 10 09 13](https://user-images.githubusercontent.com/1392040/123996178-4dde5f80-d98c-11eb-9e54-7dac6d2693a1.png)

* With this change, it now looks like what I would expect and prefer: 
![CleanShot 2021-06-30 at 10 08 18](https://user-images.githubusercontent.com/1392040/123996226-58005e00-d98c-11eb-804d-0a5a67fbab36.png)
