### PR TITLE
Deprecate aws-vault, aws-okta, warn about M1 chip

### DIFF
--- a/Dockerfile.options
+++ b/Dockerfile.options
@@ -21,21 +21,6 @@ ENV DIRENV_ENABLED=true
 # `make` outside of this directory tree.
 ENV MAKE_INCLUDES="Makefile Makefile.*"
 
-#
-# Configure aws-okta to easily assume roles
-#
-ENV AWS_OKTA_ENABLED=true
-
-#
-# Configure aws-vault to easily assume roles (not related to HashiCorp Vault)
-#
-ENV AWS_VAULT_ENABLED=true
-ENV AWS_VAULT_SERVER_ENABLED=true
-ENV AWS_VAULT_BACKEND=file
-ENV AWS_VAULT_ASSUME_ROLE_TTL=1h
-ENV AWS_VAULT_SESSION_TTL=12h
-#ENV AWS_VAULT_FILE_PASSPHRASE=
-
 
 ####################################################################################
 # kops support

--- a/README.md
+++ b/README.md
@@ -97,10 +97,16 @@ so that we may eventually make it the preferred version, after which point the `
 will maintain the `latest-alpine` and `latest-debian` Docker tags for those who want to commit to using one base OS or
 the other but still want automatic updates.
 
+**Note**: Geodesic is a large collection of tools. As such, support for the Apple M1 chip is not under
+Cloud Posse's control, rather it depends on each tool author updating each tool for the M1 chip.
+All of the compiled tools that Cloud Posse has authored and are included in Geodesic are compiled
+for M1 (`darwin_arm64`), and of course all of the scripts work on M1 if the interpreters (e.g.
+`bash`, `python`) are compiled for M1. Unfortunatetly, this is only a small portion of the overall
+toolkit that is assembled in Geodesic. Therefore we do not advise using Geodesic on the M1 at this time
+and do not anticipate M1 will be well supported before 2022. Historically, widespread support for a new
+chip takes several years to establish; we hope we will not have to wait that long.
+
 Want to learn more? [Check out our getting started with Geodesic guide!](https://docs.cloudposse.com/tutorials/geodesic-getting-started/)
-
-
-
 
 ## Usage
 
@@ -115,8 +121,7 @@ ARG OS=debian
 FROM cloudposse/geodesic:$VERSION-$OS
 
 # Add configuration options such as setting a custom BANNER,
-# turning on built-in support for aws-vault or aws-okta,
-# setting kops configuration parameters, etc. here
+# setting the initial AWS_PROFILE and AWS_DEFAULT_REGION, etc. here
 
 ENV BANNER="my-custom-geodesic"
 ```

--- a/README.yaml
+++ b/README.yaml
@@ -78,6 +78,15 @@ introduction: |-
   will maintain the `latest-alpine` and `latest-debian` Docker tags for those who want to commit to using one base OS or
   the other but still want automatic updates.
   
