### PR TITLE
Publish "latest" image to Docker hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
           TAGS="$TAGS,${{ github.repository }}:latest-${BASE_OS}"
           TAGS="$TAGS,${{ env.ECR_REGISTRY }}${{ github.repository }}:latest-${BASE_OS}"
           LATEST_TAGS="$TAGS,${{ github.repository }}:latest"
-          LATEST_TAGS="$TAGS,${{ env.ECR_REGISTRY }}${{ github.repository }}:latest"
+          LATEST_TAGS="$LATEST_TAGS,${{ env.ECR_REGISTRY }}${{ github.repository }}:latest"
         else
           LATEST_TAGS="$TAGS"
         fi


### PR DESCRIPTION
## what & why

Since Geodesic v1.8.0 we have published Docker images to `public.ecr.aws/cloudposse/geodesic` as well as Docker hub `cloudposse/geodesic`. However, due to a bug in our script, the `latest` tag was only being pushed to `public.ecr.aws` and Docker hub `latest` was stuck at `1.7.0-alpine`. 

When Geodesic v2.0.0 was released, we started tagging the Debian image as `latest` instead of the Alpine image, but due to the above bug, that only affected the `public.ecr.aws` repo, not the Docker hub rep. With this release, we restore updates of the `latest` tag to Docker hub, and consequently shift latest from Alpine to Debian there, too.

## references
- #825 

