### PR TITLE
Build arm64 native image on MacOS m1

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -365,8 +365,14 @@ COPY docs/ /usr/share/docs/
 # Build man pages
 
 ## This throws error `#49 0.196 /bin/sh: 1: /usr/local/bin/docs: not found` on Mac m1 and I can't figure out why...
-RUN if [ "$(uname- m)" != 'aarch64']; then /usr/local/bin/docs update; fi
+RUN if [ "$ARCH" = "arm64" ]; then /usr/local/bin/docs update; fi
 
+# The `-slim` version of gomplate is not available for ARM 64 so we have to alter the DOWNLOAD_URL as the one in
+# `packages` repo is not compatible.
+RUN if [ "$ARCH" = "arm64" ] ; then \
+        cd packages && \
+        make -C install gomplate DOWNLOAD_URL='$(PACKAGE_REPO_URL)/releases/download/v$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(OS)-$(ARCH)' ; \
+    fi
 
 # Make sure that "user specific" directories we are sharing
 # are in fact available to all users

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -11,6 +11,9 @@ ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Multi platform support - override this arg with `arm64` string to build for Mac m1 for example
+ARG ARCH=amd64
+
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
 ARG HELM_DIFF_VERSION=3.6.0
@@ -28,6 +31,10 @@ ARG PYTHON_VERSION=3.10.8
 # Debian comes with minimal Locale support. See https://github.com/docker-library/docs/pull/703/files
 # Recommended: LC_ALL=C.UTF-8
 ENV LC_ALL=C.UTF-8
+
+# Multi platform support - override this arg with `arm64` string to build for Mac m1 for example
+ARG ARCH=amd64
+ENV ARCH=${ARCH}
 
 # Once again, Debian is weird. Package-installed Python is system-only, and does not
 # play well with pip. See  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=765022#30
@@ -70,6 +77,10 @@ RUN find / -name __pycache__ -exec rm -rf {} \; -prune
 # Geodesic base image
 #
 FROM debian:$DEBIAN_VERSION
+
+# Multi platform support - override this arg with `arm64` string to build for Mac m1 for example
+ARG ARCH=amd64
+ENV ARCH=${ARCH}
 
 ARG VERSION
 ENV GEODESIC_VERSION=$VERSION
@@ -128,15 +139,15 @@ RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY
 
 # If runnig Dokcer build on Macos m1:
 # Since the packages are not available for arm64 let's build them using sources from Cloudposse's `package` repository
-RUN if [ "$(uname -m)" = 'aarch64' ] ; then \
+RUN if [ "$ARCH" = "arm64" ] ; then \
         # Install commonly known packages from public Debian repo
         apt-get update && apt-get install -y $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/@(cloudposse|testing)/d' | sed -E 's/@community//g') && \
-        git clone https://github.com/SpotOnInc/packages.git -b fix-obsolete-packages && \
+        git clone https://github.com/cloudposse/packages.git && \
         cd packages && \
         # Packages with `@cloudposse` or `@testing` annotation have to be built from source
-        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/_amd64/d' | sed -nE 's/@(cloudposse|testing)//pg') ARCH=arm64 && \
+        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/_amd64/d' | sed -nE 's/@(cloudposse|testing)//pg') && \
         # # Packages ending with _amd64 have no arm64 equivalent
-        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/[@]?[a-zA-Z0-9]*_amd64//pg') ; \
+        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/[@]?[a-zA-Z0-9]*_amd64//pg') ARCH=amd64 ; \
     # On any other architecture proceed as usual. Packages will come from `https://dl.cloudsmith.io/public/cloudposse/packages/deb/debian bullseye main` repo.
     else \
         apt-get update && apt-get install -y \
