### PR TITLE
Fix aws CLI auto-completions, use smaller kubectl package

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -121,14 +121,16 @@ COPY packages.txt packages-amd64-only.txt os/debian/packages-debian.txt /etc/apt
 RUN apt-get update && apt-get install -y apt-utils curl
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/cfg/setup/bash.deb.sh' | bash
 
-# Install Google package repo
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-
+# Install packages, but do not yet install the Google package repo because we do not want their version of kubectl
 RUN apt-get update && apt-get install -y \
     $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing)//g' ) && \
     mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
     touch /conf/.gitconfig
+
+# Install Google package repo
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
 
 # Here is where we would confirm that the package repo checksum is what we expect (not mismatched due to Docker layer cache)
 
@@ -291,22 +293,27 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 # We do this at the end because we need cache busting from above to get us the latest AWS CLI v2
 
 RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
-    update-alternatives --install /usr/local/bin/aws aws /usr/local/bin/aws1 1
+    mv /usr/local/bin/aws_completer /usr/local/bin/aws1_completer && \
+    update-alternatives --install /usr/local/bin/aws aws /usr/local/bin/aws1 1  \
+    --slave /usr/local/bin/aws_completer aws_completer /usr/local/bin/aws1_completer
 
 # Install AWS CLI 2
 # Get AWS CLI V2 version from https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst if you want
 # but it is updated several times a week, so we choose to just get the latest.
 # ARG AWS_CLI_VERSION=2.2.8
 RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-      AWS_ARCH=x86_64; else AWS_ARCH=aarch64; fi && \
-    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
-    cd $AWSTMPDIR && \
-    unzip -qq awscliv2.zip && \
-    ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
-    update-alternatives --install /usr/local/bin/aws aws /usr/share/aws/v2/bin/aws 2 && \
-    update-alternatives --set aws /usr/share/aws/v2/bin/aws && ln -s /usr/share/aws/v2/bin/aws /usr/local/bin/aws2 && \
-    rm -rf $AWSTMPDIR
+      if [ "$TARGETARCH" = "amd64" ]; then \
+        AWS_ARCH=x86_64; else AWS_ARCH=aarch64; fi && \
+      curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}${AWS_CLI_VERSION:+-${AWS_CLI_VERSION}}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
+      savedir="$PWD" && cd $AWSTMPDIR && \
+      unzip -qq awscliv2.zip && \
+      ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
+      update-alternatives --install /usr/local/bin/aws aws /usr/share/aws/v2/bin/aws 2 \
+      --slave /usr/local/bin/aws_completer aws_completer /usr/share/aws/v2/bin/aws_completer && \
+      update-alternatives --set aws /usr/share/aws/v2/bin/aws && \
+      ln -s /usr/share/aws/v2/bin/aws /usr/local/bin/aws2 && \
+      ln -s /usr/share/aws/v2/bin/aws_completer /usr/local/bin/aws2_completer && \
+      cd "$savedir" && rm -rf $AWSTMPDIR
 
 # We recommend AWS_PAGER="less -FRX" but you can override it in your Dockerfile
 # or in your Geodesic preferences (see `man customization`).
@@ -326,7 +333,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     curl -sSL "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/ubuntu_${AWS_ARCH}/session-manager-plugin.deb" \
     -o "/tmp/session-manager-plugin.deb" && \
     sudo dpkg -i /tmp/session-manager-plugin.deb && \
-    rm /tmp/session-manager-plugin.deb
+    rm -f /tmp/session-manager-plugin.deb
 
 # Install documentation
 COPY docs/ /usr/share/docs/

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -20,10 +20,12 @@ if [ ! -f "${AWS_CONFIG_FILE:=${GEODESIC_AWS_HOME}/config}" ] && [ -d ${GEODESIC
 	echo '[default]' >${AWS_CONFIG_FILE}
 fi
 
-# Install autocompletion rules
-if command -v aws_completer >/dev/null; then
-	complete -C "$(command -v aws_completer)" aws
-fi
+# Install autocompletion rules for aws CLI v1 and v2
+for aws in aws aws1 aws2; do
+	if command -v ${aws}_completer >/dev/null; then
+	complete -C "$(command -v ${aws}_completer)" ${aws}
+	fi
+done
 
 # This is the default assume-role function, but it can be overridden/replaced later
 # by aws-okta or aws-vault, etc. or could have already been overridden.


### PR DESCRIPTION
## what

- Fix `aws` auto-completion
- Only install latest `kubectl`

## why

- The `aws` CLI is provided in 2 versions, v1 and v2, and which version is in use is managed by `update-alternatives`. However, each version of the CLI has a corresponding version of the `aws_completer` utility to perform auto-completion, but until now, Geodesic always used the v1 completer (a python script), even with the v2 CLI. This mostly worked, but it is not supported or correct.
- Previously, we installed the `kubectl` package from `packages.cloud.google.com`, which is over 200 MB because it installs multiple versions of `kubectl`. We now install only the latest `kubectl` package from the Cloud Posse package repo, which is under 50 MB, to save space. Cloud Posse publishes packages for each minor version of `kubectl` (e.g. `kubectl-1.29`) so you can install the latest version compatible with your cluster if you do not want the current latest version.

 
## references

This was brought to our attention by https://github.com/aws/aws-cli/issues/8547 since upgrading to Python 3.12 in Geodesic v2.9.0. 