### PR TITLE
Remove obsolete `boto` (replaced with `boto3`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cryptography==38.0.4
 PyYAML==5.4.1
 awscli==1.27.27
-boto==2.49.0
 boto3==1.26.27
 crudini==0.9.3


### PR DESCRIPTION
## what
- Remove obsolete `boto` (replaced with `boto3`)

## why

- `boto` requires Python 2 and installs dependencies that require Python 2 but we no longer install Python 2 so `boto` is just extra broken cruft.

## references

- Boto: [PyPi](https://pypi.org/project/boto/) [GitHub](https://github.com/boto/boto)
- Boto3 [PyPi](https://pypi.org/project/boto3/) [GitHub](https://github.com/boto/boto3)

