### PR TITLE
Feat: Add `direnv allow` persistence between sessions

### DIFF
--- a/rootfs/etc/direnv/bash
+++ b/rootfs/etc/direnv/bash
@@ -7,10 +7,10 @@ unset BASH_ENV
 # Disable `direnv` output for scripts
 export DIRENV_LOG_FORMAT=
 
-# Allow current working directory (if we have permission)
-if [ -f .envrc ] && [ -w /etc/direnv/allow ]; then
-	direnv allow .
-fi
-
 # Process the `.envrc`
 eval "$(direnv export bash)"
+
+# Allow current working directory (if we have permission)
+if [ -f .envrc ] && [ -d /usr/share/xdg_data_home/direnv/allow ] && [ -w /usr/share/xdg_data_home/direnv/allow ]; then
+	direnv allow .
+fi

--- a/rootfs/etc/direnv/bash
+++ b/rootfs/etc/direnv/bash
@@ -11,6 +11,6 @@ export DIRENV_LOG_FORMAT=
 eval "$(direnv export bash)"
 
 # Allow current working directory (if we have permission)
-if [ -f .envrc ] && [ -d /usr/share/xdg_data_home/direnv/allow ] && [ -w /usr/share/xdg_data_home/direnv/allow ]; then
+if [ -f .envrc ] && [ -d /usr/share/xdg_data_home/direnv ] && [ -w /usr/share/xdg_data_home/direnv ]; then
 	direnv allow .
 fi

--- a/rootfs/etc/direnv/bash
+++ b/rootfs/etc/direnv/bash
@@ -7,10 +7,10 @@ unset BASH_ENV
 # Disable `direnv` output for scripts
 export DIRENV_LOG_FORMAT=
 
-# Process the `.envrc`
-eval "$(direnv export bash)"
-
 # Allow current working directory (if we have permission)
 if [ -f .envrc ] && [ -d /usr/share/xdg_data_home/direnv ] && [ -w /usr/share/xdg_data_home/direnv ]; then
 	direnv allow .
 fi
+
+# Process the `.envrc`
+eval "$(direnv export bash)"

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -110,6 +110,11 @@ function use() {
 		if [ -f "${geodesic_default_env_file}" ]; then
 			DOCKER_ARGS+=(--env-file=${geodesic_default_env_file})
 		fi
+		# persist direnv between sessions by putting in $HOME/.geodesic/direnv folder
+		local geodesic_folder="$(dirname "$geodesic_default_env_file")"
+		local geodesic_direnv_folder=${geodesic_folder}/direnv
+		mkdir -p $geodesic_direnv_folder
+		DOCKER_ARGS+=(--volume="$geodesic_direnv_folder:/usr/share/xdg_data_home/direnv")
 	else
 		echo "# Disabling user customizations: GEODESIC_CUSTOMIZATION_DISABLED is set and not 'false'"
 		DOCKER_ARGS+=(--env GEODESIC_CUSTOMIZATION_DISABLED)


### PR DESCRIPTION
## what

* Enables persistence of `direnv allow`  between sessions by dedicating `$HOME/.geodesic/direnv` to `/usr/share/xdg_data_home/direnv` in the container

## why

* `direnv allow` is not persisted between sessions