### PR TITLE
Update Debian, Alpine, etc, Preserve PATH

### DIFF
--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,7 +1,7 @@
 # https://alpinelinux.org/
-ARG ALPINE_VERSION=3.15.4
+ARG ALPINE_VERSION=3.16.2
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=385.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=401.0.0
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.4
 # https://github.com/jonmosco/kube-ps1/releases
@@ -11,12 +11,12 @@ ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
-ARG HELM_DIFF_VERSION=3.4.2
+ARG HELM_DIFF_VERSION=3.5.0
 # https://github.com/aslafy-z/helm-git/releases
 # We had issues with helm-diff 3.1.3 + helm-git 0.9.0,
 # previous workaround was to pin helm-git to version 0.8.1.
 # We expect this has been fixed now with helm-diff 3.3.2 + helm-git 0.11.1
-ARG HELM_GIT_VERSION=0.11.1
+ARG HELM_GIT_VERSION=0.11.2
 
 #
 # Python Dependencies

--- a/os/alpine/packages-alpine.txt
+++ b/os/alpine/packages-alpine.txt
@@ -3,7 +3,7 @@ busybox-extras
 diffutils
 drill
 fuse
-fzf-bash-completion
+# fzf-bash-completion # not available in Alpine 3.16
 iputils
 keybase-client@testing
 libc6-compat

--- a/os/alpine/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/os/alpine/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.30
+@version: 3.36
 
 options {
     use_dns(no);

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -1,7 +1,7 @@
 # https://www.debian.org/releases/
-ARG DEBIAN_VERSION=11.3-slim
+ARG DEBIAN_VERSION=11.4-slim
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=385.0.0-0
+ARG GOOGLE_CLOUD_SDK_VERSION=401.0.0
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.4
 # https://github.com/jonmosco/kube-ps1/releases
@@ -11,12 +11,12 @@ ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
-ARG HELM_DIFF_VERSION=3.4.2
+ARG HELM_DIFF_VERSION=3.5.0
 # https://github.com/aslafy-z/helm-git/releases
 # We had issues with helm-diff 3.1.3 + helm-git 0.9.0,
 # previous workaround was to pin helm-git to version 0.8.1.
 # We expect this has been fixed now with helm-diff 3.3.2 + helm-git 0.11.1
-ARG HELM_GIT_VERSION=0.11.1
+ARG HELM_GIT_VERSION=0.11.2
 
 
 FROM debian:$DEBIAN_VERSION as python
@@ -139,7 +139,7 @@ RUN apt-get update && apt-get install -y \
 ARG GOOGLE_CLOUD_SDK_VERSION
 ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
 
-RUN apt-get update && apt-get install -y google-cloud-sdk=$GOOGLE_CLOUD_SDK_VERSION
+RUN apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_SDK_VERSION}-\*
 
 # gcloud config writes successful status updates to stderr, but we want to preserve
 # stderr for real errors in need of action.

