### PR TITLE
Feat: Better SSH Socket Support via `ssh-agent` (Linux Host)

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y apt-utils
 
 # Install the packages that are needed to build python3
 RUN apt-get update && apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
-    libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev
+    libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev socat
 
 # Download the Python source code
 RUN curl -1sLfO https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz && \

--- a/rootfs/etc/profile.d/ssh-agent.sh
+++ b/rootfs/etc/profile.d/ssh-agent.sh
@@ -1,6 +1,7 @@
 export SSH_KEY="${SSH_KEY:-/localhost/.ssh/id_rsa}"
 
 if [ "$SSH_AUTH_SOCK_HOST" != "" ]; then
+		# https://gist.github.com/d11wtq/8699521?permalink_comment_id=3878388#gistcomment-3878388
     export SSH_AUTH_SOCK="/var/tmp/ssh-geouser"
     sudo socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork,user=geouser,group=geouser,mode=777 UNIX-CONNECT:$SSH_AUTH_SOCK_HOST  &
     echo "Looks like we have a host ssh-agent socket at $SSH_AUTH_SOCK_HOST. Mapping to user socket at $SSH_AUTH_SOCK"

--- a/rootfs/etc/profile.d/ssh-agent.sh
+++ b/rootfs/etc/profile.d/ssh-agent.sh
@@ -1,10 +1,40 @@
 export SSH_KEY="${SSH_KEY:-/localhost/.ssh/id_rsa}"
 
-# Attempt Re-use existing agent if one exists
-if [ -f "${SSH_AGENT_CONFIG}" ]; then
-	echo "* Found SSH agent config"
-	. "${SSH_AGENT_CONFIG}"
+if [ "$SSH_AUTH_SOCK_HOST" != "" ]; then
+    export SSH_AUTH_SOCK="/var/tmp/ssh-geouser"
+    sudo socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork,user=geouser,group=geouser,mode=777 UNIX-CONNECT:$SSH_AUTH_SOCK_HOST  &
+    echo "Looks like we have a host ssh-agent socket at $SSH_AUTH_SOCK_HOST. Mapping to user socket at $SSH_AUTH_SOCK"
 fi
+
+function _load_sshagent_env() {
+  [[ -r "${SSH_AGENT_CONFIG}" ]] && eval "$(<${SSH_AGENT_CONFIG})" >/dev/null
+}
+
+function _launch_sshagent() {
+  (umask 066; ssh-agent > "${SSH_AGENT_CONFIG}")
+}
+
+function _ensure_sshagent_dead() {
+  killall ssh-agent &> /dev/null
+  rm -f "${SSH_AGENT_CONFIG}"
+}
+
+function _ensure_valid_sshagent_env() {
+  ssh-add -l &>/dev/null
+  if [[ $? -gt 1 ]]; then
+    # Could not open a connection to your authentication agent.
+
+    _load_sshagent_env
+    ssh-add -l &>/dev/null
+    if [[ $? -gt 1 ]]; then
+        # Start agent and store agent connection info.
+        _ensure_sshagent_dead
+        _launch_sshagent
+    fi
+  fi
+  _load_sshagent_env
+  return
+}
 
 trap ctrl_c INT
 
@@ -14,18 +44,15 @@ function ctrl_c() {
 	rm -f "${SSH_AUTH_SOCK}"
 }
 
-# Otherwise launch a new agent
-if [ -z "${SSH_AUTH_SOCK}" ] || ! [ -e "${SSH_AUTH_SOCK}" ]; then
-	ssh-agent | grep -v '^echo' >"${SSH_AGENT_CONFIG}"
-	. "${SSH_AGENT_CONFIG}"
+_ensure_valid_sshagent_env
 
-	# Add keys (if any) to the agent
-	if [ -n "${SSH_KEY}" ] && [ -f "${SSH_KEY}" ]; then
-		echo "Add your local private SSH key to the key chain. Hit ^C to skip."
-		ssh-add "${SSH_KEY}"
-	fi
+# Add keys (if any) to the agent
+if [ -n "${SSH_KEY}" ] && [ -f "${SSH_KEY}" ]; then
+    echo "Add your local private SSH key to the key chain. Hit ^C to skip."
+    ssh-add "${SSH_KEY}"
 fi
 
 # Clean up
 trap - INT
 unset -f ctrl_c
+

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -61,15 +61,28 @@ function use() {
 
 		if [ -n "$SSH_AUTH_SOCK" ]; then
 			if [ "${OS}" == 'Linux' ]; then
+				if [ "${SSH_AUTH_SOCK:0:4}" == "/tmp" ]; then
+					echo "The ssh-agent socket at ${SSH_AUTH_SOCK} is in your /tmp folder and does not map to Docker"
+					echo "Start your ssh-agent with 'TMPDIR=/var/tmp ssh-agent'"
+					echo "or something like this in your ~/.bashrc script:"
+					echo '(umask 066; ssh-agent -a $(mktemp -d -t ssh-XXXXXXXXXX --tmpdir=/var/tmp)/agent.$$ > "${SSH_AGENT_ENV}")'
+				else
 				# Bind-mount SSH agent socket into container (linux only)
-				DOCKER_ARGS+=(--volume "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
-					--env SSH_AUTH_SOCK
+					local HOST_SOCK_DIR="$(dirname $SSH_AUTH_SOCK)"
+					local HOST_SOCK_NAME="$(basename $SSH_AUTH_SOCK)"
+					local DOCKER_SSH_FOLDER="/var/tmp"
+					local DOCKER_SSH_HOST_DIR="$DOCKER_SSH_FOLDER/host"
+					local DOCKER_SSH_HOST_SOCKET="$DOCKER_SSH_HOST_DIR/$HOST_SOCK_NAME"
+					DOCKER_ARGS+=(--volume="$HOST_SOCK_DIR:$DOCKER_SSH_HOST_DIR"
+						--env SSH_AUTH_SOCK_HOST="$DOCKER_SSH_HOST_SOCKET"
 					--env SSH_CLIENT
 					--env SSH_CONNECTION
 					--env SSH_TTY
 					--env USER
 					--env USER_ID
 					--env GROUP_ID)
+					echo "# Binding your SSH_AUTH_SOCK of $SSH_AUTH_SOCK to $DOCKER_SSH_HOST_SOCKET"
+				fi
 			elif [ "${OS}" == 'Darwin' ] && [ "${GEODESIC_MAC_FORWARD_SOCKET}" == 'true' ]; then
 				# Bind-mount SSH-agent socket (available in docker-for mac Edge 2.2 release)
 				# Note that the file/socket /run/host-services/ssh-auth.sock does not exist


### PR DESCRIPTION
## what

This fixes firing up `ssh-agent` properly by testing two conditions:
* First, attempt to list added keys using `ssh-add -l &>/dev/null`.  If this returns an error of 2, we can't communicate with the agent
* Next, load the environment (if it exists) and repeat the above test.
If these fail, then restart the ssh-agent

Additionally, only map `SSH_AUTH_SOCK` from a real folder.  `/tmp` will not properly map into docker and results in being unable to access the socket.

Finally, if on Linux and using `SSH_AUTH_SOCK` _and_ you are not running as root (an upcoming PR), you have to map the host socket using `socat` to access the host folder as `root`. 

## why

* `ssh-agent` functionality is not robust enough (see above)
