### PR TITLE
Portability fixes

### DIFF
--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -90,8 +90,8 @@ else
 	exit 1
 fi
 
-hash -r || true
-if [ "$(realpath "${INSTALL_PATH}/${APP_NAME}")" != "$(command -v "${APP_NAME}" 2>/dev/null)" ]; then
+command -v hash 2>/dev/null && hash -r  # forget hashed location of $APP_NAME
+if [ ! "${INSTALL_PATH}/${APP_NAME}" -ef "$(command -v "${APP_NAME}" 2>/dev/null)" ]; then
 	if [ -x "${INSTALL_PATH}/${APP_NAME}" ]; then
 		if [ -n "$(command -v "${APP_NAME}" 2>/dev/null)" ]; then
 			echo "# WARNING: \`${APP_NAME}\` installed in ${INSTALL_PATH} but"


### PR DESCRIPTION
## what && why
Fix non-portable constructs so that Geodesic build, install, and run work on as many hosts as possible
- Replace path equivalency testing with file equivalency testing, because the `-ef` test is specified in POSIX but `realpath` is not and is not that widely distributed (competes withe `readlink`). 