@@ -171,7 +182,7 @@ RUN { gcloud config set core/disable_usage_reporting true --installation && \
 # RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 # This directory doesn't exist on arm64 I guess because the next command throws an error "Directory doesn't exist" so let's make it. 
-RUN if [ "$(uname -m)" = 'aarch64' ] ; then mkdir -p /etc/sysctl.d ; fi
+RUN if [ "$ARCH" = "arm64" ] ; then mkdir -p /etc/sysctl.d ; fi
 
 RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf
 
@@ -303,12 +314,12 @@ RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
 # ARG AWS_CLI_VERSION=2.2.8
 RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
     # We have to use platform-specific binary
-    if [ "$(uname -m)" = 'aarch64' ] ; then \
-        export ARCH='aarch64' ; \
+    if [ "$ARCH" = "arm64" ] ; then \
+        export AWS_ARCH='aarch64' ; \
     else \
-        export ARCH='x86_64' ; \
+        export AWS_ARCH='x86_64' ; \
     fi && \
-    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
+    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
     cd $AWSTMPDIR && \
     unzip -qq awscliv2.zip && \
     ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
@@ -329,12 +340,12 @@ ENV AWS_PAGER="less -FRX"
 
 # Install AWS Session Manager Plugin
 ARG SESSION_MANAGER_PLUGIN_VERSION
-RUN if [ "$(uname -m)" = 'aarch64' ] ; then \
-        export ARCH='arm64' ; \
+RUN if [ "$ARCH" = "arm64" ] ; then \
+        export  SESSION_MANAGER_PLUGIN_ARCH='arm64' ; \
     else \
-        export ARCH='64bit' ; \
+        export SESSION_MANAGER_PLUGIN_ARCH='64bit' ; \
     fi && \
-    curl -L "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${ARCH}/session-manager-plugin.deb" \
+    curl -L "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${SESSION_MANAGER_PLUGIN_ARCH}/session-manager-plugin.deb" \
     -o "/tmp/session-manager-plugin.deb" && \
     sudo dpkg -i /tmp/session-manager-plugin.deb && \
     rm /tmp/session-manager-plugin.deb

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -341,7 +341,8 @@ RUN if [ "$(uname -m)" = 'aarch64' ] ; then \
 # Install documentation
 COPY docs/ /usr/share/docs/
 
-# Can be useful on Mac m1 as `/usr/bin/variant1` doesn't exist after build
+# Can be useful on Mac m1 as `/usr/bin/variant1` doesn't exist after build.
+# I was thinking that will fix the `docs` issue below but it didn't...
 # RUN if [ "$(uname- m)" = 'aarch64']; then \
 #         cd packages && \
 #         INSTALL_PATH=/usr/bin make -C install variant && \

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -147,7 +147,10 @@ RUN if [ "$ARCH" = "arm64" ] ; then \
         # Packages with `@cloudposse` or `@testing` annotation have to be built from source
         make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/_amd64/d' | sed -nE 's/@(cloudposse|testing)//pg') && \
         # # Packages ending with _amd64 have no arm64 equivalent
-        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/[@]?[a-zA-Z0-9]*_amd64//pg') ARCH=amd64 ; \
+        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/[@]?[a-zA-Z0-9]*_amd64//pg') ARCH=amd64 && \
+        # The `-slim` version of gomplate is not available for ARM 64 so we have to alter the DOWNLOAD_URL as the one in
+        # `packages` repo is not compatible.
+        make -C install gomplate DOWNLOAD_URL='$(PACKAGE_REPO_URL)/releases/download/v$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(OS)-$(ARCH)' ; \
     # On any other architecture proceed as usual. Packages will come from `https://dl.cloudsmith.io/public/cloudposse/packages/deb/debian bullseye main` repo.
     else \
         apt-get update && apt-get install -y \
@@ -365,14 +368,7 @@ COPY docs/ /usr/share/docs/
 # Build man pages
 
 ## This throws error `#49 0.196 /bin/sh: 1: /usr/local/bin/docs: not found` on Mac m1 and I can't figure out why...
-RUN if [ "$ARCH" = "arm64" ]; then /usr/local/bin/docs update; fi
-
-# The `-slim` version of gomplate is not available for ARM 64 so we have to alter the DOWNLOAD_URL as the one in
-# `packages` repo is not compatible.
-RUN if [ "$ARCH" = "arm64" ] ; then \
-        cd packages && \
-        make -C install gomplate DOWNLOAD_URL='$(PACKAGE_REPO_URL)/releases/download/v$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(OS)-$(ARCH)' ; \
-    fi
+RUN if [ "$ARCH" != "arm64" ]; then /usr/local/bin/docs update; fi
 
 # Make sure that "user specific" directories we are sharing
 # are in fact available to all users

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -9,6 +9,8 @@ ARG KUBE_PS1_VERSION=0.7.0
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#plugin-version-history
 ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
 ARG HELM_DIFF_VERSION=3.5.0
@@ -43,11 +45,8 @@ ENV LC_ALL=C.UTF-8
 
 RUN rm -rf /usr/local && mkdir /usr/local
 
-# Preload apt-utils
-RUN apt-get update && apt-get install -y apt-utils
-
-# Install the packages that are needed to build python3
-RUN apt-get update && apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
+# Preload apt-utils & Install the packages that are needed to build python3
+RUN apt-get update && apt-get install -y apt-utils build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
     libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev
 
 # Download the Python source code

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -127,9 +127,22 @@ RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/cfg/setup/ba
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
-RUN apt-get update && apt-get install -y \
-    $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing)//g' ) && \
-    mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
+# If runnig Dokcer build on Macos m1:
+# Since the packages are not available for arm64 let's build them using sources from Cloudposse's `package` repository
+RUN if [ "$(uname -m)" = 'aarch64' ] ; then \
+        # Install commonly known packages from public Debian repo
+        apt-get update && apt-get install -y $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/@(cloudposse|testing)/d' | sed -E 's/@community//g') && \
+        git clone https://github.com/cloudposse/packages.git && \
+        cd packages && \
+        # Packages with `@cloudposse` or `@testing` annotation have to be built from source
+        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/@(cloudposse|testing)//pg'); \
+    # On any other architecture proceed as usual. Packages will come from `https://dl.cloudsmith.io/public/cloudposse/packages/deb/debian bullseye main` repo.
+    else \
+        apt-get update && apt-get install -y \
+            $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing)//g' ) ; \
+    fi
+
+RUN mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
     touch /conf/.gitconfig
 
 #
