### PR TITLE
Add explicit permissions to labeler

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,10 @@
 name: Labeler
 on: [pull_request_target]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
 


### PR DESCRIPTION
## what

- Add explicit permissions to labeler

## why

- Labeler needs write permission to update labels, which was previously granted by default but now must be explicit

