### PR TITLE
Feat: support tenant label in `eks-update-kubeconfig`

### DIFF
--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -40,10 +40,10 @@ EOF
 function profile_name() {
 	local profile_arg="${2:-${ASSUME_ROLE}}"
 	if [[ $TENANT_LABEL_ENABLED == true ]]; then
-	  printf "%s" "${NAMESPACE}-${1%%-*}-gbl-${1##*-}-${profile_arg##*-}"
-  else
-    printf "%s" "${NAMESPACE}-gbl-${1#*-}-${profile_arg##*-}"
-  fi
+		printf "%s" "${NAMESPACE}-${1%%-*}-gbl-${1##*-}-${profile_arg##*-}"
+	else
+		printf "%s" "${NAMESPACE}-gbl-${1#*-}-${profile_arg##*-}"
+	fi
 }
 
 function file_name() {
@@ -57,11 +57,11 @@ function short_region() {
   	if [[ $1 =~ ^[a-z]+$ ]]; then
   	  echo ${AWS_DEFAULT_SHORT_REGION}
   	else
-  	  if [[ $TENANT_LABEL_ENABLED == true ]]; then
-  	    printf "%s" "$1" | cut -f2 -d-
-  	  else
-  	    printf "%s" "$1" | cut -f1 -d-
-  	  fi
+  		if [[ $TENANT_LABEL_ENABLED == true ]]; then
+  			printf "%s" "$1" | cut -f2 -d-
+  		else
+  			printf "%s" "$1" | cut -f1 -d-
+  		fi
   	fi
 }
 
@@ -110,7 +110,7 @@ main() {
 		return 0
 	fi
 	if [[ $1 =~ ^[[:alnum:]]+-[[:alnum:]]+-[[:alnum:]]+$ ]]; then
-	  TENANT_LABEL_ENABLED=true
+		TENANT_LABEL_ENABLED=true
 	fi
 
 	local kubecfg="$(file_name $1 $role)"

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -30,7 +30,7 @@ Usage:
   context, override the EKS_KUBECONFIG_PATTERN environment variable such that it points to a single file, for example
   /config/.kube/config. Afterwards, a tool such as kubectx can be used to switch between contexts.
   If you chose to do this, remember that "off" deletes the entire kubeconfig file.
-  
+
   NOTE: This tool assumes you are using Cloud Posse's standard naming conventions:
   * Cluster name "uw2-corp" expands to "${NAMESPACE}-uw2-corp-eks-cluster"
   * Role name "admin" expands to "${NAMESPACE}-gbl-corp-admin"
@@ -40,6 +40,25 @@ Usage:
   * Role name "admin" expands to "${NAMESPACE}-acme-gbl-corp-admin"
 
 EOF
+}
+
+function tenant_enabled() {
+	# If atmos is at a version lower than 1.3.4, it will not support 'atmos config describe'.
+	# See: https://github.com/cloudposse/atmos/releases/tag/v1.3.4
+	atmos_min_version_describe_config="v1.3.4"
+	atmos_version="$(atmos version)"
+	if printf '%s\n%s\n' "${atmos_min_version_describe_config}" "${atmos_version}" | sort --check=quiet --version-sor; then
+		atmos describe config 2> /dev/null | jq -r '.Stacks.name_pattern' | grep tenant > /dev/null && true || false
+	else
+		cat <<- EOF && false
+		WARNING:
+		The current version of atmos is ${atmos_version}, and the minimum version required to determine if the 'tenant' label
+		is being used is ${atmos_min_version_describe_config}. Because of this, it is assumed 'tenant' is not used. If you would like to use the 'tenant' label,
+		update atmos to ${atmos_min_version_describe_config} or above.
+
+		EOF
+	fi
+	return
 }
 
 function profile_name() {
@@ -114,7 +133,7 @@ main() {
 		file_name $2 $role
 		return 0
 	fi
-	if [[ $1 =~ ^[^-]+-[^-]+-[^-]+$ ]]; then
+	if tenant_enabled; then
 		TENANT_LABEL_ENABLED=true
 	fi
 

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -10,6 +10,7 @@
 # We expect AWS_DEFAULT_SHORT_REGION was set in Dockerfile, and if not there,
 # then in aws.sh, but just in case...
 AWS_DEFAULT_SHORT_REGION=${AWS_DEFAULT_SHORT_REGION:-$(aws-region --${AWS_REGION_ABBREVIATION_TYPE} ${AWS_DEFAULT_REGION:-us-west-2})}
+TENANT_LABEL_ENABLED=false
 
 function usage() {
 	cat >&2 <<'EOF'
@@ -34,7 +35,11 @@ EOF
 
 function profile_name() {
 	local profile_arg="${2:-${ASSUME_ROLE}}"
-	printf "%s" "${NAMESPACE}-gbl-${1#*-}-${profile_arg##*-}"
+	if [[ $TENANT_LABEL_ENABLED == true ]]; then
+	  printf "%s" "${NAMESPACE}-${1%%-*}-gbl-${1##*-}-${profile_arg##*-}"
+  else
+    printf "%s" "${NAMESPACE}-gbl-${1#*-}-${profile_arg##*-}"
+  fi
 }
 
 function file_name() {
@@ -48,7 +53,11 @@ function short_region() {
   	if [[ $1 =~ ^[a-z]+$ ]]; then
   	  echo ${AWS_DEFAULT_SHORT_REGION}
   	else
-  	  printf "%s" "$1" | cut -f1 -d-
+  	  if [[ $TENANT_LABEL_ENABLED == true ]]; then
+  	    printf "%s" "$1" | cut -f2 -d-
+  	  else
+  	    printf "%s" "$1" | cut -f1 -d-
+  	  fi
   	fi
 }
 
@@ -95,6 +104,9 @@ main() {
 	if [[ $1 == "set-kubeconfig" ]]; then
 		file_name $2 $role
 		return 0
+	fi
+	if [[ $1 =~ ^[[:alnum:]]+-[[:alnum:]]+-[[:alnum:]]+$ ]]; then
+	  TENANT_LABEL_ENABLED=true
 	fi
 
 	local kubecfg="$(file_name $1 $role)"

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -26,7 +26,7 @@ Usage:
 
   With "off", deletes the currently active kubecfg file.
 
-  If it is desired to have single kubeconfig file with all contexts, as opposed to a separate kubeconfig file for each
+  If it is desired to have a single kubeconfig file with all contexts, as opposed to a separate kubeconfig file for each
   context, override the EKS_KUBECONFIG_PATTERN environment variable such that it points to a single file, for example
   /config/.kube/config. Afterwards, a tool such as kubectx can be used to switch between contexts.
 

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -26,6 +26,10 @@ Usage:
 
   With "off", deletes the currently active kubecfg file.
 
+  If it is desired to have single kubeconfig file with all contexts, as opposed to a separate kubeconfig file for each
+  context, override the EKS_KUBECONFIG_PATTERN environment variable such that it points to a single file, for example
+  /config/.kube/config. Afterwards, a tool such as kubectx can be used to switch between contexts.
+
   NOTE: This tool assumes you are using Cloud Posse's standard naming conventions:
   * Cluster name "uw2-corp" expands to "${NAMESPACE}-uw2-corp-eks-cluster"
   * Role name "admin" expands to "${NAMESPACE}-gbl-corp-admin"

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -29,7 +29,8 @@ Usage:
   If it is desired to have a single kubeconfig file with all contexts, as opposed to a separate kubeconfig file for each
   context, override the EKS_KUBECONFIG_PATTERN environment variable such that it points to a single file, for example
   /config/.kube/config. Afterwards, a tool such as kubectx can be used to switch between contexts.
-
+  If you chose to do this, remember that "off" deletes the entire kubeconfig file.
+  
   NOTE: This tool assumes you are using Cloud Posse's standard naming conventions:
   * Cluster name "uw2-corp" expands to "${NAMESPACE}-uw2-corp-eks-cluster"
   * Role name "admin" expands to "${NAMESPACE}-gbl-corp-admin"
@@ -113,7 +114,7 @@ main() {
 		file_name $2 $role
 		return 0
 	fi
-	if [[ $1 =~ ^[[:alnum:]]+-[[:alnum:]]+-[[:alnum:]]+$ ]]; then
+	if [[ $1 =~ ^[^-]+-[^-]+-[^-]+$ ]]; then
 		TENANT_LABEL_ENABLED=true
 	fi
 

--- a/rootfs/usr/local/bin/eks-update-kubeconfig
+++ b/rootfs/usr/local/bin/eks-update-kubeconfig
@@ -30,6 +30,10 @@ Usage:
   * Cluster name "uw2-corp" expands to "${NAMESPACE}-uw2-corp-eks-cluster"
   * Role name "admin" expands to "${NAMESPACE}-gbl-corp-admin"
 
+  NOTE: This tool supports using an optional "tenant" label (see: https://github.com/cloudposse/terraform-null-label):
+  * Cluster name "acme-uw2-corp" expands to "${NAMESPACE}-acme-uw2-corp-eks-cluster"
+  * Role name "admin" expands to "${NAMESPACE}-acme-gbl-corp-admin"
+
 EOF
 }
 


### PR DESCRIPTION
## what

* Support optional tenant label in `eks-update-kubeconfig`

## why

* `null-label` supports an optional `tenant` label, however `eks-update-kubeconfig` does not.
* Misc: add additional help documentation explaining how to have a single kubeconfig file with multiple contexts, rather than a separate file for each context.

## references

- https://github.com/cloudposse/terraform-null-label/releases/tag/0.25.0
- requires https://github.com/cloudposse/atmos/pull/71
- https://github.com/cloudposse/atmos/releases/tag/v1.3.4

## tests

**NOTE**: outdated, see comments below

### with tenant label

<details>
<summary>eks-update-kubeconfig mgmt-uw2-sandbox</summary>

```bash
Updated context arn:aws:eks:us-west-2:[REDACTED]:cluster/[REDACTED]-mgmt-uw2-sandbox-eks-cluster in /conf/.kube/kubecfg.mgmt-uw2-sandbox-admin
```
</details>

### without tenant label

<details>
<summary>eks-update-kubeconfig ue1-sandbox</summary>

```bash
Added new context arn:aws:eks:us-east-1:[REDACTED]:cluster/[REDACTED]-ue1-sandbox-eks-cluster to /conf/.kube/kubecfg.ue1-sandbox-admin
```
</details>