### PR TITLE
Configure SSH for AWS Session Manager, add zip

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -80,3 +80,4 @@ variant2@cloudposse
 vert@cloudposse
 vim
 yq@cloudposse
+zip

--- a/rootfs/etc/ssh/ssh_config
+++ b/rootfs/etc/ssh/ssh_config
@@ -17,6 +17,10 @@
 # list of available options, their meanings and defaults, please see the
 # ssh_config(5) man page.
 
+# SSH over AWS Session Manager
+host i-* mi-*
+    ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+
 # Host *
 #   ForwardAgent no
 #   ForwardX11 no


### PR DESCRIPTION
## what

- Configure SSH to use AWS Session Manager for connectivity to instances
- Install `zip`

## why

- AWS Session Manager allows for connectivity without requiring any inbound port access
- Standard tool required for creating certain AWS resources among other things

## references

- https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html

