### PR TITLE
Update labeler from v2.1.0 to v4

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v2.1.0
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## what

- Update labeler from v2.1.0 to v4

## why

- Labeler version prior to v4 run on obsolete node12.

## references

- Runners use [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/)
- [Labeler update](https://github.com/actions/labeler/releases/tag/v4.0.0) for node16
