### PR TITLE
Add OCI annotations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,7 @@
 name: "docker"
 on:
+  workflow_dispatch:
+
   pull_request:
     types: [opened, synchronize, reopened]
   release:
@@ -14,6 +16,7 @@ jobs:
       id-token: write
       contents: read
     env:
+      LATEST_TAG_OS: 'debian'
       IAM_ROLE_SESSION_NAME: geodesic-ci
       AWS_REGION: us-east-1
       ECR_REGISTRY: public.ecr.aws/ # Images will be published to `public.ecr.aws/cloudposse/$repositoryName`
@@ -44,7 +47,6 @@ jobs:
       # We therefore designate whichever base OS version we recommend as the best supported
       # as the one to get the "latest" tag. Initially that will be Alpine.
       env:
-        LATEST_TAG_OS: 'debian'
         BASE_OS: ${{matrix.os}}
 
       run: |
@@ -63,6 +65,8 @@ jobs:
         fi
         printf "Version resolved to %s\n" "${VERSION}"
         echo version=${VERSION} >> $GITHUB_OUTPUT
+        printf "Commit SHA resolved to %s\n" "${COMMIT_SHA}"
+        echo commit_sha=${COMMIT_SHA} >> $GITHUB_OUTPUT
         TAGS="${{ github.repository }}:sha-${COMMIT_SHA:0:7}-${BASE_OS}"
         TAGS="$TAGS,${{ env.ECR_REGISTRY }}${{ github.repository }}:sha-${COMMIT_SHA:0:7}-${BASE_OS}"
         if [[ -n $VERSION ]]; then
@@ -85,23 +89,58 @@ jobs:
           printf "%s\n" "${TAGS}"
           echo tags=${TAGS} >> $GITHUB_OUTPUT
         fi
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to DockerHub
-      if: steps.prepare.outputs.publish == 'true'
-      uses: docker/login-action@v3
+    - name: Metadata
+      uses: docker/metadata-action@v5
+      env:
+        DOCKER_METADATA_PR_HEAD_SHA: true
+        DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: "Build and push docker image to DockerHub"
-      id: docker_build
-      uses: docker/build-push-action@v5
-      with:
-        push: ${{ steps.prepare.outputs.publish == 'true' }}
-        platforms: ${{ steps.prepare.outputs.platforms }}
-        tags: ${{ steps.prepare.outputs.tags }}
-        file: ./os/${{matrix.os}}/Dockerfile.${{matrix.os}}
-        build-args: |
-          VERSION=${{ steps.prepare.outputs.version }}
+        images: |
+          cloudposse/geodesic
+          ${{ env.ECR_REGISTRY }}cloudposse/geodesic
+        flavor: |
+          suffix=-${{ env.BASE_OS }}
+          latest=false
+        labels: |
+          org.opencontainers.image.title=Geodesic
+          org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
+          org.opencontainers.image.vendor=Cloud Posse, LLC
+          org.opencontainers.image.licenses=NOASSERTION
+        tags: |
+          type=semver,pattern={{version}}
+          type=ref,event=pr,prefix=pr-,suffix=-${{matrix.os}}
+          type=sha,prefix=sha-,suffix=-${{matrix.os}}
+          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') && matrix.os == env.LATEST_TAG_OS }}
+
+    - name: Show metadata
+      run: |
+        printf "Old tags for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.prepare.outputs.tags) }}'
+        printf "New tags for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.metadata.outputs.tags) }}'
+        printf "Metadata annotations for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.metadata.outputs.annotations) }}'
+        printf "Metadata labels for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.metadata.outputs.labels) }}'
+
+# {{date 'YYYY-MM-DDTHH:mm:ssZ'}}
+
+
+#    - name: Set up QEMU
+#      uses: docker/setup-qemu-action@v3
+#    - name: Set up Docker Buildx
+#      uses: docker/setup-buildx-action@v3
+#    - name: Login to DockerHub
+#      if: steps.prepare.outputs.publish == 'true'
+#      uses: docker/login-action@v3
+#      with:
+#        username: ${{ secrets.DOCKERHUB_USERNAME }}
+#        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+#    - name: "Build and push docker image to DockerHub"
+#      id: docker_build
+#      uses: docker/build-push-action@v5
+#      with:
+#        cache-from: type=gha
+#        cache-to: type=gha,mode=max
+#        push: ${{ steps.prepare.outputs.publish == 'true' }}
+#        platforms: ${{ steps.prepare.outputs.platforms }}
+#        tags: ${{ steps.prepare.outputs.tags }}
+#        file: ./os/${{matrix.os}}/Dockerfile.${{matrix.os}}
+#        build-args: |
+#          VERSION=${{ steps.prepare.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,15 +109,11 @@ jobs:
           org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
           org.opencontainers.image.vendor=Cloud Posse, LLC
           org.opencontainers.image.licenses=NOASSERTION
