### PR TITLE
Non-automatic tool updates

### DIFF
--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,17 +1,19 @@
 # https://alpinelinux.org/
 ARG ALPINE_VERSION=3.18.5
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=422.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=455.0.0
 # https://github.com/ahmetb/kubectx/releases
-ARG KUBECTX_COMPLETION_VERSION=0.9.4
+ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
 ARG KUBE_PS1_VERSION=0.8.0
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#plugin-version-history
 ARG SESSION_MANAGER_PLUGIN_VERSION=latest
+# https://bindfs.org/downloads/
+ARG BINDFS_VERSION=1.17.6
 
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
-ARG HELM_DIFF_VERSION=3.6.0
+ARG HELM_DIFF_VERSION=3.8.1
 # https://github.com/aslafy-z/helm-git/releases
 # We had issues with helm-diff 3.1.3 + helm-git 0.9.0,
 # previous workaround was to pin helm-git to version 0.8.1.
@@ -43,19 +45,21 @@ COPY requirements.txt /requirements.txt
 # so we have to install it on the "host" (which builds a wheel) before installing for the distribution.
 # As of 2022-05-15 PyYAML also requires the installation of Cython for some reason, although
 # it does not appear to actually use it. Seems like a build tool configuration issue,
-# so we were not pinning Cython or putting it in requrements.txt becuase Debian does not need it.
+# so we were not pinning Cython or putting it in requrements.txt because Debian does not need it.
 # As of 2023-07-21, we must pin Cython<3 for PyYaml <6
 # See https://github.com/yaml/pyyaml/issues/724
-# However, as of AWS CLI v1.29.4, we can use PyYaml 6.0.1, which solve the problem, and let us remove Cython.
+# However, as of AWS CLI v1.29.4, we can use PyYaml 6.0.1, which solves the problem, and lets us remove Cython.
 RUN python3 -m pip install --upgrade pip setuptools wheel && \
     pip install $(grep cryptography /requirements.txt) && \
     pip install -r /requirements.txt --ignore-installed --prefix=/dist --no-build-isolation --no-warn-script-location
 
 ### While we have gcc installed, we take advantage of that and build bindfs
-### Use fuse (FUSE 2) rather than fuse3 for consistency with Debian
-RUN apk add curl fuse fuse-dev
-RUN curl -qOsSL https://bindfs.org/downloads/bindfs-1.15.1.tar.gz
-RUN tar zxf bindfs-1.15.1.tar.gz && cd bindfs-1.15.1/ && \
+### We used to use fuse (FUSE 2) rather than fuse3 for consistency with Debian,
+### but Debian upgraded to Fuse 3 with Debian 11 ("bullseye"), so we are now using Fuse 3.
+RUN apk add curl fuse3 fuse3-dev
+ARG BINDFS_VERSION
+RUN curl -qOsSL https://bindfs.org/downloads/bindfs-${BINDFS_VERSION}.tar.gz
+RUN tar zxf bindfs-${BINDFS_VERSION}.tar.gz && cd bindfs-${BINDFS_VERSION}/ && \
     ./configure && make && make install
 
 #

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -45,7 +45,7 @@ COPY requirements.txt /requirements.txt
 # so we have to install it on the "host" (which builds a wheel) before installing for the distribution.
 # As of 2022-05-15 PyYAML also requires the installation of Cython for some reason, although
 # it does not appear to actually use it. Seems like a build tool configuration issue,
-# so we were not pinning Cython or putting it in requrements.txt because Debian does not need it.
+# so we were not pinning Cython or putting it in requirements.txt because Debian does not need it.
 # As of 2023-07-21, we must pin Cython<3 for PyYaml <6
 # See https://github.com/yaml/pyyaml/issues/724
 # However, as of AWS CLI v1.29.4, we can use PyYaml 6.0.1, which solves the problem, and lets us remove Cython.

--- a/os/alpine/packages-alpine.txt
+++ b/os/alpine/packages-alpine.txt
@@ -2,7 +2,6 @@
 busybox-extras
 diffutils
 drill
-fuse
 # fzf-bash-completion # not available in Alpine 3.16
 iputils
 keybase-client@testing

--- a/os/alpine/rootfs/etc/syslog-ng/syslog-ng.conf
+++ b/os/alpine/rootfs/etc/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.36
+@version: 4.1
 
 options {
     use_dns(no);

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -1,12 +1,18 @@
 # https://www.debian.org/releases/
-ARG DEBIAN_VERSION=11.8-slim
+# https://hub.docker.com/_/debian
+# We use codename (bullseye) instead of version number (11) because we want to select
+# the matching Python Docker image, which is named after the codename only.
+# bullseye-20231120 corresponds to Debian 11.8
+ARG DEBIAN_CODENAME=bullseye
+# Debian codenamed images are tagged with date codes rather than minor version numbers.
+ARG DEBAIN_DATECODE=20231120
 # Find the current version of Python at https://www.python.org/downloads/source/
-ARG PYTHON_VERSION=3.10.10
+ARG PYTHON_VERSION=3.11.6
 
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=422.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=455.0.0
 # https://github.com/ahmetb/kubectx/releases
-ARG KUBECTX_COMPLETION_VERSION=0.9.4
+ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
 ARG KUBE_PS1_VERSION=0.8.0
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#plugin-version-history
@@ -14,7 +20,7 @@ ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
-ARG HELM_DIFF_VERSION=3.6.0
+ARG HELM_DIFF_VERSION=3.8.1
 # https://github.com/aslafy-z/helm-git/releases
 # We had issues with helm-diff 3.1.3 + helm-git 0.9.0,
 # previous workaround was to pin helm-git to version 0.8.1.
@@ -22,7 +28,7 @@ ARG HELM_DIFF_VERSION=3.6.0
 ARG HELM_GIT_VERSION=0.15.1
 
 
-FROM python:$PYTHON_VERSION-slim-bullseye as python
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME} as python
 
 # Debian comes with minimal Locale support. See https://github.com/docker-library/docs/pull/703/files
 # Recommended: LC_ALL=C.UTF-8