--- a/os/debian/rootfs/etc/profile
+++ b/os/debian/rootfs/etc/profile
@@ -1,0 +1,61 @@
+# Modified copy of /etc/profile distributed with Debian 11.3
+# Changed to preserve PATH rather than set it.
+
+# /etc/profile: system-wide .profile file for the Bourne shell (sh(1))
+# and Bourne compatible shells (bash(1), ksh(1), ash(1), ...).
+
+# Comment out what Debian distributes that always resets the PATH
+# if [ "$(id -u)" -eq 0 ]; then
+#   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# else
+#   PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games"
+# fi
+# export PATH
+
+# Copy this from Alpine, which copied it from Arch Linux, to set the Debian path
+# while somewhat respecting the PATH set in the Dockerfile
+
+append_path () {
+	case ":$PATH:" in
+		*:"$1":*)
+			;;
+		*)
+			PATH="${PATH:+$PATH:}$1"
+			;;
+	esac
+}
+
+append_path "/usr/local/sbin"
+append_path "/usr/local/bin"
+append_path "/usr/sbin"
+append_path "/usr/bin"
+append_path "/sbin"
+append_path "/bin"
+unset -f append_path
+
+# End of modifications, the rest is the same as what Debian distributes
+
+if [ "${PS1-}" ]; then
+  if [ "${BASH-}" ] && [ "$BASH" != "/bin/sh" ]; then
+    # The file bash.bashrc already sets the default PS1.
+    # PS1='\h:\w\$ '
+    if [ -f /etc/bash.bashrc ]; then
+      . /etc/bash.bashrc
+    fi
+  else
+    if [ "$(id -u)" -eq 0 ]; then
+      PS1='# '
+    else
+      PS1='$ '
+    fi
+  fi
+fi
+
+if [ -d /etc/profile.d ]; then
+  for i in /etc/profile.d/*.sh; do
+    if [ -r $i ]; then
+      . $i
+    fi
+  done
+  unset i
+fi

--- a/rootfs/etc/profile.d/_30-geodesic-config.sh
+++ b/rootfs/etc/profile.d/_30-geodesic-config.sh
@@ -80,7 +80,7 @@ function _expand_dir_or_file() {
 	local -n expand_list=$1
 	local resource=$2
 	local dir=${3-${PWD}}
-	local default_exclusion_pattern="(~|.bak|.log|.old|.orig|.disabled)$"
+	local default_exclusion_pattern="(~|.bak|.log|.old|.orig|.txt|.md|.disabled)$"
 	local exclude="${GEODESIC_AUTO_LOAD_EXCLUSIONS:-$default_exclusion_pattern}"
 
 	[[ -n $_GEODESIC_TRACE_CUSTOMIZATION ]] && echo trace: looking for resources of type "$resource" in "$dir"

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -88,7 +88,7 @@ function export_current_aws_role() {
 
 	# Quick check, are we who we say we are?
 	local profile_arn
-	local profile_target=${AWS_PROFILE:-${AWS_VAULT}}
+	local profile_target=${AWS_PROFILE:-${AWS_VAULT:-default}}
 	if [[ -n $profile_target ]]; then
 		profile_arn=$(aws --profile "${profile_target}" sts get-caller-identity --output text --query 'Arn' 2>/dev/null | cut -d/ -f1-2)
 		if [[ $profile_arn == $current_role ]]; then

--- a/rootfs/etc/profile.d/banner.sh
+++ b/rootfs/etc/profile.d/banner.sh
@@ -2,6 +2,7 @@ COLOR_RESET="[0m"
 BANNER_COMMAND="${BANNER_COMMAND:-figurine}"
 BANNER_COLOR="${BANNER_COLOR:-[36m}"
 BANNER_INDENT="${BANNER_INDENT:-    }"
+# See font examples at http://www.figlet.org/examples.html
 BANNER_FONT="${BANNER_FONT:-Nancyj.flf}" # " IDE parser fix
 
 if [ "${SHLVL}" == "1" ]; then

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -11,7 +11,7 @@ export SCREEN_SIZE="${LINES}x${COLUMNS}"
 # in part because you cannot export an array or pass it to a child process.
 # However, not all the utilities we use support being managed through our PROMPT_HOOKS.
 # Some utilities (such as `direnv`) operate directly on the PROMPT_COMMAND variable, adding
-# themselves to it. Also, the PROMPT_COMMAND is inheritied by subshells, but we will be
+# themselves to it. Also, the PROMPT_COMMAND is inherited by subshells, but we will be
 # running this initialization script again in the subshell.
 # So we cannot just unthinkingly set PROMPT_COMMAND=prompter or PROMPT_COMMAND="${PROMPT_COMMAND};prompter"
 # Instead, we examine the PROMPT_COMMAND variable, initialize it to "prompter;" if it is empty,


### PR DESCRIPTION
## what
- Copy Alpine `PATH` initialization to Debian, replacing Debian behavior of clobbering preexisting `PATH`
- Update Debian 11.3 -> 11.4
- Update Alpine 3.15.4 -> 3.16.2
- Miscellaneous cleanups

## why
- Debian behavior is to ignore any existing value of `PATH` environment variable when launching `bash` and set it to a predefined value. This makes it impossible to set the `PATH` in the Dockerfile. Alpine's approach (taken from Arch Linux) is to append the path components to any existing `PATH` value, allowing users to set a preferred path, but still ensuring that all expected/required directories are included in `PATH` to start.
- Keep up-to-date
- Clean up little things that were nevertheless irritating

## references
- Supersedes and closes #790 
- Supersedes and closes #799 