@@ -155,6 +168,9 @@ RUN { gcloud config set core/disable_usage_reporting true --installation && \
 # we had a compelling reason to need en_US.UTF-8, we could install the
 # "locales" package and run the following command:
 # RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+# This directory doesn't exist on arm64 I guess because the next command throws an error "Directory doesn't exist" so let's make it. 
+RUN if [ "$(uname -m)" = 'aarch64' ] ; then mkdir -p /etc/sysctl.d ; fi
 
 RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf
 
@@ -285,7 +301,13 @@ RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
 # but it is updated several times a week, so we choose to just get the latest.
 # ARG AWS_CLI_VERSION=2.2.8
 RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
-    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
+    # We have to use platform-specific binary
+    if [ "$(uname -m)" = 'aarch64' ] ; then \
+        export ARCH='aarch64' ; \
+    else \
+        export ARCH='x86_64' ; \
+    fi && \
+    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
     cd $AWSTMPDIR && \
     unzip -qq awscliv2.zip && \
     ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
@@ -306,7 +328,12 @@ ENV AWS_PAGER="less -FRX"
 
 # Install AWS Session Manager Plugin
 ARG SESSION_MANAGER_PLUGIN_VERSION
-RUN curl -L "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_64bit/session-manager-plugin.deb" \
+RUN if [ "$(uname -m)" = 'aarch64' ] ; then \
+        export ARCH='arm64' ; \
+    else \
+        export ARCH='64bit' ; \
+    fi && \
+    curl -L "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${ARCH}/session-manager-plugin.deb" \
     -o "/tmp/session-manager-plugin.deb" && \
     sudo dpkg -i /tmp/session-manager-plugin.deb && \
     rm /tmp/session-manager-plugin.deb
@@ -314,8 +341,19 @@ RUN curl -L "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION
 # Install documentation
 COPY docs/ /usr/share/docs/
 
+# Can be useful on Mac m1 as `/usr/bin/variant1` doesn't exist after build
+# RUN if [ "$(uname- m)" = 'aarch64']; then \
+#         cd packages && \
+#         INSTALL_PATH=/usr/bin make -C install variant && \
+#         mv /usr/bin/variant /usr/bin/variant1 ; \
+#     fi
+
+
 # Build man pages
-RUN /usr/local/bin/docs update
+
+## This throws error `#49 0.196 /bin/sh: 1: /usr/local/bin/docs: not found` on Mac m1 and I can't figure out why...
+RUN if [ "$(uname- m)" != 'aarch64']; then /usr/local/bin/docs update; fi
+
 
 # Make sure that "user specific" directories we are sharing
 # are in fact available to all users

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -131,14 +131,16 @@ RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY
 RUN if [ "$(uname -m)" = 'aarch64' ] ; then \
         # Install commonly known packages from public Debian repo
         apt-get update && apt-get install -y $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/@(cloudposse|testing)/d' | sed -E 's/@community//g') && \
-        git clone https://github.com/cloudposse/packages.git && \
+        git clone https://github.com/SpotOnInc/packages.git -b fix-obsolete-packages && \
         cd packages && \
         # Packages with `@cloudposse` or `@testing` annotation have to be built from source
-        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/@(cloudposse|testing)//pg'); \
+        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E '/_amd64/d' | sed -nE 's/@(cloudposse|testing)//pg') ARCH=arm64 && \
+        # # Packages ending with _amd64 have no arm64 equivalent
+        make -C install $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -nE 's/[@]?[a-zA-Z0-9]*_amd64//pg') ; \
     # On any other architecture proceed as usual. Packages will come from `https://dl.cloudsmith.io/public/cloudposse/packages/deb/debian bullseye main` repo.
     else \
         apt-get update && apt-get install -y \