+  **Note**: Geodesic is a large collection of tools. As such, support for the Apple M1 chip is not under
+  Cloud Posse's control, rather it depends on each tool author updating each tool for the M1 chip.
+  All of the compiled tools that Cloud Posse has authored and are included in Geodesic are compiled
+  for M1 (`darwin_arm64`), and of course all of the scripts work on M1 if the interpreters (e.g.
+  `bash`, `python`) are compiled for M1. Unfortunatetly, this is only a small portion of the overall
+  toolkit that is assembled in Geodesic. Therefore we do not advise using Geodesic on the M1 at this time
+  and do not anticipate M1 will be well supported before 2022. Historically, widespread support for a new
+  chip takes several years to establish; we hope we will not have to wait that long.
+  
   Want to learn more? [Check out our getting started with Geodesic guide!](https://docs.cloudposse.com/tutorials/geodesic-getting-started/)
 
 usage: |-
@@ -90,8 +99,7 @@ usage: |-
   FROM cloudposse/geodesic:$VERSION-$OS
 
   # Add configuration options such as setting a custom BANNER,
-  # turning on built-in support for aws-vault or aws-okta,
-  # setting kops configuration parameters, etc. here
+  # setting the initial AWS_PROFILE and AWS_DEFAULT_REGION, etc. here
 
   ENV BANNER="my-custom-geodesic"
   ```

--- a/docs/about.md
+++ b/docs/about.md
@@ -11,7 +11,6 @@ about - About the Geodesic Cloud Automation Shell
 
 ## FEATURES
 
-* **Secure** - TLS/PKI, OAuth2, MFA Everywhere, remote access VPN, [ultra secure bastion/jumphost](https://github.com/cloudposse/bastion) with audit capabilities and slack notifications, [IAM assumed roles](https://github.com/99designs/aws-vault/), automatic key rotation, encryption at rest, and VPCs
 * **Repeatable** - 100% Infrastructure-as-Code with change automation and support for scriptable admin tasks in any language, including Terraform
 * **Extensible** - A framework where everything can be extended to work the way you want to
 * **Comprehensive** - our [helm charts library](https://github.com/cloudposse/charts) are designed to tightly integrate your cloud-platform with Github Teams and Slack Notifications and CI/CD systems like TravisCI, CircleCI or Jenkins
@@ -21,14 +20,10 @@ about - About the Geodesic Cloud Automation Shell
 
 At its core, Geodesic is a framework for provisioning cloud infrastructure and the applications that sit on top of it. We leverage as many existing tools as possible to facilitate cloud fabrication and administration. We're like the connective tissue that sits between all of the components of a modern cloud.
 
-* [`atlantis`](https://www.runatlantis.io/) - GitOps style operations by Pull Request. Ideal for terraform, helm and helmfile.
-* [`aws-vault`](https://github.com/99designs/aws-vault) for securely storing and accessing AWS credentials in an encrypted vault for the purpose of assuming IAM roles
 * [`aws-cli`](https://github.com/aws/aws-cli/) for interacting directly with the AWS APIs
 * [`chamber`](https://github.com/segmentio/chamber) for managing secrets with AWS SSM+KMS and exposing them as environment variables
-* [`direnv`](https://direnv.net) for managing environment variables per project or globally
 * [`helm`](https://github.com/kubernetes/helm/) for installing packages like Varnish or Apache on the Kubernetes cluster
 * [`helmfile`](https://github.com/roboll/helmfile) for 12-factorizing chart values and installing chart collections
-* [`kops`](https://github.com/kubernetes/kops/) for Kubernetes cluster orchestration
 * [`kubectl`](https://kubernetes.io/docs/user-guide/kubectl-overview/) for controlling kubernetes resources like deployments or load balancers
 * [`gcloud`, `gsutil`](https://cloud.google.com/sdk/) for integration with Google Cloud (e.g. GKE, GCE, Google Storage)
 * [`gomplate`](https://github.com/hairyhenderson/gomplate/) for template rendering configuration files using the GoLang template engine. Supports lots of local and remote datasources

--- a/docs/assume_active_aws_role.md
+++ b/docs/assume_active_aws_role.md
@@ -7,9 +7,12 @@ date: May 2019
 
 ## NAME
 
-`assume_active_aws_role` - assume a role provided by the `aws-vault` server
+_(Deprecated)_ `assume_active_aws_role` - assume a role provided by the `aws-vault` server
 
 ## SYNOPSIS
+
+_Note: Support for `aws-vault`, including `assume_active_aws_role` has been discontinued.
+Cloud Posse recommends using [Leapp](https://leapp.cloud) instead._
 
 For the case where you have an active `aws-vault` server but the current shell is not using it, 
 you can run `assume_active_aws_role` to assume the role being served by the server.  Normally 

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,8 +1,8 @@
 ARG ALPINE_VERSION=3.13.5
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=342.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=352.0.0
 # https://github.com/ahmetb/kubectx/releases
-ARG KUBECTX_COMPLETION_VERSION=0.9.3
+ARG KUBECTX_COMPLETION_VERSION=0.9.4
 
 #
 # Python Dependencies
@@ -204,7 +204,8 @@ ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
 ENV AWS_REGION_ABBREVIATION_TYPE=fixed
 
 #
-# Configure aws-vault to easily assume roles (not related to HashiCorp Vault)
+# Support for aws-vault (not related to HashiCorp Vault) is deprecated
+# in favor of Leapp.  https://leapp.cloud
 #
 ENV AWS_VAULT_ENABLED=false
 ENV AWS_VAULT_SERVER_ENABLED=false
@@ -214,7 +215,8 @@ ENV AWS_VAULT_BACKEND=file
 # ENV AWS_VAULT_FILE_PASSPHRASE=
 
 #
-# Configure aws-okta to easily assume roles
+# Support for aws-okta is deprecated
+# in favor of Leapp.  https://leapp.cloud
 #
 ENV AWS_OKTA_ENABLED=false
 

--- a/os/alpine/packages-alpine.txt
+++ b/os/alpine/packages-alpine.txt
@@ -1,5 +1,6 @@
 # Essential alpine-only packages
 busybox-extras
+diffutils
 drill
 fzf-bash-completion
 iputils

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -1,12 +1,12 @@
-ARG DEBIAN_VERSION=10.9-slim
+ARG DEBIAN_VERSION=10.10-slim
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=342.0.0-0
+ARG GOOGLE_CLOUD_SDK_VERSION=352.0.0-0
 # https://github.com/ahmetb/kubectx/releases
-ARG KUBECTX_COMPLETION_VERSION=0.9.3
+ARG KUBECTX_COMPLETION_VERSION=0.9.4
 
 FROM debian:$DEBIAN_VERSION as python
 # Find the current version of Python at https://www.python.org/downloads/source/
-ARG PYTHON_VERSION=3.8.9
+ARG PYTHON_VERSION=3.8.11
 
 # Debian comes with minimal Locale support. See https://github.com/docker-library/docs/pull/703/files
 # Recommended: LC_ALL=C.UTF-8
@@ -226,13 +226,6 @@ ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
 # Region abbreviation types are "fixed" (always 3 chars), "short" (4-5 chars), or "long" (the full AWS string)
 # See https://github.com/cloudposse/terraform-aws-utils#introduction
 ENV AWS_REGION_ABBREVIATION_TYPE=short
-
-#
-# Disable aws-vault and okta support by default, enable in child Dockerfile or personal configuration if needed
-#
-ENV AWS_VAULT_ENABLED=false
-ENV AWS_VAULT_SERVER_ENABLED=false
-ENV AWS_OKTA_ENABLED=false
 
 # Shell customization
 # options for `less`. `R` allows ANSI color codes to be displayed while stripping out

--- a/packages.txt
+++ b/packages.txt
@@ -1,7 +1,6 @@
 # Essential alpine packages
 awless@cloudposse
 aws-iam-authenticator@cloudposse
-aws-vault@cloudposse
 bash
 bash-completion
 bats@community

--- a/rootfs/etc/motd
+++ b/rootfs/etc/motd
@@ -1,7 +1,10 @@
 
 IMPORTANT:
-* Your $HOME directory has been mounted to `/localhost`
-* Use `aws-vault` to manage your sessions
-* Run `assume-role` to start a session
+* Your host $HOME directory has been mounted to `/localhost`.
+* Your host AWS configuration and credentials should be available.
+* Use Leapp on your host computer to manage your credentials.
+* Leapp is free, open source, and available from https://leapp.cloud
+* Use AWS_PROFILE environment variable to manage your AWS IAM role.
+* You can interactively select AWS profiles via the `assume-role` command.
 
 

--- a/rootfs/etc/profile.d/aws-okta.sh
+++ b/rootfs/etc/profile.d/aws-okta.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 
 if [ "${AWS_OKTA_ENABLED}" == "true" ]; then
+  echo
+	echo
+	red '* You have AWS_OKTA_ENABLED set to "true".'
+	red '* Cloud Posse no longer recommends using aws-okta and is'
+	red '* discontinuing support for aws-okta use inside Geodesic.'
+	red '* Cloud Posse recommends using Leapp to manage credentials'
+	red '* and the standard AWS config file and AWS_PROFILE'
+	red '* environment variable for switching roles.'
+	red '* Leapp is free and available from https://leapp.cloud'
+	red '* When AWS_OKTA_ENABLED is not set to true, the'
+	red '* assume-role command is available to allow you to'
+	red '* interactively set your AWS_PROFILE in a new shell.'
+	echo
+	echo
+
 	if ! which aws-okta >/dev/null; then
 		echo "aws-okta not installed"
 		exit 1

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -35,8 +35,8 @@ fi
 
 function aws_choose_role() {
 	_preview="${FZF_PREVIEW:-crudini --format=ini --get "$AWS_CONFIG_FILE" 'profile {}'}"
-	crudini --get "${AWS_CONFIG_FILE}" |
-		awk -F ' ' '{print $2}' |
+	cat "${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}" "${AWS_CONFIG_FILE:-~/.aws/config}" 2>/dev/null | \
+	crudini --get - | sed 's/^ *profile *//' | \
 		fzf \
 			--height 30% \
 			--preview-window right:70% \
@@ -45,7 +45,7 @@ function aws_choose_role() {
 			--prompt='-> ' \
 			--tiebreak='begin,index' \
 			--header 'Select AWS profile' \
-			--query "${ASSUME_ROLE_INTERACTIVE_QUERY:-${NAMESPACE}-${STAGE}-}" \
+			--query "${ASSUME_ROLE_INTERACTIVE_QUERY:-${NAMESPACE:+${NAMESPACE}-}${STAGE:+${STAGE}-}}" \
 			--preview "$_preview"
 }
 
@@ -61,13 +61,13 @@ function aws_sdk_assume_role() {
 	fi
 
 	local assume_role="${ASSUME_ROLE}"
-	trap '[[ -n $assume_role ]] && ASSUME_ROLE="$assume_role"' RETURN EXIT
 	ASSUME_ROLE="$role"
 	if [ $# -eq 0 ]; then
 		AWS_PROFILE="$role" bash -l
 	else
 		AWS_PROFILE="$role" $*
 	fi
+	ASSUME_ROLE="$assume_role";
 }
 
 # Asks AWS what the currently active identity is and

--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -5,6 +5,23 @@ BANNER_INDENT="${BANNER_INDENT:-    }"
 BANNER_FONT="${BANNER_FONT:-Nancyj.flf}" # " IDE parser fix
 
 if [ "${SHLVL}" == "1" ]; then
+  function _check_support() {
+		[[ $(arch) != "x86_64" ]] || grep -qs GenuineIntel /proc/cpuinfo && return
+		echo
+		echo
+		red '**********************************************************************'
+		red '**********************************************************************'
+		red '**                                                                  **'
+		red '**    You appear to be running Geodesic on an Apple M1 CPU          **'
+		red '**  Geodesic is not supported on the Apple M1 and has known issues  **'
+		red '**     See https://github.com/cloudposse/geodesic/issues/719        **'
+		red '**                                                                  **'
+		red '**********************************************************************'
+		red '**********************************************************************'
+		echo
+		echo
+  }
+
 	function _header() {
 		local vstring
 		local debian_version="/etc/debian_version"
@@ -31,6 +48,11 @@ if [ "${SHLVL}" == "1" ]; then
 			fi
 		fi
 	}
+	# We call _check_support twice so that the warning appears
+	# both above and below the banner
+	_check_support
 	_header
+	_check_support
+	unset _check_support
 	unset _header
 fi

--- a/rootfs/etc/profile.d/iterm.sh
+++ b/rootfs/etc/profile.d/iterm.sh
@@ -1,21 +1,22 @@
 # A badge is a large text label that appears in the top right of a terminal session to provide dynamic status
-set_badge() {
-	if [ "${TERM_PROGRAM}" == "iTerm.app" ]; then
-		# https://www.iterm2.com/documentation-badges.html
-		printf "\e]1337;SetBadgeFormat=%s\a" $(echo "$1" | base64)
+if [ "${TERM_PROGRAM}" == "iTerm.app" ]; then
+	# https://www.iterm2.com/documentation-badges.html
+	printf "\e]1337;SetBadgeFormat=%s\a" $(printf "%s" "${SHELL_NAME}" | base64)
+
+	## Display an exit greeting
+	function _geodesic_iterm_exit() {
+		local status=$?
+		# Clear the badge
+		printf "\e]1337;SetBadgeFormat=\a"
+		echo 'Goodbye'
+		exit $status
+	}
+
+	# Friendly exit greeting for interactive terminals, if exit trap not already set
+	if [[ -t 1 ]] && [[ -z "$(trap -p exit)" ]]; then
+		trap _geodesic_iterm_exit EXIT
 	fi
-}
-
-## Display an exit greeting
-function _exit() {
-	local status=$?
-	set_badge ""
-	echo 'Goodbye'
-	exit $status
-}
-
-# Friendly exit greeting for interactive terminals
-if [ -t 1 ]; then
-	trap _exit EXIT
-	set_badge "${SHELL_NAME}"
 fi
+
+
+

--- a/rootfs/etc/profile.d/motd.sh
+++ b/rootfs/etc/profile.d/motd.sh
@@ -1,4 +1,4 @@
-if [ -z "${ASSUME_ROLE}" ]; then
+if [[ $SHLVL -eq 1 ]]; then
 	if [ -f "/etc/motd" ]; then
 		cat "/etc/motd"
 	fi

--- a/rootfs/usr/local/bin/aws-config-setup
+++ b/rootfs/usr/local/bin/aws-config-setup
@@ -1,81 +1,8 @@
 #!/bin/bash
-export AWS_REGION="${AWS_REGION:-us-east-1}"
 
-if [ -z "${AWS_CONFIG_FILE}" ]; then
-	echo "AWS_CONFIG_FILE not defined"
-	exit 1
-fi
+echo
+echo 'This command used to help you configure aws-vault, but that is no longer supported.'
+echo 'We recommend you store, manage, and activate your AWS credentials with Leapp.'
+echo 'Leapp is free and open source. Get it from https://leapp.cloud'
+echo
 
-if [ -z "${AWS_DEFAULT_PROFILE}" ]; then
-	echo "AWS_DEFAULT_PROFILE not defined"
-	exit 1
-fi
-
-if [ -z "${AWS_ACCOUNT_ID}" ]; then
-	echo "AWS_ACCOUNT_ID not defined"
-	exit 1
-fi
-
-if [ -z "${AWS_ROOT_ACCOUNT_ID}" ]; then
-	echo "AWS_ROOT_ACCOUNT_ID not defined"
-	exit 1
-fi
-
-if [ ! -d "/localhost/.awsvault/" ] || [ ! -w "/localhost/.awsvault/" ]; then
-	echo "/localhost/.awsvault/ is not writable"
-	exit 1
-fi
-
-if [ -d "/localhost/.awsvault/keys/" ] && [ ! -w "/localhost/.awsvault/keys/" ]; then
-	echo "/localhost/.awsvault/keys/ is not writable"
-	exit 1
-fi
-
-if [ "${AWS_VAULT_BACKEND}" != "file" ]; then
-	echo "*"
-	echo "* WARNING: AWS_VAULT_BACKEND is \"${AWS_VAULT_BACKEND}\". Geodesic only supports AWS_VAULT_BACKEND=\"file\"."
-	echo "*"
-fi
-
-# Derive the source profile from the prefix of the default profile
-export AWS_SOURCE_PROFILE=$(echo ${AWS_DEFAULT_PROFILE} | cut -d- -f1)
-
-if [ "${AWS_SOURCE_PROFILE}" == "${AWS_DEFAULT_PROFILE}" ]; then
-	echo "AWS_DEFAULT_PROFILE should look like namespace-stage-role (e.g. eg-testing-admin)"
-	exit 1
-fi
-
-# Define empty source profile
-crudini --set --inplace ${AWS_CONFIG_FILE} "profile ${AWS_SOURCE_PROFILE}"
-
-# Define default profile
-crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" region "${AWS_REGION}"
-
-if [ "${AWS_ACCOUNT_ID}" == "${AWS_ROOT_ACCOUNT_ID}" ]; then
-	crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${AWS_DEFAULT_PROFILE}"
-else
-	crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" role_arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/OrganizationAccountAccessRole"
-fi
-
-# Prompt the user to setup MFA
-read -p "Use MFA? [y/n] " SETUP_MFA
-
-if [ "${SETUP_MFA}" == "y" ]; then
-	read -p "AWS IAM Username: " AWS_USERNAME
-	export AWS_MFA_SERIAL="arn:aws:iam::${AWS_ROOT_ACCOUNT_ID}:mfa/${AWS_USERNAME}"
-	crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial "${AWS_MFA_SERIAL}"
-else
-	crudini --del "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" mfa_serial
-fi
-
-# Reference the source profile settings
-crudini --set --inplace "${AWS_CONFIG_FILE}" "profile ${AWS_DEFAULT_PROFILE}" source_profile "${AWS_SOURCE_PROFILE}"
-
-# Prompt the user to setup their AWS credentials in aws-vault
-read -p "Setup AWS Credentials (aws-vault)? [y/n] " SETUP_VAULT
-
-if [ "${SETUP_VAULT}" == "y" ]; then
-	aws-vault add "${AWS_SOURCE_PROFILE}"
-fi
-
-echo "Configured AWS ${AWS_DEFAULT_PROFILE} profile for ${AWS_REGION} region in the ${AWS_ACCOUNT_ID} account"

--- a/rootfs/usr/local/bin/aws-region
+++ b/rootfs/usr/local/bin/aws-region
@@ -156,8 +156,6 @@ test() {
 	echo Passed
 }
 
-trap "unset -n abbr_map" EXIT RETURN
-
 if [[ $1 == "test" ]]; then
 	test
 elif [[ $1 =~ ^--?l ]]; then

--- a/rootfs/usr/local/bin/kubectl-auto-select
+++ b/rootfs/usr/local/bin/kubectl-auto-select
@@ -40,7 +40,7 @@ function normalize_version() {
 	# Customized Kubernetes versions, such as from AWS EKS, may have more than just the
 	# digits in the minor version, e.g. "16+", so strip out everything after leading digits,
 	# including patch version.
-	version=$(sed -E 's/((\d\.)?(\d+))([^d].*)?/\1/' <<<$version)
+	version=$(sed -E 's/(([0-9]\.)?([0-9]+))([^0-9].*)?/\1/' <<<$version)
 	[[ $version =~ ^1\. ]] || version="1.${version}"
 	echo "$version"
 }

--- a/rootfs/usr/local/bin/yaml-diff
+++ b/rootfs/usr/local/bin/yaml-diff
@@ -20,14 +20,8 @@ function yaml-diff() {
 	local new=$(mktemp)
 	trap "rm -rf $old $new" RETURN EXIT
 
-	local sort_array_filter='walk( if type == "array" then sort else . end )'
-	local filter="."
-
-	# TODO add a switch for this
-	false && filter="$sort_array_filter"
-
-	yq r -j "$1" | jq -S "$filter" | yq r - >"$old"
-	yq r -j "$2" | jq -S "$filter" | yq r - >"$new"
+	yq eval --no-colors 'sortKeys(..)' "$1" > "$old"
+	yq eval --no-colors 'sortKeys(..)' "$2" > "$new"
 
 	local color=never
 	[[ -t 1 ]] && color=always


### PR DESCRIPTION
## what & why
- Remove `aws-vault` from image, deprecate `aws-vault` and `aws-okta`, recommend [Leapp](https://leapp.cloud). Leapp is now our preferred solution for managing AWS credentials, and `aws sso` is our preferred command-line solution. `aws-vault` and `aws-okta` have issues and required a lot of specialized support that is not worth maintaining now that we have these superior solutions.
- Document that we are not yet supporting Geodesic on the Apple M1 chip. Add a warning when running Geodesic on M1. We know it doesn't work, we can't do anything about it now, our best recommendation is to stick with Intel CPUs for at least another 6 months.
- Update Google Cloud SDK 342.0.0 -> 352.0.0 (353 is current but has a breaking change, so we are waiting a while on that.)
- Update `kubectx` completion 0.9.3 -> 0.9.4
- Update `motd` (message of the day), dropping `aws-vault` workflow prompts and recommending Leapp. Prevent `motd` from displaying when launching subshells.
- Enhance `assume-role` to work with Leapp credentials as well as AWS config profiles. Fix `fzf` initial query when `NAMESPACE` or `STAGE` is not set
- Review scripts to remove/fix instances of scripts and functions clobbering existing `trap` settings. Scripts were clobbering both `RETURN` and `EXIT` traps, but they should now either not be overwriting existing traps or should be restoring the previous trap on `RETURN` or `EXIT`.
- Fix issue where `assume-role` launched a subshell with a new role, and when the shell exited, the parent shell prompt would still show the role active, even though it was not.
- Fix issue with `kubectl-auto-select` where it would have trouble parsing EKS Kubernetes versions and fail to select the correct corresponding version of `kubectl`. 
- Install `diffutils` (GNU `diff`) in Alpine so that `diff` in Alpine behaves like `diff` in Debian and scripts can count on consistent options. 
- Fix `yaml-diff`, which was expecting `yq` to be version 2.x and was completely broken by the substantial changes in the now current `yq` version 4.12.0