### PR TITLE
Update scripts for yq v4 CLI changes

### DIFF
--- a/rootfs/usr/local/bin/codefresh-pipeline
+++ b/rootfs/usr/local/bin/codefresh-pipeline
@@ -84,9 +84,9 @@ function download_pipelines() {
 function convert_to_yaml() {
 	if [[ -n "$2" ]]; then
 		if [[ $2 == "-" ]]; then
-			yq r "$1"
+			yq -P "$1"
 		else
-			yq r "$1" >"$2"
+			yq -P "$1" >"$2"
 		fi
 	else
 		local subdirs="$3"
@@ -103,7 +103,7 @@ function convert_to_yaml() {
 			[[ -d "$project" ]] || mkdir -p "$project"
 			target="${project}/${target}"
 		fi
-		yq r "$1" >"$target"
+		yq -P "$1" >"$target"
 		green "* Wrote  ${target}"
 	fi
 }
@@ -118,7 +118,7 @@ function filter_pipeline() {
 function compare_pipeline() {
 	# Check that the pipeline file exists and is parseable
 	local status
-	yq r "$1" >/dev/null 2>&1
+	yq -P "$1" >/dev/null 2>&1
 	status=$?
 
 	if (($status == 1)); then
@@ -130,7 +130,7 @@ function compare_pipeline() {
 	fi
 
 	local name
-	name=$(yq r -j "$1" | jq -r .metadata.name) || {
+	name=$(yq -o=json "$1" | jq -r .metadata.name) || {
 		red "! Cannot find pipeline name in $1"
 		return 1
 	}
@@ -139,7 +139,7 @@ function compare_pipeline() {
 
 	if (
 		set -o pipefail
-		codefresh get pipeline --limit 1 -o json "$name" | filter_pipeline | yq r - >"$old"
+		codefresh get pipeline --limit 1 -o json "$name" | filter_pipeline | yq -P - >"$old"
 	); then
 		yaml-diff "$old" "$1"
 	else

--- a/rootfs/usr/local/bin/grafana-db
+++ b/rootfs/usr/local/bin/grafana-db
@@ -160,7 +160,7 @@ function parse_dashboard_definition() {
 		# Compact the JSON to a single line
 		jq -rc
 	else
-		yq r -j '-d*' - | jq -rc '.. | if .data? then (.data | to_entries | .[].value | fromjson) elif .json? then .json else empty end'
+		yq -o=json - | jq -rc '.. | if .data? then (.data | to_entries | .[].value | fromjson) elif .json? then .json else empty end'
 	fi
 }
 

--- a/rootfs/usr/local/bin/helm3-metadata-fix
+++ b/rootfs/usr/local/bin/helm3-metadata-fix
@@ -40,7 +40,7 @@ function main() {
 
 	trap "rm -f $temp" EXIT
 
-	helm -n $namespace get manifest $release | yq r -j '-d*' - |
+	helm -n $namespace get manifest $release | yq -o=json - |
 		jq -c "$jqfilter" >"$temp"
 
 	if kubectl -n $namespace diff -f "$temp"; then


### PR DESCRIPTION
## what
- Update scripts for `yq` v4 CLI changes

## why
- Some of our shell scripts use [yq](https://github.com/mikefarah/yq/), but the options and commands changed significantly from v2 (current when the scripts were written) to the now current (and installed in Geodesic) v4, causing the scripts to break. This PR updates the scripts to work with `yq` v4.

## references
- https://mikefarah.gitbook.io/yq/
- Supersedes and closes #806 