### PR TITLE
Fix #739 provide OS-specific instructions for installing docker

### DIFF
--- a/rootfs/etc/motd
+++ b/rootfs/etc/motd
@@ -1,7 +1,8 @@
 
 IMPORTANT:
-* Your host $HOME directory has been mounted to `/localhost`.
-* Your host AWS configuration and credentials should be available.
+* Unless there were errors reported above,
+* your host $HOME directory should be mounted to `/localhost`, and
+* your host AWS configuration and credentials should be available.
 * Use Leapp on your host computer to manage your credentials.
 * Leapp is free, open source, and available from https://leapp.cloud
 * Use AWS_PROFILE environment variable to manage your AWS IAM role.

--- a/rootfs/sbin/docker
+++ b/rootfs/sbin/docker
@@ -7,10 +7,23 @@ function green() {
 	echo "$(tput setaf 2)$*$(tput sgr0)"
 }
 
+if [[ $(command -v docker 2> /dev/null) != $(realpath "$0") ]]; then
+  red docker stub has detected real docker is installed. Execute
+  green "   hash -r"
+  red to inform your shell of the new docker binary
+  red
+  red "executing \"$(command -v docker) $*\""
+  exec $(command -v docker) "$@"
+fi
+
 red docker command not found.
 green To install:
-echo "    apk add docker-cli"
+echo "    $(install-docker-command)"
 echo
 green To inform your shell a new command has been installed
 echo "    hash -r"
 echo
+red Be sure you started Geodesic with the --with-docker option
+red or else you will not be able to connect to the Docker daemon socket
+echo
+

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -87,7 +87,7 @@ function use() {
 		# Note that the mounted /var/run/docker.sock is not a file or
 		# socket in the Mac host OS, it is in the dockerd VM.
 		# https://docs.docker.com/docker-for-mac/osxfs/#namespaces
-		echo "# Enabling docker support. Be sure you install a docker CLI binary (apk add docker-cli)."
+		echo "# Enabling docker support. Be sure you install a docker CLI binary{{getenv "DOCKER_INSTALL_PROMPT"}}."
 		DOCKER_ARGS+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
 		# Some reports say this is needed for Windows WSL
 		if [[ $(uname -r) =~ Microsoft$ ]]; then

--- a/rootfs/usr/local/bin/install-docker-command
+++ b/rootfs/usr/local/bin/install-docker-command
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Simple utility to output the correct command to use to install Docker on this OS
+
+source /etc/os-release
+
+if [[ $ID == "alpine" ]]; then
+  echo "apk add docker-cli"
+elif [[ $ID == "debian" ]]; then
+  echo "apt-get install -y docker.io"
+else
+  echo "Unknown OS $ID. Use Google to find how to install Docker on this OS."
+  exit 1
+fi

--- a/rootfs/usr/local/bin/wrapper
+++ b/rootfs/usr/local/bin/wrapper
@@ -1,2 +1,3 @@
 #!/bin/bash
+export DOCKER_INSTALL_PROMPT=" ($(install-docker-command))" || unset DOCKER_INSTALL_PROMPT
 gomplate -f /templates/wrapper


### PR DESCRIPTION
## what
- Fix #739 provide OS-specific instructions for installing `docker`

## why
- Previously, Geodesic provided instructions for installing `docker` on Alpine, even if it was running under Debian.