### PR TITLE
Fix: show prompt even if you are not using `kube-ps1`

### DIFF
--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -153,8 +153,13 @@ function geodesic_prompt() {
 		KUBE_PS1_KUBECONFIG_CACHE=""
 	fi
 
+	local kube_prompt=""
+	if typeset -f "${kube_ps1}" > /dev/null; then
+		kube_prompt="$(kube_ps1)"
+	fi
+
 	if [ -n "${BANNER}" ]; then
-		PS1=$' ${BANNER_MARK}'" ${BANNER} $(kube_ps1)${secrets_active}\n${tf_prompt}${dir_prompt}"
+		PS1=$' ${BANNER_MARK}'" ${BANNER} ${kube_prompt}${secrets_active}\n${tf_prompt}${dir_prompt}"
 	else
 		PS1="${tf_prompt}${dir_prompt}"
 	fi


### PR DESCRIPTION
## what

* Only attempt to print `kube_ps1` in prompt if you are using `kube-ps1`.

## why

* For non-kubernetes users, we sometimes encounter `kube_ps1 not found`.
