### PR TITLE
fix: handling of user+group creation on Debian

### DIFF
--- a/rootfs/etc/profile.d/user.sh
+++ b/rootfs/etc/profile.d/user.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 
-id "${USER}" &>/dev/null
-if [[ "$?" -ne 0 ]]; then
+if [[ -n "${GROUP}" ]] && ! id -g "${GROUP}" &>/dev/null; then
+	if [[ -n "${GROUP_ID}" ]]; then
+		addgroup --force-badname --gid "${GROUP_ID}" "${GROUP}" &>/dev/null
+	fi
+fi
+
+if ! id "${USER}" &>/dev/null; then
 	if [[ -n "${USER_ID}" ]] && [[ -n "${GROUP_ID}" ]]; then
-		adduser -D -u ${USER_ID} -g ${GROUP_ID} -h ${HOME} ${USER} &>/dev/null
+		if [[ "${GEODESIC_OS}" = 'debian' ]]; then
+			# Trust the host USER a much as permissible, to that end we need to force
+			# a bad username for cases in which the username may contain dots and the
+			# like.
+			adduser --force-badname --uid "${USER_ID}" --gid "${GROUP_ID}" --home "${HOME}" --disabled-password --gecos '' "${USER}" &>/dev/null
+		else
+			adduser -D -u "${USER_ID}" -g "${GROUP_ID}" -h "${HOME}" "${USER}" &>/dev/null
+		fi
 	fi
 fi

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -12,6 +12,10 @@ readonly OS=$(uname -s)
 
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
+# While a dot in the username or groupname is frowned upon in POSIX user/group
+# names, it is still permissible. Further more, it may help debug any oddities
+# that arise with converting of names from ActiveDirectory/SSD/LDAP/etc..
+export GROUP="$(id -gn|tr '[:blank:]-' '.')"
 
 export options=()
 export targets=()
@@ -68,6 +72,7 @@ function use() {
 					--env SSH_TTY
 					--env USER
 					--env USER_ID
+					--env GROUP
 					--env GROUP_ID)
 			elif [ "${OS}" == 'Darwin' ] && [ "${GEODESIC_MAC_FORWARD_SOCKET}" == 'true' ]; then
 				# Bind-mount SSH-agent socket (available in docker-for mac Edge 2.2 release)


### PR DESCRIPTION
The current handling of user, uid, and gid are incomplete and subject to failure.

* The adduser/addgroup commands on Debian based systems are much more pedantic than other platforms and will error out on some surprising conditions.
* We want to support situations in which the username or groupname is pulled from systems which support characters such a spaces in the names which are prohibited in the POSIX passwd/group files.
* We need to handle the condition in which the group the user belongs to does not already exist.

## what
* Pass the groupname via the `GROUP` env variable in the wrapper script
* Create the group if it does not already exist
* Properly create the user on debian based systems

## why
![Screenshot from 2024-01-10 12-05-57](https://github.com/cloudposse/geodesic/assets/5922290/efae52b1-00fa-4b2e-b721-f304a4acb426)