-            $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing)//g' ) ; \
+            $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing).*//g' ) ; \
     fi
 
 RUN mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \

--- a/packages.txt
+++ b/packages.txt
@@ -1,10 +1,10 @@
 # Essential alpine packages
-awless@cloudposse
+awless@cloudposse_amd64
 aws-iam-authenticator@cloudposse
 bash
 bash-completion
 bats@community
-cfssl@cloudposse
+cfssl@cloudposse_amd64
 coreutils
 chamber@cloudposse
 curl
@@ -20,7 +20,7 @@ fuse
 fzf@cloudposse
 gettext
 git
-github-commenter@cloudposse
+github-commenter@cloudposse_amd64
 gomplate@cloudposse
 goofys@cloudposse
 gosu@cloudposse
@@ -53,10 +53,10 @@ pandoc@cloudposse
 postgresql-client
 pwgen
 python3
-rakkess@cloudposse
+rakkess@cloudposse_amd64
 rbac-lookup@cloudposse
 retry@cloudposse
-scenery@cloudposse
+scenery@cloudposse_amd64
 shellcheck@cloudposse
 shfmt@cloudposse
 sops@cloudposse
@@ -71,8 +71,8 @@ terraform@cloudposse
 # will cause problems for people who install one or the other
 terragrunt@cloudposse
 terrahelp@cloudposse
-tfenv@cloudposse
-tfmask@cloudposse
+tfenv@cloudposse_amd64
+tfmask@cloudposse_amd64
 unzip
 util-linux
 variant@cloudposse

--- a/packages.txt
+++ b/packages.txt
@@ -17,7 +17,7 @@ figlet
 figurine@cloudposse
 file
 fuse
-fzf@cloudposse
+fzf
 gettext
 git
 github-commenter@cloudposse_amd64

--- a/packages.txt
+++ b/packages.txt
@@ -61,6 +61,7 @@ shellcheck@cloudposse
 shfmt@cloudposse
 sops@cloudposse
 sshpass
+stern@cloudposse
 sudo
 syslog-ng
 tar

--- a/packages.txt
+++ b/packages.txt
@@ -61,7 +61,6 @@ shellcheck@cloudposse
 shfmt@cloudposse
 sops@cloudposse
 sshpass
-stern@cloudposse
 sudo
 syslog-ng
 tar


### PR DESCRIPTION
## what
* Dockerfile that you can actually build on Mac m1
* It's a Debian image (check "How to build" paragraph)
* since your cloudsmith docker repo doesn't have arm64 packages I used your [packages repo](https://github.com/cloudposse/packages) for packages installation that are not available in public repos
* looks like these packages are being installed in `/usr/local/bin` rather than `/usr/bin`
* the Dockerfile looks hacky at a glance. It definitely need some work to be pretty again. Populating the Debian repo with arm64 packages (and equivalent for Alpine) will definitely help.
* However, I didn't test all the functionality (just the bunch of commands I use everyday).
* geodesic prompt and `assume-role` works fine
* `/usr/local/bin/docs update` doesn't work during `docker build` phase (I described it in the Dockerfile)
* `/usr/bin/variant1` is missing.
* other things may be missing as well...

## why
* I made it out of curiosity if running the geodesic container in native (arm64) mode will be faster on my Mac m1 machine rather than keeping it in emulation mode
* I can't really say if it makes the difference as I just put it together and started using it.
* It's more like proof of concept for further development, however, it's usable

## references
* Looks like the discussion about this functionality is already in place https://github.com/cloudposse/geodesic/issues/719

## How to build:
```
sudo make -e DOCKER_BASE_OS=debian DOCKER_BUILD_FLAGS="--build-arg ARCH=arm64" build
```