### PR TITLE
Install stubs for tools missing arm64 support

### DIFF
--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -109,13 +109,11 @@ ENV KOPS_CLUSTER_NAME=example.foo.bar
 USER root
 
 # install the cloudposse alpine repository
-ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-RUN echo "@cloudposse https://apk.cloudposse.com/3.13/vendor" >> /etc/apk/repositories
+RUN apk add --no-cache bash curl && \
+  curl -1sLf \
+  'https://dl.cloudsmith.io/public/cloudposse/packages/setup.alpine.sh' \
+  | bash
 
-# Use TLS for alpine default repos
-RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories && \
-    echo "@testing https://alpine.global.ssl.fastly.net/alpine/edge/testing" >> /etc/apk/repositories && \
-    echo "@community https://alpine.global.ssl.fastly.net/alpine/edge/community" >> /etc/apk/repositories
 
 ##########################################################################################
 # See Dockerfile.options for how to install `glibc` for greater compatibility, including #

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -112,7 +112,9 @@ USER root
 RUN apk add --no-cache bash curl && \
   curl -1sLf \
   'https://dl.cloudsmith.io/public/cloudposse/packages/setup.alpine.sh' \
-  | bash
+  | bash && \
+  printf "@cloudposse %s\n\n" "$(grep -h -v '^[@#]' /etc/apk/repositories | grep -F "public/cloudposse/packages" | head -1)" \
+  >> /etc/apk/repositories
 
 
 ##########################################################################################

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -116,6 +116,12 @@ RUN apk add --no-cache bash curl && \
   printf "@cloudposse %s\n\n" "$(grep -h -v '^[@#]' /etc/apk/repositories | grep -F "public/cloudposse/packages" | head -1)" \
   >> /etc/apk/repositories
 
+# Install the @community repo tag (community repo is already installed, but not tagged as @community)
+RUN printf "@community %s\n" "$(grep -E 'alpine/v[^/]+/community' /etc/apk/repositories | head -1)" >> /etc/apk/repositories
+
+# Install the @testing repo tag
+RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
 
 ##########################################################################################
 # See Dockerfile.options for how to install `glibc` for greater compatibility, including #

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -99,7 +99,7 @@ USER root
 # Keep dpkg quiet about running non-interactively
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-COPY packages.txt os/debian/packages-debian.txt /etc/apt/
+COPY packages.txt packages-amd64-only.txt os/debian/packages-debian.txt /etc/apt/
 
 ## Here is where we would copy in the repo checksum in an attempt to ensure updates bust the Docker build cache
 
@@ -261,6 +261,18 @@ COPY os/debian/rootfs/ /
 
 
 ARG TARGETARCH
+
+# For certain pagkage we like to have but are not available on arm64,
+# install them on amd64, and link to a stub script on arm64.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      apt-get update && apt-get install -y \
+      $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
+    else \
+      for pkg in $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); do \
+        ln  -s /usr/local/bin/no-arm64-support /usr/local/bin/$pkg; \
+      done; \
+    fi
+
 
 # Move AWS CLI v1 aside and install AWS CLI v2 as default, leaving both available as alternatives.
 # We do this at the end because we need cache busting from above to get us the latest AWS CLI v2

--- a/packages-amd64-only.txt
+++ b/packages-amd64-only.txt
@@ -1,0 +1,9 @@
+# These are packages that are only supported on amd64,
+# typically because they have not been updated since 2021.
+awless@cloudposse
+cfssl@cloudposse
+emailcli@cloudposse
+goofys@cloudposse
+rakkess@cloudposse
+tfenv@cloudposse
+tfmask@cloudposse

--- a/packages.txt
+++ b/packages.txt
@@ -12,7 +12,7 @@ direnv@community
 dumb-init
 emacs-nox
 fetch@cloudposse
-emailcli@cloudposse
+# no arm64 emailcli@cloudposse
 figlet
 figurine@cloudposse
 file
@@ -20,9 +20,9 @@ fuse
 fzf@cloudposse
 gettext
 git
-# no arm64 github-commenter@cloudposse
+github-commenter@cloudposse
 gomplate@cloudposse
-goofys@cloudposse
+#no arm64 support goofys@cloudposse
 gosu@cloudposse
 groff
 helm@cloudposse

--- a/rootfs/usr/local/bin/no-arm64-support
+++ b/rootfs/usr/local/bin/no-arm64-support
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+printf "$(tput setaf 1)%s is not supported on this platform (arm64)$(tput setaf 0)\n" "$(basename "$0")" >&2
+exit 1


### PR DESCRIPTION
## what
- For tools we have been including in Geodesic but that do not have `arm64` support:
   - Install the tool in the `amd4` versions of Geodesic
   - Install a stub script that explains the tool is missing due to lack of support

## why
* In #837, we removed all the tools without `arm64` support from both versions. However, those tools are used by scripts and commands we continue to include, and we do not know how important those are to the Geodesic community. This way, they will continue to work as before for `amd64` versions and will generate meaningful error messages (instead of generic "command not found" errors) in the `arm64` version. 

