### PR TITLE
Bugfixes for local arm64 builds, Add Docker Labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ export DOCKER_FILE ?= os/$(DOCKER_BASE_OS)/Dockerfile.$(DOCKER_BASE_OS)
 export DOCKER_BUILD_FLAGS = --build-arg DEV_VERSION=$(shell printf "%s/%s" $$(git describe --tags 2>/dev/null || echo "unk") $$(git branch --no-color --show-current || echo "unk"))
 export INSTALL_PATH ?= /usr/local/bin
 export APP_NAME ?= geodesic
+export BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%S%z")
+export TARGETARCH ?= $(shell uname -m)
+export VCS_REF ?= $(shell git log -1 --format="%H" -- $(DOCKER_FILE))
+export VCS_URL ?= $(shell git config --get remote.origin.url)
+export ARGS := BUILD_DATE TARGETARCH VCS_REF VCS_URL
 
 include $(shell curl --silent -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
 

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -20,6 +20,8 @@ ARG HELM_DIFF_VERSION=3.8.1
 # We expect this has been fixed now with helm-diff 3.3.2 + helm-git 0.11.1
 ARG HELM_GIT_VERSION=0.15.1
 
+ARG TARGETARCH
+
 #
 # Python Dependencies
 #
@@ -68,11 +70,14 @@ RUN tar zxf bindfs-${BINDFS_VERSION}.tar.gz && cd bindfs-${BINDFS_VERSION}/ && \
 FROM ubuntu:22.04 as session-manager-plugin
 
 ARG SESSION_MANAGER_PLUGIN_VERSION
-RUN apt-get update \
-    && apt-get install -y curl \
-    && curl -Lo "session-manager-plugin.deb" "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_64bit/session-manager-plugin.deb" \
-    && dpkg -i "session-manager-plugin.deb" \
-    && /usr/local/sessionmanagerplugin/bin/session-manager-plugin  --version
+# does not handle installing both arm64 and amd64 session-manager on a multiplatform docker image
+# but the original did not also, and could not handle arm64 images either
+# and we will never generate "32bit" x86 arch
+RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
+       AWS_ARCH=64bit; else AWS_ARCH="arm64"; fi \
+    && apt-get update && apt-get install -y curl \
+    && curl -sSLo "session-manager-plugin.deb" "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${AWS_ARCH}/session-manager-plugin.deb" \
+    && dpkg -i "session-manager-plugin.deb"
 
 #
 # Google Cloud SDK
@@ -83,10 +88,19 @@ FROM google/cloud-sdk:$GOOGLE_CLOUD_SDK_VERSION-alpine as google-cloud-sdk
 # Geodesic base image
 #
 FROM alpine:$ALPINE_VERSION
+#COPY --from=sessionmanagerplugin /usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
 
 ARG VERSION
 ENV GEODESIC_VERSION=$VERSION
 ENV GEODESIC_OS=alpine
+
+# Carry over ARGs to the final stage
+ARG ALPINE_VERSION
+ARG BUILD_DATE
+ARG TARGETARCH
+ARG VCS_URL
+ARG VCS_REF
+
 
 # Set XDG environment variables per https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 # This is not a "multi-user" system, so we'll use special directories under
@@ -138,11 +152,21 @@ RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/a
 ##########################################################################################
 
 # Install alpine package manifest
-COPY packages.txt os/alpine/packages-alpine.txt /etc/apk/
+COPY packages.txt packages-amd64-only.txt os/alpine/packages-alpine.txt os/alpine/packages-alpine-amd64-only.txt /etc/apk/
+RUN cat /etc/apk/packages-alpine-amd64-only.txt >> /etc/apk/packages-amd64-only.txt
 
 ## Here is where we would copy in the repo checksum in an attempt to ensure updates bust the Docker build cache
-
-RUN apk add --update $(grep -h -v '^#' /etc/apk/packages.txt /etc/apk/packages-alpine.txt) && \
+RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
+      echo "Installing amd64 packages..." && \
+      apk add --update $(grep -h -v '^#' /etc/apk/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
+    elif echo "$TARGETARCH" | grep -q "arm64"; then \
+      echo "Attempting arm64 package installations or linking stubs for amd64-only packages..." && \
+      for pkg in $(grep -h -v '^#' /etc/apk/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); do \
+        ln -s /usr/local/bin/no-arm64-support /usr/local/bin/$pkg; \
+      done; \
+    else \
+      echo "Unsupported architecture in TARGETARCH"; \
+    fi; \
     mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
     touch /conf/.gitconfig
 
@@ -151,7 +175,9 @@ RUN apk add --update $(grep -h -v '^#' /etc/apk/packages.txt /etc/apk/packages-a
 RUN echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/00-ipv6.conf
 
 # Disable vim from reading a swapfile (incompatible with goofys)
-RUN echo 'set noswapfile' >> /etc/vim/vimrc
+# /etc/vim does not always exist
+RUN mkdir -p /etc/vim && \
+    echo 'set noswapfile' >> /etc/vim/vimrc
 
 WORKDIR /tmp
 
@@ -178,9 +204,10 @@ RUN ln -s /usr/local/google-cloud-sdk/completion.bash.inc /etc/bash_completion.d
 
 # gcloud config writes successful status updates to stderr, but we want to preserve
 # stderr for real errors in need of action.
-RUN { gcloud config set core/disable_usage_reporting true --installation && \
-      gcloud config set component_manager/disable_update_check true --installation && \
-      gcloud config set metrics/environment github_docker_image --installation; } 2>&1
+# this assumes 'python' which is prob python3 and may need an alias
+#RUN { gcloud config set core/disable_usage_reporting true --installation && \
+#      gcloud config set component_manager/disable_update_check true --installation && \
+#      gcloud config set metrics/environment github_docker_image --installation; } 2>&1
 
 # Explicitly set  KUBECONFIG to enable kube_ps1 prompt
 ENV KUBECONFIG=/conf/.kube/config
@@ -194,7 +221,8 @@ RUN chmod 600 $KUBECONFIG
 #
 # Set KUBERNETES_VERSION and KOPS_BASE_IMAGE in /conf/kops/kops.envrc
 #
-RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
+# might not be present
+#RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
 ARG KUBECTX_COMPLETION_VERSION
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubens.bash /etc/bash_completion.d/kubens.sh
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubectx.bash /etc/bash_completion.d/kubectx.sh
@@ -237,9 +265,10 @@ RUN chmod 755 /etc/bash_completion.d/kubens.sh /etc/bash_completion.d/kubectx.sh
 ARG HELM_DIFF_VERSION
 ARG HELM_GIT_VERSION
 
-RUN helm3 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \
-    && helm3 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \
-    && rm -rf $XDG_CACHE_HOME/helm
+# also not present find it
+#RUN helm3 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \
+#    && helm3 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \
+#    && rm -rf $XDG_CACHE_HOME/helm
 
 # helm version 3 uses XDG variables set above.
 # XDG directory permissions updated at end of installs.
@@ -322,7 +351,7 @@ COPY os/alpine/rootfs/ /
 COPY docs/ /usr/share/docs/
 
 # Build man pages
-RUN /usr/local/bin/docs update
+#RUN /usr/local/bin/docs update
 
 # Make sure that "user specific" directories we are sharing
 # are in fact available to all users
@@ -337,3 +366,21 @@ CMD ["-c", "boot"]
 ARG DEV_VERSION
 ENV GEODESIC_DEV_VERSION=$DEV_VERSION
 ENV GEODESIC_VERSION="${GEODESIC_VERSION}${GEODESIC_DEV_VERSION:+ (${GEODESIC_DEV_VERSION})}"
+
+LABEL maintainer='hello@cloudposse.com' \
+      description='Geodesic is a DevOps Linux Toolbox in Docker' \
+      base-image="$GEODESIC_OS:$ALPINE_VERSION" \
+      build-date="$BUILD_DATE" \
+      vcs-ref="$VCS_REF" \
+      vcs-url="$VCS_URL" \
+      architecture="$TARGETARCH" \
+      org.opencontainers.image.architecture="$TARGETARCH" \
+      org.opencontainers.image.base.name="$GEODESIC_OS:$ALPINE_VERSION" \
+      org.opencontainers.image.description='Geodesic is a DevOps Linux Toolbox in Docker' \
+      org.opencontainers.image.title='Geodesic' \
+      org.opencontainers.image.vendor='CloudPosse' \
+      org.opencontainers.image.version="$GEODESIC_VERSION" \
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.url='https://geodesic.tools' \
+      org.opencontainers.image.source="$VCS_URL"

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -68,14 +68,17 @@ RUN tar zxf bindfs-${BINDFS_VERSION}.tar.gz && cd bindfs-${BINDFS_VERSION}/ && \
 # Get AWS session-manager-plugin from Ubuntu package
 #
 FROM ubuntu:22.04 as session-manager-plugin
-
+# carry over ARGs needed in this stage
+ARG TARGETARCH
 ARG SESSION_MANAGER_PLUGIN_VERSION
-# does not handle installing both arm64 and amd64 session-manager on a multiplatform docker image
-# but the original did not also, and could not handle arm64 images either
-# and we will never generate "32bit" x86 arch
-RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
-       AWS_ARCH=64bit; else AWS_ARCH="arm64"; fi \
+ARG GOOGLE_CLOUD_SDK_VERSION
+
+# reverse the logic - if exclusively arm64 install session-manager as arm64
+# otherwise if amd64, amd64,arm64 or empty assume amd64 and install (only) amd64
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+       AWS_ARCH="arm64"; else AWS_ARCH="64bit"; fi \
     && apt-get update && apt-get install -y curl \
+    && echo "Target Arch is: $TARGETARCH" \
     && curl -sSLo "session-manager-plugin.deb" "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${AWS_ARCH}/session-manager-plugin.deb" \
     && dpkg -i "session-manager-plugin.deb"
 
@@ -156,16 +159,17 @@ COPY packages.txt packages-amd64-only.txt os/alpine/packages-alpine.txt os/alpin
 RUN cat /etc/apk/packages-alpine-amd64-only.txt >> /etc/apk/packages-amd64-only.txt
 
 ## Here is where we would copy in the repo checksum in an attempt to ensure updates bust the Docker build cache
-RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
-      echo "Installing amd64 packages..." && \
-      apk add --update $(grep -h -v '^#' /etc/apk/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
-    elif echo "$TARGETARCH" | grep -q "arm64"; then \
+# reverse the checks, if it is exclusively arm64 skip appropriate packages
+# otherwise and when TARGETARCH is empty, assume amd64
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      echo "Target Arch: $TARGETARCH" && \
       echo "Attempting arm64 package installations or linking stubs for amd64-only packages..." && \
       for pkg in $(grep -h -v '^#' /etc/apk/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); do \
         ln -s /usr/local/bin/no-arm64-support /usr/local/bin/$pkg; \
       done; \
     else \
-      echo "Unsupported architecture in TARGETARCH"; \
+      echo "Installing amd64 packages..." && \
+      apk add --update $(grep -h -v '^#' /etc/apk/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
     fi; \
     mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
     touch /conf/.gitconfig
@@ -205,9 +209,14 @@ RUN ln -s /usr/local/google-cloud-sdk/completion.bash.inc /etc/bash_completion.d
 # gcloud config writes successful status updates to stderr, but we want to preserve
 # stderr for real errors in need of action.
 # this assumes 'python' which is prob python3 and may need an alias
-#RUN { gcloud config set core/disable_usage_reporting true --installation && \
-#      gcloud config set component_manager/disable_update_check true --installation && \
-#      gcloud config set metrics/environment github_docker_image --installation; } 2>&1
+RUN if [ $TARGETARCH = "arm64" ]; then \
+      echo "Target Arch: $TARGETARCH" && \
+      echo "gcloud on alpine calls python which is not in the path; skipping"; \
+    else \
+        { gcloud config set core/disable_usage_reporting true --installation && \
+          gcloud config set component_manager/disable_update_check true --installation && \
+          gcloud config set metrics/environment github_docker_image --installation; } 2>&1; \
+    fi;
 
 # Explicitly set  KUBECONFIG to enable kube_ps1 prompt
 ENV KUBECONFIG=/conf/.kube/config
@@ -222,7 +231,12 @@ RUN chmod 600 $KUBECONFIG
 # Set KUBERNETES_VERSION and KOPS_BASE_IMAGE in /conf/kops/kops.envrc
 #
 # might not be present
-#RUN kubectl completion bash > /etc/bash_completion.d/kubectl.sh
+RUN if [ $TARGETARCH = "arm64" ]; then \
+      echo "kubectl for alpine arm64 not published; skipping"; \
+    else \
+      kubectl completion bash > /etc/bash_completion.d/kubectl.sh; \
+    fi
+
 ARG KUBECTX_COMPLETION_VERSION
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubens.bash /etc/bash_completion.d/kubens.sh
 ADD https://raw.githubusercontent.com/ahmetb/kubectx/v${KUBECTX_COMPLETION_VERSION}/completion/kubectx.bash /etc/bash_completion.d/kubectx.sh
@@ -266,9 +280,13 @@ ARG HELM_DIFF_VERSION
 ARG HELM_GIT_VERSION
 
 # also not present find it
-#RUN helm3 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \
-#    && helm3 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \
-#    && rm -rf $XDG_CACHE_HOME/helm
+RUN if [ $TARGETARCH = "arm64" ]; then \
+      echo "helm3 for alpine arm64 not published; skipping"; \
+    else \
+      helm3 plugin install https://github.com/databus23/helm-diff.git --version v${HELM_DIFF_VERSION} \
+      && helm3 plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION} \
+      && rm -rf $XDG_CACHE_HOME/helm; \
+    fi
 
 # helm version 3 uses XDG variables set above.
 # XDG directory permissions updated at end of installs.
@@ -351,7 +369,11 @@ COPY os/alpine/rootfs/ /
 COPY docs/ /usr/share/docs/
 
 # Build man pages
-#RUN /usr/local/bin/docs update
+RUN if [ $TARGETARCH = "arm64" ]; then \
+      echo "alpine on arm64 does not get 'docs'; skipping"; \
+    else \
+      /usr/local/bin/docs update; \
+    fi
 
 # Make sure that "user specific" directories we are sharing
 # are in fact available to all users

--- a/os/alpine/packages-alpine-amd64-only.txt
+++ b/os/alpine/packages-alpine-amd64-only.txt
@@ -1,0 +1,22 @@
+# These are packages that are only supported on amd64,
+# because they are not published to CloudPosse's Cloudsmith repo
+# in apk arm64 aarch64 versions
+aws-iam-authenticator@cloudposse
+chamber@cloudposse
+fetch@cloudposse
+figurine@cloudposse
+github-commenter@cloudposse
+helm3@cloudposse
+kubectl@cloudposse
+kubens@cloudposse
+rbac-lookup@cloudposse
+retry@cloudposse
+sops@cloudposse
+terragrunt@cloudposse
+terrahelp@cloudposse
+variant@cloudposse
+variant2@cloudposse
+vert@cloudposse
+gosu@cloudposse
+helmfile@cloudposse
+stern@cloudposse

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -290,21 +290,17 @@ COPY os/debian/rootfs/ /
 ARG TARGETARCH
 
 # For certain pagkage we like to have but are not available on arm64,
-# install them on amd64, and link to a stub script on arm64.
-# First, check if 'amd64' is part of TARGETARCH. If so, install amd64 packages.
-# If 'amd64' is not part of TARGETARCH, then check for 'arm64' and attempt to install arm64 packages or use stubs as necessary.
-RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
-      echo "Installing amd64 packages..." && \
-      apt-get update && apt-get install -y \
-      $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
-    elif echo "$TARGETARCH" | grep -q "arm64"; then \
+# reverse the logic; we can get empty, arm64, amd64, or amd64,arm64 as values
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
       echo "Attempting arm64 package installations or linking stubs for amd64-only packages..." && \
       for pkg in $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); do \
         # 'no-arm64-support' is a script that explains the lack of arm64 support
         ln -s /usr/local/bin/no-arm64-support /usr/local/bin/$pkg; \
       done; \
     else \
-      echo "Unsupported architecture in TARGETARCH"; \
+      echo "Installing amd64 packages..." && \
+      apt-get update && apt-get install -y \
+      $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
     fi
 
 # Move AWS CLI v1 aside and install AWS CLI v2 as default, leaving both available as alternatives.
@@ -318,8 +314,8 @@ RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
 # but it is updated several times a week, so we choose to just get the latest.
 # ARG AWS_CLI_VERSION=2.2.8
 RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
-    if echo "$TARGETARCH" | grep -q "amd64"; then \
-      AWS_ARCH=x86_64; else AWS_ARCH=aarch64; fi && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      AWS_ARCH=aarch64; else AWS_ARCH=x86_64; fi && \
     curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
     cd $AWSTMPDIR && \
     unzip -qq awscliv2.zip && \
@@ -343,8 +339,8 @@ ENV AWS_PAGER="less -FRX"
 ARG SESSION_MANAGER_PLUGIN_VERSION
 # does not install both versions of session manager but the original did not either
 # start with this and refactor to handle multi-platform session-manager if needed
-RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
-      AWS_ARCH=64bit; else AWS_ARCH="$TARGETARCH"; fi && \
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      AWS_ARCH="arm64"; else AWS_ARCH="64bit"; fi && \
     curl -sSL "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${AWS_ARCH}/session-manager-plugin.deb" \
     -o "/tmp/session-manager-plugin.deb" && \
     sudo dpkg -i /tmp/session-manager-plugin.deb && \
@@ -369,11 +365,6 @@ CMD ["-c", "boot"]
 ARG DEV_VERSION
 ENV GEODESIC_DEV_VERSION=$DEV_VERSION
 ENV GEODESIC_VERSION="${GEODESIC_VERSION}${GEODESIC_DEV_VERSION:+ (${GEODESIC_DEV_VERSION})}"
-
-# Additional inputs from Makefile or Github Actions
-ARG VCS_URL
-ARG VCS_REF
-ARG BUILD_DATE
 
 LABEL maintainer='hello@cloudposse.com' \
       description='Geodesic is a DevOps Linux Toolbox in Docker' \

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -27,6 +27,12 @@ ARG HELM_DIFF_VERSION=3.8.1
 # We expect this has been fixed now with helm-diff 3.3.2 + helm-git 0.11.1
 ARG HELM_GIT_VERSION=0.15.1
 
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+ARG TARGETARCH
+
 
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME} as python
 
@@ -62,7 +68,22 @@ RUN find / -xdev -name __pycache__ -exec rm -rf {} \; -prune
 #
 FROM debian:${DEBIAN_CODENAME}-${DEBAIN_DATECODE}-slim
 
+# Re-declare ARGs for this stage to use them in LABELs
+ARG BUILD_DATE
+ARG DEBIAN_CODENAME
+ARG DEBAIN_DATECODE
+ARG PYTHON_VERSION
+ARG GOOGLE_CLOUD_SDK_VERSION
+ARG KUBECTX_COMPLETION_VERSION
+ARG KUBE_PS1_VERSION
+ARG HELM_DIFF_VERSION
+ARG HELM_GIT_VERSION
+ARG SESSION_MANAGER_PLUGIN_VERSION
+ARG TARGETARCH
+ARG VCS_URL
+ARG VCS_REF
 ARG VERSION
+
 ENV GEODESIC_VERSION=$VERSION
 ENV GEODESIC_OS=debian
 
@@ -270,15 +291,21 @@ ARG TARGETARCH
 
 # For certain pagkage we like to have but are not available on arm64,
 # install them on amd64, and link to a stub script on arm64.
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+# First, check if 'amd64' is part of TARGETARCH. If so, install amd64 packages.
+# If 'amd64' is not part of TARGETARCH, then check for 'arm64' and attempt to install arm64 packages or use stubs as necessary.
+RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
+      echo "Installing amd64 packages..." && \
       apt-get update && apt-get install -y \
       $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); \
-    else \
+    elif echo "$TARGETARCH" | grep -q "arm64"; then \
+      echo "Attempting arm64 package installations or linking stubs for amd64-only packages..." && \
       for pkg in $(grep -h -v '^#' /etc/apt/packages-amd64-only.txt | sed -E 's/@(cloudposse|community|testing)//g' ); do \
-        ln  -s /usr/local/bin/no-arm64-support /usr/local/bin/$pkg; \
+        # 'no-arm64-support' is a script that explains the lack of arm64 support
+        ln -s /usr/local/bin/no-arm64-support /usr/local/bin/$pkg; \
       done; \
+    else \
+      echo "Unsupported architecture in TARGETARCH"; \
     fi
-
 
 # Move AWS CLI v1 aside and install AWS CLI v2 as default, leaving both available as alternatives.
 # We do this at the end because we need cache busting from above to get us the latest AWS CLI v2
@@ -291,7 +318,7 @@ RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
 # but it is updated several times a week, so we choose to just get the latest.
 # ARG AWS_CLI_VERSION=2.2.8
 RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
+    if echo "$TARGETARCH" | grep -q "amd64"; then \
       AWS_ARCH=x86_64; else AWS_ARCH=aarch64; fi && \
     curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
     cd $AWSTMPDIR && \
@@ -314,9 +341,11 @@ ENV AWS_PAGER="less -FRX"
 
 # Install AWS Session Manager Plugin
 ARG SESSION_MANAGER_PLUGIN_VERSION
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+# does not install both versions of session manager but the original did not either
+# start with this and refactor to handle multi-platform session-manager if needed
+RUN if echo "$TARGETARCH" | grep -q "amd64"; then \
       AWS_ARCH=64bit; else AWS_ARCH="$TARGETARCH"; fi && \
-    curl -L "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${AWS_ARCH}/session-manager-plugin.deb" \
+    curl -sSL "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${AWS_ARCH}/session-manager-plugin.deb" \
     -o "/tmp/session-manager-plugin.deb" && \
     sudo dpkg -i /tmp/session-manager-plugin.deb && \
     rm /tmp/session-manager-plugin.deb
@@ -340,3 +369,26 @@ CMD ["-c", "boot"]
 ARG DEV_VERSION
 ENV GEODESIC_DEV_VERSION=$DEV_VERSION
 ENV GEODESIC_VERSION="${GEODESIC_VERSION}${GEODESIC_DEV_VERSION:+ (${GEODESIC_DEV_VERSION})}"
+
+# Additional inputs from Makefile or Github Actions
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+LABEL maintainer='hello@cloudposse.com' \
+      description='Geodesic is a DevOps Linux Toolbox in Docker' \
+      base-image=$GEODESIC_OS:$DEBIAN_CODENAME \
+      build-date=$BUILD_DATE \
+      vcs-ref=$VCS_REF \
+      vcs-url=$VCS_URL \
+      architecture=$TARGETARCH \
+      org.opencontainers.image.architecture=$TARGETARCH \
+      org.opencontainers.image.base.name=$GEODESIC_OS:$DEBIAN_CODENAME \
+      org.opencontainers.image.description='Geodesic is a DevOps Linux Toolbox in Docker' \
+      org.opencontainers.image.title='Geodesic' \
+      org.opencontainers.image.vendor='CloudPosse' \
+      org.opencontainers.image.version=$GEODESIC_VERSION \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.url='https://geodesic.tools' \
+      org.opencontainers.image.source=$VCS_URL


### PR DESCRIPTION
## what

- improves Alpine and Debian builds for arm64
- fixes #899 
- introduces docker labels
- mimics existing amd64-only package exceptions from Debian builds for alpine where not published for arm64 in CloudPosse CloudSmith repo

## why
- #899 
- Prepping for PR that removes 516 security vulnerabilities including 8 critical cvss and 179 high cvss vulnerabilities in Geodesic. This PR includes prerequisites. Submitted sequentially to keep it simple.
- Labeling docker images in standard ways, traditional and OCI, improves collaboration and analysis and allows docker image consumers to more easily identify and manage artifacts
- NOTE: this does not include changes to Github actions to set values in these labels. Those changes are untested. I'm not including them here.

## references
* closes #899  
* https://github.com/opencontainers/image-spec/blob/main/annotations.md
* https://cloudsmith.io/~cloudposse/repos/packages/packages/?q=format%3Aalpine+AND+%28architecture%3Aaarch64+OR+architecture%3Aarm64%29