-        assertions: |
-          index:org.opencontainers.image.title=Geodesic
-          index:org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
-          index:org.opencontainers.image.vendor=Cloud Posse, LLC
-          index:org.opencontainers.image.licenses=NOASSERTION
-          manifest:org.opencontainers.image.title=Geodesic
-          manifest:org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
-          manifest:org.opencontainers.image.vendor=Cloud Posse, LLC
-          manifest:org.opencontainers.image.licenses=NOASSERTION
+        annotations: |
+          org.opencontainers.image.title=Geodesic
+          org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
+          org.opencontainers.image.vendor=Cloud Posse, LLC
+          org.opencontainers.image.licenses=NOASSERTION
         tags: |
           type=semver,pattern={{version}}
           type=ref,event=pr,prefix=pr-,suffix=-${{matrix.os}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,10 +123,9 @@ jobs:
 
     - name: Show metadata
       run: |
-        printf "Old tags for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.prepare.outputs.tags) }}'
-        printf "New tags for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.tags }}'
-        printf "Metadata annotations for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.annotations }}'
-        printf "Metadata labels for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.labels }}'
+        printf "Old tags for cloudposse/geodesic\n\n"
+        printf "  %s\n" $(tr , " " <<<'${{ steps.prepare.outputs.tags }}' | sort)
+        printf "\n\nNew tags for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.tags }}'
 
 
     - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
           cloudposse/geodesic
           ${{ env.ECR_REGISTRY }}cloudposse/geodesic
         flavor: |
-          suffix=-${{ env.BASE_OS }}
+          suffix=-${{ matrix.os }}
           latest=false
         # Geodesic's original code is licensed under the Apache 2.0 License (Apache-2.0)
         # but it contains many other components with different licenses.
@@ -110,15 +110,20 @@ jobs:
           org.opencontainers.image.vendor=Cloud Posse, LLC
           org.opencontainers.image.licenses=NOASSERTION
         assertions: |
-          org.opencontainers.image.title=Geodesic
-          org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
-          org.opencontainers.image.vendor=Cloud Posse, LLC
-          org.opencontainers.image.licenses=NOASSERTION
+          index:org.opencontainers.image.title=Geodesic
+          index:org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
+          index:org.opencontainers.image.vendor=Cloud Posse, LLC
+          index:org.opencontainers.image.licenses=NOASSERTION
+          manifest:org.opencontainers.image.title=Geodesic
+          manifest:org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
+          manifest:org.opencontainers.image.vendor=Cloud Posse, LLC
+          manifest:org.opencontainers.image.licenses=NOASSERTION
         tags: |
           type=semver,pattern={{version}}
           type=ref,event=pr,prefix=pr-,suffix=-${{matrix.os}}
           type=sha,prefix=sha-,suffix=-${{matrix.os}}
-          type=raw,value=latest,enable=${{ steps.prepare.outputs.publish == 'true' && matrix.os == env.LATEST_TAG_OS }}
+          type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
+          type=raw,value=latest,suffix=,enable=${{ github.event_name == 'release' && github.event.action == 'published' && matrix.os == env.LATEST_TAG_OS }}
 
     - name: Show metadata
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,8 @@ jobs:
           printf "%s\n" "${TAGS}"
           echo tags=${TAGS} >> $GITHUB_OUTPUT
         fi
-    - name: Metadata
+    - name: Prepare Metadata for Docker Images
+      id: Metadata
       uses: docker/metadata-action@v5
       env:
         DOCKER_METADATA_PR_HEAD_SHA: true
@@ -101,7 +102,14 @@ jobs:
         flavor: |
           suffix=-${{ env.BASE_OS }}
           latest=false
+        # Geodesic's original code is licensed under the Apache 2.0 License (Apache-2.0)
+        # but it contains many other components with different licenses.
         labels: |
+          org.opencontainers.image.title=Geodesic
+          org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
+          org.opencontainers.image.vendor=Cloud Posse, LLC
+          org.opencontainers.image.licenses=NOASSERTION
+        assertions: |
           org.opencontainers.image.title=Geodesic
           org.opencontainers.image.description=Geodesic is a DevOps Linux Toolbox in Docker
           org.opencontainers.image.vendor=Cloud Posse, LLC
@@ -110,37 +118,37 @@ jobs:
           type=semver,pattern={{version}}
           type=ref,event=pr,prefix=pr-,suffix=-${{matrix.os}}
           type=sha,prefix=sha-,suffix=-${{matrix.os}}
-          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') && matrix.os == env.LATEST_TAG_OS }}
+          type=raw,value=latest,enable=${{ steps.prepare.outputs.publish == 'true' && matrix.os == env.LATEST_TAG_OS }}
 
     - name: Show metadata
       run: |
         printf "Old tags for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.prepare.outputs.tags) }}'
-        printf "New tags for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.metadata.outputs.tags) }}'
-        printf "Metadata annotations for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.metadata.outputs.annotations) }}'
-        printf "Metadata labels for cloudposse/geodesic\n\n%s\n\n" '${{ toJSON(steps.metadata.outputs.labels) }}'
-
-# {{date 'YYYY-MM-DDTHH:mm:ssZ'}}
+        printf "New tags for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.tags }}'
+        printf "Metadata annotations for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.annotations }}'
+        printf "Metadata labels for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.labels }}'
 
 
-#    - name: Set up QEMU
-#      uses: docker/setup-qemu-action@v3
-#    - name: Set up Docker Buildx
-#      uses: docker/setup-buildx-action@v3
-#    - name: Login to DockerHub
-#      if: steps.prepare.outputs.publish == 'true'
-#      uses: docker/login-action@v3
-#      with:
-#        username: ${{ secrets.DOCKERHUB_USERNAME }}
-#        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-#    - name: "Build and push docker image to DockerHub"
-#      id: docker_build
-#      uses: docker/build-push-action@v5
-#      with:
-#        cache-from: type=gha
-#        cache-to: type=gha,mode=max
-#        push: ${{ steps.prepare.outputs.publish == 'true' }}
-#        platforms: ${{ steps.prepare.outputs.platforms }}
-#        tags: ${{ steps.prepare.outputs.tags }}
-#        file: ./os/${{matrix.os}}/Dockerfile.${{matrix.os}}
-#        build-args: |
-#          VERSION=${{ steps.prepare.outputs.version }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to DockerHub
+      if: steps.prepare.outputs.publish == 'true'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: "Build and push docker image to DockerHub"
+      id: docker_build
+      uses: docker/build-push-action@v5
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        push: ${{ steps.prepare.outputs.publish == 'true' }}
+        platforms: ${{ steps.prepare.outputs.platforms }}
+        tags: ${{ steps.Metadata.outputs.tags }}
+        labels: ${{ steps.Metadata.outputs.labels }}
+        annotations: ${{ steps.Metadata.outputs.annotations }}
+        file: ./os/${{matrix.os}}/Dockerfile.${{matrix.os}}
+        build-args: |
+          VERSION=${{ steps.prepare.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Show metadata
       run: |
         printf "Old tags for cloudposse/geodesic\n\n"
-        printf "  %s\n" $(tr , " " <<<'${{ steps.prepare.outputs.tags }}' | sort)
+        printf "  %s\n" $(tr , " " <<<'${{ steps.prepare.outputs.tags }}') | sort
         printf "\n\nNew tags for cloudposse/geodesic\n\n%s\n\n" '${{ steps.Metadata.outputs.tags }}'
 
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ export DOCKER_TAG ?= $(DOCKER_BASE_TAG)-$(DOCKER_BASE_OS)
 export DOCKER_IMAGE_NAME_BASE ?= $(DOCKER_IMAGE):$(DOCKER_BASE_TAG)
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_FILE ?= os/$(DOCKER_BASE_OS)/Dockerfile.$(DOCKER_BASE_OS)
-export DOCKER_BUILD_FLAGS = --build-arg DEV_VERSION=$(shell printf "%s/%s" $$(git describe --tags 2>/dev/null || echo "unk") $$(git branch --no-color --show-current || echo "unk"))
+export DOCKER_DEV_BUILD_FLAGS = --build-arg DEV_VERSION=$(shell printf "%s/%s" $$(git describe --tags 2>/dev/null || echo "unk") $$(git branch --no-color --show-current || echo "unk"))
+# Force Alpine build to be amd64, allow Debian build to be alternate platform by setting BUILD_ARCH
+export BUILD_ARCH ?= $(if $(subst alpine,,$(DOCKER_BASE_OS)),,amd64)
+export DOCKER_ARCH_BUILD_FLAGS = $(if $(BUILD_ARCH), --platform=linux/$(BUILD_ARCH),)
+# Set DOCKER_EXTRA_BUILD_FLAGS to add to the default build flags, set DOCKER_BUILD_FLAGS to override
+export DOCKER_BUILD_FLAGS ?= $(DOCKER_EXTRA_BUILD_FLAGS) $(DOCKER_ARCH_BUILD_FLAGS) $(DOCKER_DEV_BUILD_FLAGS)
 export INSTALL_PATH ?= /usr/local/bin
 export APP_NAME ?= geodesic
 

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -88,6 +88,11 @@ ARG VERSION
 ENV GEODESIC_VERSION=$VERSION
 ENV GEODESIC_OS=alpine
 
+ARG TARGETARCH
+ARG TARGETOS
+RUN [ "$TARGETARCH" = "amd64" ] || (echo "Unsupported TARGETARCH: \"$TARGETARCH\"" >&2 && false)
+RUN [ "$TARGETOS" = "linux" ] || (echo "Unsupported TARGETOS: \"$TARGETOS\"" >&2 && false)
+
 # Set XDG environment variables per https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 # This is not a "multi-user" system, so we'll use special directories under
 # - /etc as the global configuration dir instead of default $HOME/.config

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -90,6 +90,7 @@ ENV GEODESIC_OS=alpine
 
 ARG TARGETARCH
 ARG TARGETOS
+RUN [ -n "$TARGETARCH" ] && [ -n "$TARGETOS" ] || (echo "Geodesic must be built with buildkit."; echo "See: https://docs.docker.com/build/buildkit/"; false)
 RUN [ "$TARGETARCH" = "amd64" ] || (echo "Unsupported TARGETARCH: \"$TARGETARCH\"" >&2 && false)
 RUN [ "$TARGETOS" = "linux" ] || (echo "Unsupported TARGETOS: \"$TARGETOS\"" >&2 && false)
 

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -66,8 +66,10 @@ ARG VERSION
 ENV GEODESIC_VERSION=$VERSION
 ENV GEODESIC_OS=debian
 
+# TARGETARCH and TARGETOS are defined by buildkit, but not available with other builders
 ARG TARGETARCH
 ARG TARGETOS
+RUN [ -n "$TARGETARCH" ] && [ -n "$TARGETOS" ] || (echo "Geodesic must be built with buildkit."; echo "See: https://docs.docker.com/build/buildkit/"; false)
 RUN [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ] || (echo "Unsupported TARGETARCH: \"$TARGETARCH\"" && false)
 RUN [ "$TARGETOS" = "linux" ] || (echo "Unsupported TARGETOS: \"$TARGETOS\"" && false)
 

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -66,6 +66,12 @@ ARG VERSION
 ENV GEODESIC_VERSION=$VERSION
 ENV GEODESIC_OS=debian
 
+ARG TARGETARCH
+ARG TARGETOS
+RUN [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ] || (echo "Unsupported TARGETARCH: \"$TARGETARCH\"" && false)
+RUN [ "$TARGETOS" = "linux" ] || (echo "Unsupported TARGETOS: \"$TARGETOS\"" && false)
+
+
 # Set a default terminal to "dumb" (headless) to make `tput` happy when running scripts.
 # When we launch Geodesic for interactive use, we forward the host value of `TERM`
 ENV TERM=dumb
@@ -265,8 +271,6 @@ ENV MAKEFLAGS="--no-print-directory"
 COPY rootfs/ /
 COPY os/debian/rootfs/ /
 
-
-ARG TARGETARCH
 
 # For certain pagkage we like to have but are not available on arm64,
 # install them on amd64, and link to a stub script on arm64.


### PR DESCRIPTION
## what

- Add OCI annotations to published images

## why

- Standard compliance and better support for third-party tooling

## references

- [OCI annotations](https://specs.opencontainers.org/image-spec/annotations/)
- Supersedes and closes #915 
