### PR TITLE
Configure atmos auto-completion, verify host filesystem detection

### DIFF
--- a/rootfs/etc/profile.d/_workdir.sh
+++ b/rootfs/etc/profile.d/_workdir.sh
@@ -14,10 +14,12 @@ function _file_device() {
 # Intended to support files on user-defined bind mounts in addition to `/localhost`.
 # This function is run by the command line prompt setup, so it should be very fast.
 # Therefore we cache some info in the environment.
-if df -a | grep -q /localhost; then
+if [[ $GEODESIC_LOCALHOST_DEVICE == "disabled" ]]; then
+	red "# Host filesystem device detection disabled."
+elif df -a | grep -q /localhost; then
 	export GEODESIC_LOCALHOST_DEVICE=$(_file_device /localhost)
 	if [[ $GEODESIC_LOCALHOST_DEVICE == $(_file_device /) ]]; then
-		red "# Host filesystem detection failed. Disabling HOST prompt."
+		red "# Host filesystem device detection failed. Falling back to \"path starts with /localhost\"."
 		GEODESIC_LOCALHOST_DEVICE="same-as-root"
 	fi
 else
@@ -25,9 +27,13 @@ else
 fi
 
 function file_on_host() {
-	[[ $GEODESIC_LOCALHOST_DEVICE != "same-as-root" ]] && \
-	[[ $GEODESIC_LOCALHOST_DEVICE != "missing" ]] && \
-	[[ $(_file_device "$1") == ${GEODESIC_LOCALHOST_DEVICE} ]]
+	if [[ $GEODESIC_LOCALHOST_DEVICE  =~ ^(disabled|missing)$ ]]; then
+		return 1
+	elif [[ $GEODESIC_LOCALHOST_DEVICE == "same-as-root" ]]; then
+		[[ $(readlink -e "$1") =~ ^/localhost(/.*)?$ ]]
+	else
+		[[ $(_file_device "$1") == ${GEODESIC_LOCALHOST_DEVICE} ]]
+	fi
 }
 
 function _default_initial_wd() {
@@ -46,7 +52,7 @@ if [[ -d $GEODESIC_WORKDIR ]]; then
 	[[ $SHLVL == 1 ]] && green "# Initial working directory configured as ${GEODESIC_WORKDIR}"
 else
 	if [[ -d $GEODESIC_HOST_CWD ]]; then
-		if [[ -n $LOCAL_HOME ]] && $(file_on_host "$GEODESIC_HOST_CWD"); then
+		if [[ -n $LOCAL_HOME ]] && { [[ $GEODESIC_LOCALHOST_DEVICE  == "disabled" ]] || $(file_on_host "$GEODESIC_HOST_CWD"); }; then
 			export GEODESIC_WORKDIR=$(readlink -e "${GEODESIC_HOST_CWD}")
 			green "# Initial working directory set from host CWD to ${GEODESIC_WORKDIR}"
 		else

--- a/rootfs/etc/profile.d/_workdir.sh
+++ b/rootfs/etc/profile.d/_workdir.sh
@@ -16,12 +16,18 @@ function _file_device() {
 # Therefore we cache some info in the environment.
 if df -a | grep -q /localhost; then
 	export GEODESIC_LOCALHOST_DEVICE=$(_file_device /localhost)
+	if [[ $GEODESIC_LOCALHOST_DEVICE == $(_file_device /) ]]; then
+		red "# Host filesystem detection failed. Disabling HOST prompt."
+		GEODESIC_LOCALHOST_DEVICE="same-as-root"
+	fi
 else
-	export GEODESIC_LOCALHOST_MISSING=true
+	export GEODESIC_LOCALHOST_DEVICE="missing"
 fi
 
 function file_on_host() {
-	[[ $GEODESIC_LOCALHOST_MISSING != "true" ]] && [[ $(_file_device "$1") == ${GEODESIC_LOCALHOST_DEVICE} ]]
+	[[ $GEODESIC_LOCALHOST_DEVICE != "same-as-root" ]] && \
+	[[ $GEODESIC_LOCALHOST_DEVICE != "missing" ]] && \
+	[[ $(_file_device "$1") == ${GEODESIC_LOCALHOST_DEVICE} ]]
 }
 
 function _default_initial_wd() {

--- a/rootfs/etc/profile.d/atmos.sh
+++ b/rootfs/etc/profile.d/atmos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function _configure_atmos_base_path() {
+function atmos_configure_base_path() {
 	# Leave $ATMOS_BASE_PATH alone if it is already set
 	if [[ -n $ATMOS_BASE_PATH ]]; then
 		if [[ $SHLVL == 1 ]]; then
@@ -31,8 +31,11 @@ function _configure_atmos_base_path() {
 	yellow "# No candidate for ATMOS_BASE_PATH found, leaving it unset"
 }
 
-# Only configure ATMOS_BASE_PATH if we find an `atmos` executable,
-# but otherwise leave the function available for the user to call explicitly.
+# Only configure ATMOS_BASE_PATH if we find an `atmos` executable.
+# Leave the function available for the user to call explicitly.
 # NOTE: If we start shipping `atmos` with Geodesic by default, change this to
-#   [[ -f /usr/local/etc/atmos/atmos.yaml ]] && _configure_atmos_base_path
-command -v atmos >/dev/null && _configure_atmos_base_path && unset -f _configure_atmos_base_path
+#   if [[ -f /usr/local/etc/atmos/atmos.yaml ]]; then
+if command -v atmos >/dev/null; then
+	atmos_configure_base_path
+	source <(atmos completion bash) || echo error setting up atmos auto-completion
+fi

--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -6,7 +6,7 @@ BANNER_FONT="${BANNER_FONT:-Nancyj.flf}" # " IDE parser fix
 
 if [ "${SHLVL}" == "1" ]; then
   function _check_support() {
-		[[ $(arch) != "x86_64" ]] || grep -qs GenuineIntel /proc/cpuinfo && return
+		[[ $(arch) != "x86_64" ]] || grep -qsE 'GenuineIntel|AuthenticAMD' /proc/cpuinfo && return
 		echo
 		echo
 		red '**********************************************************************'


### PR DESCRIPTION
## what
- Notify user when Geodesic cannot distinguish host file system from container file system by device name and fall back to parsing file system path.
- Distinguish AMD CPU from Apple M1
- Configure `atmos` auto-completion when `atmos` is installed.

## why
- On Fedora, for example, the host and container filesystems are on the same device. This means we cannot tell if another host path was bind mounted or not. In this situation, we fall back to reporting that files under `/localhost` are on the HOST and other files are not, which was the test we were previously. (The newer device-based test is to support developers who keep their development file tree outside of their home file tree.)
- We warn users about trying to run Geodesic on Apple M1, but the warning was being displayed when running on genuine AMD CPUs, which is wrong. Closes #757.
- Convenience.