### PR TITLE
Remove redundant --quiet option from docker command

### DIFF
--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -196,8 +196,8 @@ function use() {
 		)
 
 	trap run_exit_hooks EXIT
-	# the extra curly braces around .ID are because this file goes through go template substitution local before being installed as a shell script
-	container_id=$(docker ps --quiet --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
+	# the extra curly braces around .ID are because this file goes through go template substitution locally before being installed as a shell script
+	container_id=$(docker ps --filter name="^/${DOCKER_NAME}\$" --format '{{`{{ .ID }}`}}')
 	if [ -n "$container_id" ]; then
 		echo "# Attaching to existing ${DOCKER_NAME} session ($container_id)"
 		if [ $# -eq 0 ]; then


### PR DESCRIPTION
## what

- Remove `--quiet` option from Docker command that checks if Geodesic is already running

## why

- Starting with Docker CLI version 24.0.0, the `--quiet` option overrides the `--format` option. For backward compatibility, we prefer to continue to use the `--format` option, even thought the format is that same as that produced by v24 `--quiet`. 

## notes

Resolves warning on starting Geodesic:

```
WARNING: Ignoring custom format, because both --format and --quiet are set.
```

