### PR TITLE
DEV-105: attempt to fix atmos.sh init script

### DIFF
--- a/rootfs/etc/init.d/atmos.sh
+++ b/rootfs/etc/init.d/atmos.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 # check if atmos base path is unset and verify that the stacks and components dir is in current directory
-if [ -z $ATMOS_BASE_PATH ] && [ -d "${GEODESIC_WORKDIR}/stacks" -a -d "${GEODESIC_WORKDIR}/components" ]; then
-  export ATMOS_BASE_PATH=${GEODESIC_WORKDIR}
-  echo "Set ATMOS_BASE_PATH = ${GEODESIC_WORKDIR}"
-fi
+function atmos-base {
+  local PATH=${1:-$PWD}
+  if [ -z $ATMOS_BASE_PATH ] && [ -d "$PATH/stacks" -a -d "$PATH/components" ]; then
+    # echo "Set ATMOS_BASE_PATH = ${PATH}"
+    export ATMOS_BASE_PATH="$PATH"
+  # else
+    # echo "Cannot find stacks/ and components/ in $PATH"
+  fi
+}
+
+atmos-base

--- a/rootfs/etc/init.d/atmos.sh
+++ b/rootfs/etc/init.d/atmos.sh
@@ -2,8 +2,8 @@
 
 # check if atmos base path is unset and verify that the stacks and components dir is in current directory
 function atmos-base {
-  local PATH=${1:-$PWD}
-  if [ -z $ATMOS_BASE_PATH ] && [ -d "$PATH/stacks" -a -d "$PATH/components" ]; then
+  local PATH="${1:-$PWD}"
+  if [ -z "$ATMOS_BASE_PATH" ] && [ -d "$PATH/stacks" -a -d "$PATH/components" ]; then
     # echo "Set ATMOS_BASE_PATH = ${PATH}"
     export ATMOS_BASE_PATH="$PATH"
   # else


### PR DESCRIPTION
## what

- [x] Removed echo statements since the string after the echo is interpretted as a command `bash: line 1: Set: command not found`
- [x] Turned this into a function so it can be easily called
- [x] Uses PWD instead of the unassigned GEODESIC_WORKDIR
- [ ] Should run when the container starts but doesn't... 

## why

* To deprecate /atmos_root, atmos now uses ATMOS_BASE_PATH env var natively but this needs to be set
* In the previous PR, we decided to set this env var to the PWD where Geodesic is started but ONLY if ATMOS_BASE_PATH is unset and ONLY if the dir contains both `stacks` and `components` dirs
* Current 0.148.0 (not pre-release) was published because I thought it was working but I had accidentally set this env var in my personal geodesic script instead of relying on 0.148.0's init.d script.

## commands

Returns nothing
```
$ make all
$ env | grep -i atmos
```

Manually sourcing from geodesic works as expected
```
$ source /etc/init.d/atmos.sh
$ env | grep -i atmos
ATMOS_BASE_PATH=/localhost/git/github/project/infra
```

when the container is first run, by `make all` or by wrapper, how come it doesn't run the `init.d` scripts ?

## references
* [DEV-105](https://cloudposse.atlassian.net/browse/DEV-105)
* Previous PR https://github.com/cloudposse/geodesic/pull/753