### PR TITLE
Add rakkess to linux/arm64 in Debian

### DIFF
--- a/packages-amd64-only.txt
+++ b/packages-amd64-only.txt
@@ -4,6 +4,7 @@ awless@cloudposse
 cfssl@cloudposse
 emailcli@cloudposse
 goofys@cloudposse
-rakkess@cloudposse
+# We specially custom built and packaged rakkess v0.5.1 for linux/arm64 to support EKS access entry validation
+# rakkess@cloudposse
 tfenv@cloudposse
 tfmask@cloudposse

--- a/packages.txt
+++ b/packages.txt
@@ -52,7 +52,8 @@ pandoc@cloudposse
 postgresql-client
 pwgen
 python3
-# no arm64 rakkess@cloudposse
+# We specially custom built and packaged rakkess v0.5.1 for linux/arm64 to support EKS access entry validation 2024-03-06
+rakkess@cloudposse
 rbac-lookup@cloudposse
 retry@cloudposse
 # abandoned 2021-03-08 scenery@cloudposse

--- a/rootfs/usr/local/bin/no-arm64-support
+++ b/rootfs/usr/local/bin/no-arm64-support
@@ -1,4 +1,16 @@
 #!/bin/bash
 
+# If someone manages to install the real file on the system,
+# then redirect the link that is causing this script to run
+# and execute the real file. We do not remove it because that
+# causes problems with command hashing.
+if [ -x /usr/bin/$(basename "$0") ]; then
+  if [ -L "$0" ]; then
+    rm -f "$0"
+    ln -s /usr/bin/$(basename "$0") "$0"
+  fi
+  exec /usr/bin/$(basename "$0") "$@"
+fi
+
 printf "$(tput setaf 1)%s is not supported on this platform (arm64)$(tput setaf 0)\n" "$(basename "$0")" >&2
 exit 1


### PR DESCRIPTION
## what

- Add [rakkess](https://github.com/corneliusweig/rakkess) to `linux/arm64` Debian build

## why

- Previously we excluded `rakkess` from the `arm64` build because there was no binary available and it was not considered that useful a tool. However, with AWS now supporting a [new mechanism for access control for EKS clusters](https://github.com/aws/containers-roadmap/issues/185#issuecomment-1862970742), it is newly useful in verifying access control given that it access can no longer be determined by simply looking at Kubernetes resources.

## references

- https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html
- https://github.com/corneliusweig/rakkess
- Some of the best documentation is in [this issue comment](https://github.com/aws/containers-roadmap/issues/185#issuecomment-1863025784)

