### PR TITLE
feat(wrapper): set workdir in docker similar to cwd at startup

### DIFF
--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -156,6 +156,12 @@ function use() {
 		echo "# Mounting ${local_home} into container"
 		DOCKER_ARGS+=(--volume=${local_home}:/localhost)
 		DOCKER_ARGS+=(--env LOCAL_HOME=${local_home})
+
+                if [[ ${PWD}/ = ${local_home}/* ]]; then
+                    work_dir="/localhost/${PWD#"$local_home"/}"
+                    echo "# Using $work_dir as workdir"
+                    DOCKER_ARGS+=(--workdir "$work_dir")
+                fi
 	fi
 
 	DOCKER_ARGS+=(--privileged


### PR DESCRIPTION
If $HOME is mounted into docker and the CWD is the inside $HOME, set the
docker workdir to be the same directory used when the wrapper was
called.