### PR TITLE
Make bindfs mapping bidirectional, remove host USER name from env

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,5 +1,5 @@
 name: Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -55,7 +55,7 @@ RUN python3 -m pip install --upgrade --progress-bar off pip setuptools wheel && 
     pip install --progress-bar off -r /requirements.txt --prefix=/usr/local --no-build-isolation
 
 # Remove Python cache files
-RUN find / -name __pycache__ -exec rm -rf {} \; -prune
+RUN find / -xdev -name __pycache__ -exec rm -rf {} \; -prune
 
 #
 # Geodesic base image

--- a/rootfs/etc/profile.d/_20-localhost.sh
+++ b/rootfs/etc/profile.d/_20-localhost.sh
@@ -15,7 +15,7 @@ if [[ $SHLVL == 1 ]] && [[ -n $GEODESIC_HOST_UID ]] && [[ -n $GEODESIC_HOST_GID 
 		red "#  * Verify that content under /localhost is what you expect."
 		red "#  * Report the issue at https://github.com/cloudposse/geodesic/issues"
 		red "#  * Include the output of \`env | grep GEODESIC\` and \`df -a\` in your issue description."
-	elif bindfs -o nonempty ${GEODESIC_BINDFS_OPTIONS} --create-for-user="$GEODESIC_HOST_UID" --create-for-group="$GEODESIC_HOST_GID" "${GEODESIC_LOCALHOST}" /localhost; then
+	elif bindfs -o nonempty ${GEODESIC_BINDFS_OPTIONS} "--map=${GEODESIC_HOST_UID}/0:@${GEODESIC_HOST_GID}/@0" "${GEODESIC_LOCALHOST}" /localhost; then
 		green "# BindFS mapping of ${GEODESIC_LOCALHOST} to /localhost enabled."
 		green "# Files created under /localhost will have UID:GID ${GEODESIC_HOST_UID}:${GEODESIC_HOST_GID} on host."
 		export GEODESIC_LOCALHOST_MAPPED_DEVICE="${GEODESIC_LOCALHOST}"

--- a/rootfs/etc/profile.d/user.sh
+++ b/rootfs/etc/profile.d/user.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-id "${USER}" &>/dev/null
-if [[ "$?" -ne 0 ]]; then
-	if [[ -n "${USER_ID}" ]] && [[ -n "${GROUP_ID}" ]]; then
-		adduser -D -u ${USER_ID} -g ${GROUP_ID} -h ${HOME} ${USER} &>/dev/null
-	fi
-fi

--- a/rootfs/templates/wrapper
+++ b/rootfs/templates/wrapper
@@ -66,7 +66,6 @@ function use() {
 					--env SSH_CLIENT
 					--env SSH_CONNECTION
 					--env SSH_TTY
-					--env USER
 					--env USER_ID
 					--env GROUP_ID)
 			elif [ "${OS}" == 'Darwin' ] && [ "${GEODESIC_MAC_FORWARD_SOCKET}" == 'true' ]; then


### PR DESCRIPTION
## REMINDER

This PR fixes an issue with using `bindfs` to work around file ownership issues caused by running the Docker daemon as root (#594). This support is provided as a courtesy, but the better solution is to [run Docker in "rootless" mode](https://docs.docker.com/engine/security/rootless/), which is done automatically when you use [Docker Desktop](https://docs.docker.com/desktop/). Support for running Docker as `root` should be considered deprecated.

## what

- Use bi-directional UID and GUID mapping in `bindfs` mount of host filesystem
- Remove host username (`$USER`) from Geodesic environment

## why

- To guard against [CVE-2022-24765](https://nvd.nist.gov/vuln/detail/cve-2022-24765), `git` checks the ownership of all directories it looks at for configuration, and complains if it finds a directory with a different owner.
- The host's username was injected to support `ansible` 8 years ago (#65). It was never working properly on Debian due to the different structure of the `adduser` command on Debian vs Alpine, and should not be necessary now. If it turns out to be needed for some reason, we should develop a more robust solution.

## references

- [Git vulnerability to configuration injection](https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765)
- Supersedes and closes #900 