@@ -54,7 +60,7 @@ RUN find / -name __pycache__ -exec rm -rf {} \; -prune
 #
 # Geodesic base image
 #
-FROM debian:$DEBIAN_VERSION
+FROM debian:${DEBIAN_CODENAME}-${DEBAIN_DATECODE}-slim
 
 ARG VERSION
 ENV GEODESIC_VERSION=$VERSION

--- a/packages.txt
+++ b/packages.txt
@@ -16,7 +16,7 @@ fetch@cloudposse
 figlet
 figurine@cloudposse
 file
-fuse
+fuse3
 fzf@cloudposse
 gettext
 git

--- a/rootfs/usr/local/bin/kubectl-auto-select
+++ b/rootfs/usr/local/bin/kubectl-auto-select
@@ -29,7 +29,7 @@ function usage() {
 # Output the normalized major and minor version number
 # 1. Remove any leading "v"
 # 2. If no dots, assume it is minor version with major version "1"
-function normalize_version() {
+function _normalize_version() {
 	[[ -n $1 ]] || return
 	if [[ $1 == "null" ]]; then
 		red "Unable to determine Kubernetes (kubectl) version"
@@ -45,13 +45,22 @@ function normalize_version() {
 	echo "$version"
 }
 
-function install() {
-	apk add -u kubectl-$(normalize_version "$1")@cloudposse
+function _install() {
+  if command -v apk >/dev/null 2>&1; then
+    apk update
+    apk add -u kubectl-$(_normalize_version "$1")@cloudposse
+  elif command -v apt-get >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y kubectl-$(_normalize_version "$1")-\*
+  else
+    red "Unable to install kubectl version $1"
+    exit 1
+  fi
 }
 
 # Output the major.minor version of the kubectl client
 function kubectl_mm_version() {
-	normalize_version $(kubectl version --client -o json 2>/dev/null | jq -r .clientVersion.minor)
+	_normalize_version $(kubectl version --client -o json 2>/dev/null | jq -r .clientVersion.minor)
 }
 
 # Output the git version of the kubectl client
@@ -65,7 +74,7 @@ function set_alternatives() {
 
 	if [[ ! -x /usr/share/kubectl/"${version}"/bin/kubectl-"${version}" ]]; then
 		if [[ $INSTALL == "true" ]]; then
-			apk add -u kubectl-${version}@cloudposse
+			_install "${version}"
 		else
 			red "kubectl version ${version} not installed."
 			red "Install it with $0 --install $@"
@@ -97,7 +106,7 @@ function set_from_server() {
 	fi
 
 	if versions=$(kubectl version -o json 2>/dev/null) &&
-		serverVersion=$(normalize_version $(jq -r '.serverVersion.minor' <<<$versions)) &&
+		serverVersion=$(_normalize_version $(jq -r '.serverVersion.minor' <<<$versions)) &&
 		[[ $serverVersion != "null" ]]; then
 
 		green "Detected server version $serverVersion"
@@ -119,7 +128,7 @@ if [[ $1 =~ ^- ]]; then
 fi
 
 if [[ -n $1 ]]; then
-	set_alternatives $(normalize_version "$1")
+	set_alternatives $(_normalize_version "$1")
 else
 	set_from_server
 fi


### PR DESCRIPTION
## what

- Enhance `kubectl-auto-select` to work with Debian
- Configure Debian version by codename
- Upgrade Alpine to use Fuse 3
- For Alpine, configure `bindfs` version via Docker `ARG` and upgrade `bindfs` v1.15.1 -> 1.17.6
- Upgrade Python on Debian from v3.10.10 to v3.11.6
- Upgrade Google Cloud SDK v422.0.0 -> 455.0.0
- Upgrade `kubectx` v0.9.4 -> v0.9.5
- Upgrade `helm-diff` v3.6.0 -> v3.8.1


## why

- `kubectl-auto-select` was written for Alpine and failed on Debian due to differing package managers
- Python is configured by Debian codename, so keep it in sync with Debian by using codename is both places
- Debian upgraded to Fuse 3 in v11 "bullseye" so keep Alpine relatively in sync
- Alpine `bindfs` version was hard coded, but not easily changed, and was old. Debian installs `bindfs` via package, and for some reason is sticking to v1.14.7.
- Alpine is using Python 3.11.6, so update Debian to corresponding version
- Update tools not tracked by automation to current versions

