### PR TITLE
Preserve history in assume-role, prevent `make all` from attaching to old container

### DIFF
--- a/rootfs/etc/profile.d/aws-okta.sh
+++ b/rootfs/etc/profile.d/aws-okta.sh
@@ -63,7 +63,12 @@ if [ "${AWS_OKTA_ENABLED}" == "true" ]; then
 
 		shift
 		if [ $# -eq 0 ]; then
+			history -a # append history to file so it is available in subshell
 			aws-okta exec ${AWS_OKTA_ARGS[@]} $role -- bash -l
+			# read history from the subshell into the parent shell
+			# history -n does not work when HISTFILESIZE > HISTSIZE
+			history -c
+			history -r
 		else
 			aws-okta exec ${AWS_OKTA_ARGS[@]} $role -- $*
 		fi

--- a/rootfs/etc/profile.d/aws-vault.sh
+++ b/rootfs/etc/profile.d/aws-vault.sh
@@ -279,7 +279,12 @@ else
 		shift
 		[[ "${AWS_VAULT_SERVER_ENABLED:-false}" == "true" ]] && export AWS_VAULT_SERVER_DISABLED="${AWS_VAULT_SERVER_DISABLED:-server already started}"
 		if [ $# -eq 0 ]; then
+			history -a # append history to file so it is available in subshell
 			aws-vault exec ${AWS_VAULT_ARGS[@]} $role -- bash -l
+			# read history from the subshell into the parent shell
+			# history -n does not work when HISTFILESIZE > HISTSIZE
+			history -c
+			history -r
 		else
 			aws-vault exec ${AWS_VAULT_ARGS[@]} $role -- $*
 		fi

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -63,7 +63,12 @@ function aws_sdk_assume_role() {
 	local assume_role="${ASSUME_ROLE}"
 	ASSUME_ROLE="$role"
 	if [ $# -eq 0 ]; then
+		history -a # append history to file so it is available in subshell
 		AWS_PROFILE="$role" bash -l
+		# read history from the subshell into the parent shell
+		# history -n does not work when HISTFILESIZE > HISTSIZE
+		history -c
+		history -r
 	else
 		AWS_PROFILE="$role" $*
 	fi

--- a/rootfs/etc/profile.d/set-cluster.sh
+++ b/rootfs/etc/profile.d/set-cluster.sh
@@ -4,7 +4,7 @@
 #   set-cluster <cluster-short-name>|off
 #
 #   With <cluster-short-name> updates the kubecfg file for the cluster with that short name (e.g. "corp")
-#   and updates KUBECONFIG to point ot that file.
+#   and updates KUBECONFIG to point to that file.
 
 #   With "off", deletes the currently active kubecfg file and unsets KUBECONFIG
 #


### PR DESCRIPTION
## what

* Preserve history in assume-role
* Prevent `make all` from attaching to old container

## why

* Better user experience if command history from top-level shell is available in subshell and vice versa
* Users get confused when `make all` succeeds but their shell does not include the latest changes
