### PR TITLE
Update Dependencies, add OpenTofu package repo

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -3,13 +3,13 @@ name: draft-release
 on:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
+    # Drafts your next Release notes as Pull Requests are merged into "main"
     - uses: release-drafter/release-drafter@v6
       with:
         publish: false

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -5,7 +5,7 @@
 #
 # Note that Geodesic supports runtime customizations that
 # do not require a custom Dockerfile. See:
-#   https://github.com/cloudposse/geodesic/blob/master/docs/customization.md
+#   https://github.com/cloudposse/geodesic/blob/main/docs/customization.md
 #
 # See Dockerfile.options for some common options you might want.
 #

--- a/Dockerfile.options
+++ b/Dockerfile.options
@@ -12,9 +12,9 @@ ENV LESS=R
 # Our older Geodesic configurations relied on `direnv`, which we no longer recommend,
 # preferring YAML configuration files instead.
 ENV DIRENV_ENABLED=true
-# When using DIRENV with Terraform, you can enable special prompt support
-ENV GEODESIC_TERRAFORM_WORKSPACE_PROMPT_ENABLED=true
-ENV GEODESIC_TF_PROMPT_ACTIVE=true
+
+# When using Terraform worksapces, you can enable special prompt support
+ENV GEODESIC_TF_PROMPT_ENABLED=true
 
 # Our older Geodesic configuration uses multiple Makefiles, like Makefile.tasks
 # and depends on this setting, however this setting is set by default by `direnv`
@@ -24,6 +24,23 @@ ENV GEODESIC_TF_PROMPT_ACTIVE=true
 # it for trusted directories under `/conf` and therefore it will not affect
 # `make` outside of this directory tree.
 ENV MAKE_INCLUDES="Makefile Makefile.*"
+
+
+#
+# Install Google Cloud SDK (requires Python)
+# This is separate so that updating it does not invalidate the Docker cache layer with all the packages installed above
+# https://cloud.google.com/sdk/docs/release-notes
+ARG GOOGLE_CLOUD_CLI_VERSION
+ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
+
+RUN apt-get update && apt-get install -y google-cloud-cli=${GOOGLE_CLOUD_CLI_VERSION}-\*
+
+# gcloud config writes successful status updates to stderr, but we want to preserve
+# stderr for real errors in need of action.
+RUN { gcloud config set core/disable_usage_reporting true --installation && \
+      gcloud config set component_manager/disable_update_check true --installation && \
+      gcloud config set metrics/environment github_docker_image --installation; } 2>&1
+
 
 
 ####################################################################################

--- a/Makefile.custom
+++ b/Makefile.custom
@@ -7,7 +7,7 @@
 # how to customize your Dockerfile.
 # Note that Geodesic supports runtime customizations that
 # do not require a custom Dockerfile: See
-#   https://github.com/cloudposse/geodesic/blob/master/docs/customization.md
+#   https://github.com/cloudposse/geodesic/blob/main/docs/customization.md
 #
 #
 # The `make` variables build up to $(DOCKER_IMAGE):$(DOCKER_TAG) being

--- a/docs/logo.md
+++ b/docs/logo.md
@@ -11,7 +11,7 @@ logo - Explanation of the Geodesic Logo
 
 ## SYNOPSIS
 
-![Geodesic Logo](https://raw.githubusercontent.com/cloudposse/geodesic/master/docs/geodesic-small.png)
+![Geodesic Logo](https://raw.githubusercontent.com/cloudposse/geodesic/main/docs/geodesic-small.png)
 
 In mathematics, a geodesic line is the shortest distance between two points on a sphere. It's also a solid structure composed of geometric shapes such as hexagons.
 

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,7 +1,7 @@
 # https://alpinelinux.org/
 ARG ALPINE_VERSION=3.18.6
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=463.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=472.0.0
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
@@ -9,7 +9,7 @@ ARG KUBE_PS1_VERSION=0.8.0
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#plugin-version-history
 ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 # https://bindfs.org/downloads/
-ARG BINDFS_VERSION=1.17.6
+ARG BINDFS_VERSION=1.17.7
 
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
@@ -135,6 +135,8 @@ RUN printf "@community %s\n" "$(grep -E 'alpine/v[^/]+/community' /etc/apk/repos
 # Install the @testing repo tag
 RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
+# Install 3.19 community as @opentofu to get OpenTofu v1.6.2
+RUN echo "@opentofu https://dl-cdn.alpinelinux.org/alpine/v3.19/community" >> /etc/apk/repositories
 
 ##########################################################################################
 # See Dockerfile.options for how to install `glibc` for greater compatibility, including #

--- a/os/alpine/Dockerfile.alpine
+++ b/os/alpine/Dockerfile.alpine
@@ -1,7 +1,5 @@
 # https://alpinelinux.org/
 ARG ALPINE_VERSION=3.18.6
-# https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=472.0.0
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
@@ -39,7 +37,9 @@ RUN apk add --update -U python3 python3-dev py3-pip libffi-dev gcc linux-headers
 #   - libxml2
 #   - libxslt
 
-COPY requirements.txt /requirements.txt
+COPY requirements.txt /requirements-global.txt
+COPY os/alpine/requirements.txt /requirements-alpine.txt
+RUN cat /requirements-alpine.txt /requirements-global.txt > /requirements.txt
 
 # The cryptography package has to be built specially for Alpine before it can be installed,
 # so we have to install it on the "host" (which builds a wheel) before installing for the distribution.
@@ -74,10 +74,6 @@ RUN apt-get update \
     && dpkg -i "session-manager-plugin.deb" \
     && /usr/local/sessionmanagerplugin/bin/session-manager-plugin  --version
 
-#
-# Google Cloud SDK
-#
-FROM google/cloud-sdk:$GOOGLE_CLOUD_SDK_VERSION-alpine as google-cloud-sdk
 
 #
 # Geodesic base image
@@ -171,24 +167,6 @@ COPY --from=python /usr/local/bin/bindfs /usr/local/bin/bindfs
 
 # Install AWS CLI session manager plugin
 COPY --from=session-manager-plugin /usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/session-manager-plugin
-
-#
-# Install Google Cloud SDK
-#
-ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
-
-COPY --from=google-cloud-sdk /google-cloud-sdk/ /usr/local/google-cloud-sdk/
-
-RUN ln -s /usr/local/google-cloud-sdk/completion.bash.inc /etc/bash_completion.d/gcloud.sh && \
-    ln -s /usr/local/google-cloud-sdk/bin/gcloud /usr/local/bin/ && \
-    ln -s /usr/local/google-cloud-sdk/bin/gsutil /usr/local/bin/ && \
-    ln -s /usr/local/google-cloud-sdk/bin/bq /usr/local/bin/
-
-# gcloud config writes successful status updates to stderr, but we want to preserve
-# stderr for real errors in need of action.
-RUN { gcloud config set core/disable_usage_reporting true --installation && \
-      gcloud config set component_manager/disable_update_check true --installation && \
-      gcloud config set metrics/environment github_docker_image --installation; } 2>&1
 
 # Explicitly set  KUBECONFIG to enable kube_ps1 prompt
 ENV KUBECONFIG=/conf/.kube/config

--- a/os/alpine/requirements.txt
+++ b/os/alpine/requirements.txt
@@ -1,0 +1,4 @@
+cryptography==42.0.5
+PyYAML==6.0.1
+awscli==1.32.93
+boto3==1.34.93

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -2,15 +2,15 @@
 # https://hub.docker.com/_/debian
 # We use codename (bookworm) instead of version number (12) because we want to select
 # the matching Python Docker image, which is named after the codename only.
-# bookworm-20240130 corresponds to Debian 12.4
+# bookworm-20240423 corresponds to Debian 12.5
 ARG DEBIAN_CODENAME=bookworm
 # Debian codenamed images are tagged with date codes rather than minor version numbers.
-ARG DEBAIN_DATECODE=20240130
+ARG DEBAIN_DATECODE=20240423
 # Find the current version of Python at https://www.python.org/downloads/source/
-ARG PYTHON_VERSION=3.12.2
+ARG PYTHON_VERSION=3.12.3
 
 # https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=463.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=472.0.0
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
@@ -113,6 +113,9 @@ USER root
 # Keep dpkg quiet about running non-interactively
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
+# Make Cloud Posse repo the preference for `kubectl` because
+# the Google Cloud SDK repo uses a different versioning scheme
+COPY os/debian/rootfs/etc/apt/preferences.d/kubectl-preferences /etc/apt/preferences.d/kubectl-preferences
 COPY packages.txt packages-amd64-only.txt os/debian/packages-debian.txt /etc/apt/
 
 ## Here is where we would copy in the repo checksum in an attempt to ensure updates bust the Docker build cache
@@ -121,15 +124,24 @@ COPY packages.txt packages-amd64-only.txt os/debian/packages-debian.txt /etc/apt
 RUN apt-get update && apt-get install -y apt-utils curl
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/cloudposse/packages/cfg/setup/bash.deb.sh' | bash
 
-# Install packages, but do not yet install the Google package repo because we do not want their version of kubectl
-RUN apt-get update && apt-get install -y \
-    $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing)//g' ) && \
-    mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
-    touch /conf/.gitconfig
+# Add OpenTofu package repo
+RUN curl -fsSL https://get.opentofu.org/opentofu.gpg > /etc/apt/keyrings/opentofu.gpg && \
+    curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | \
+      gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu-repo.gpg >/dev/null && \
+    chmod a+r /etc/apt/keyrings/opentofu.gpg /etc/apt/keyrings/opentofu-repo.gpg && \
+    printf "%s [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main\n" \
+        "deb" "deb-src" > /etc/apt/sources.list.d/opentofu.list && \
+    chmod a+r /etc/apt/sources.list.d/opentofu.list
 
 # Install Google package repo
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+# Install packages
+RUN apt-get update && apt-get install -y \
+    $(grep -h -v '^#' /etc/apt/packages.txt /etc/apt/packages-debian.txt | sed -E 's/@(cloudposse|community|testing)//g' ) && \
+    mkdir -p /etc/bash_completion.d/ /etc/profile.d/ /conf && \
+    touch /conf/.gitconfig
 
 
 # Here is where we would confirm that the package repo checksum is what we expect (not mismatched due to Docker layer cache)

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -132,8 +132,9 @@ RUN curl -fsSL https://get.opentofu.org/opentofu.gpg > /etc/apt/keyrings/opentof
     chmod a+r /etc/apt/sources.list.d/opentofu.list
 
 # Install Google package repo
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl -1sLf 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main"  \
+      > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
 # Install packages
 RUN apt-get update && apt-get install -y \

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -9,8 +9,6 @@ ARG DEBAIN_DATECODE=20240423
 # Find the current version of Python at https://www.python.org/downloads/source/
 ARG PYTHON_VERSION=3.12.3
 
-# https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION=472.0.0
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
@@ -164,21 +162,6 @@ WORKDIR /tmp
 # Copy python dependencies
 COPY --from=python /usr/local/ /usr/local/
 
-#
-# Install Google Cloud SDK (requires Python)
-# This is separate so that updating it does not invalidate the Docker cache layer with all the packages installed above
-# https://cloud.google.com/sdk/docs/release-notes
-ARG GOOGLE_CLOUD_SDK_VERSION
-ENV CLOUDSDK_CONFIG=/localhost/.config/gcloud/
-
-RUN apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_SDK_VERSION}-\*
-
-# gcloud config writes successful status updates to stderr, but we want to preserve
-# stderr for real errors in need of action.
-RUN { gcloud config set core/disable_usage_reporting true --installation && \
-      gcloud config set component_manager/disable_update_check true --installation && \
-      gcloud config set metrics/environment github_docker_image --installation; } 2>&1
-
 # Explicitly set  KUBECONFIG to enable kube_ps1 prompt
 ENV KUBECONFIG=/conf/.kube/config
 # Install an empty kubeconfig to suppress some warnings
@@ -304,10 +287,11 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 # Move AWS CLI v1 aside and install AWS CLI v2 as default, leaving both available as alternatives.
 # We do this at the end because we need cache busting from above to get us the latest AWS CLI v2
 
-RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
+RUN if [[ -x /usr/local/bin/aws ]]; then mv /usr/local/bin/aws /usr/local/bin/aws1 && \
     mv /usr/local/bin/aws_completer /usr/local/bin/aws1_completer && \
     update-alternatives --install /usr/local/bin/aws aws /usr/local/bin/aws1 1  \
-    --slave /usr/local/bin/aws_completer aws_completer /usr/local/bin/aws1_completer
+    --slave /usr/local/bin/aws_completer aws_completer /usr/local/bin/aws1_completer; \
+    fi
 
 # Install AWS CLI 2
 # Get AWS CLI V2 version from https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst if you want

--- a/os/debian/rootfs/etc/apt/preferences.d/kubectl-preferences
+++ b/os/debian/rootfs/etc/apt/preferences.d/kubectl-preferences
@@ -1,0 +1,7 @@
+Package: kubectl
+Pin: origin "dl.cloudsmith.io"
+Pin-Priority: 900
+
+Package: kubectl
+Pin: origin "packages.cloud.google.com"
+Pin-Priority: 50

--- a/packages.txt
+++ b/packages.txt
@@ -31,16 +31,12 @@ helm@cloudposse
 helm3@cloudposse
 helmfile@cloudposse
 jq
-# The latest version of kubectl is wrong for most of our customers, but the
-# version-specific packages are organized to automatically configure the latest
-# installed version as the default, meaning if we install a version and a user
-# installs an earlier version, the earlier version will not be the default version
-# even though the user explicitly installed it, which is very confusing.
-# Also, we do not have a good mechanism for keeping the installed kubectl version
-# up-to-date other than referencing the latest package. So we install the latest
-# version and hope it throws appropriate errors and/or warnings when working
-# with an older version, which is a better bet than hoping an old version gives
-# appropriate error messages about working with a newer version.
+# We install the Cloud Posse kubectl package, which has the latest version of kubectl.
+# However, for Debian, we have to suppress the kubectl package from the
+# Google Cloud SDK repository, because they use an entirely different versioning scheme.
+# Also, we use the Debian "alternatives" system to manage the kubectl binary,
+# and provide `kubectl-1.x` packages for each minor version of kubectl,
+# and they automatically configure themselves to override this default version.
 kubectl@cloudposse
 kubectx@cloudposse
 kubens@cloudposse
@@ -54,7 +50,7 @@ pandoc@cloudposse
 postgresql-client
 pwgen
 python3
-# We specially custom built and packaged rakkess v0.5.1 for linux/arm64 to support EKS access entry validation 2024-03-06
+# We specially built and packaged rakkess v0.5.1 for linux/arm64 to support EKS access entry validation 2024-03-06
 rakkess@cloudposse
 rbac-lookup@cloudposse
 retry@cloudposse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-cryptography==42.0.5
-PyYAML==6.0.1
-awscli==1.32.93
-boto3==1.34.93
 crudini==0.9.5

--- a/rootfs/usr/local/bin/grafana-db
+++ b/rootfs/usr/local/bin/grafana-db
@@ -23,7 +23,7 @@ Usage:
 
 Example:
   # Load the latest version of kube-prometheus standard Kubernetes Grafana dashboards, replacing any already uploaded
-  grafana-db --overwrite https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
+  grafana-db --overwrite https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/main/manifests/grafana-dashboardDefinitions.yaml
 
   # Load the Kubernetes Capacity dashboard with gnetId 5228 from Grafana.com
   grafana-db 5228


### PR DESCRIPTION
## Breaking Changes

- Google Cloud SDK is no longer pre-installed. The Google Cloud Debian package repository is installed, so you can install it into Debian with `apt-get`. 
- AWS CLI v1 is no longer installed in Debian. The CLI v2 has been the default for Debian Geodesic for almost 3 years, so this should impact many people, if any.
- Python dependencies of AWS CLI v2 (including `boto3`) are also no longer pre-installed on Debian. 


## what

### All OSes

  - Update repository default branch name `master` -> `main`
  - Google Cloud SDK is no longer installed

### Debian only

  - Update Debian 12.4 -> 12.5
  - Update Python 3.12.2 -> 2.12.3
  - Add [OpenTofu Debian package repository](https://opentofu.org/docs/intro/install/deb/)
  - Pin `kubectl` package to Cloud Posse repository over Google Cloud SDK repository

### Alpine only

  - Update `bindfs` on Alpine 1.17.6 -> 1.17.7
  - Install Alpine v3.19 `community` package repo as `@opentofu`

## why

- Branch name: Conform to Cloud Posse and GitHub standards.
- The `google-cloud-sdk` package is deprecated in favor of `google-cloud-cli` and additional packages. For example, the current version of the Google Cloud CLI [is 474.0.0](https://cloud.google.com/sdk/docs/release-notes#47400_2024-04-30), but the latest `google-cloud-sdk` package version is 467.0.0.
- Recent releases of Google Cloud SDK ([474.0.0](https://cloud.google.com/sdk/docs/release-notes#47400_2024-04-30), [473.0.0](https://cloud.google.com/sdk/docs/release-notes#47300_2024-04-23), and [470.0.0](https://cloud.google.com/sdk/docs/release-notes#47000_2024-03-26)) have had breaking changes, making it important that users have control over which version they use and when they change versions. There is no longer a single good choice of which version to install, so Cloud Posse does not want force one on anyone.
- Reduce size of distributed Docker image.
- Debian version, Debian Python version, Alpine BindFS version: Stay current.
- Enable [OpenTofu](https://opentofu.org/) to be installed easily:
  - On Debian: `apt-get update && apt-get install tofu` (or ... `tofu=1.6.2`)
  - On Alpine: `apk update && apk add opentofu@opentofu`
- Google Cloud SDK package repo has a package named `kubectl` that installs multiple versions of `kubectl`, causing excessive bloat. Cloud Posse's `kubectl` package installs only the latest version, sufficient for `kubectl-auto-select` to determine and install the correct version for your cluster. Cloud Posse provides `kubectl-1.x` packages which take advantage of the Debian Alternatives system to allow both versions to be present but automatically select the more specific package's version to be used by default, but this feature is not compatible with Google's package.

## references

- [OpenTofu](https://opentofu.org/)
- Google Cloud SDK [v473.0.0 Release Notes](https://cloud.google.com/sdk/docs/release-notes#47300_2024-04-23)
- Google Cloud SDK [v474.0.0 Release Notes](https://cloud.google.com/sdk/docs/release-notes#47400_2024-04-30)
- Google Cloud Community post [referencing deprecation](https://www.googlecloudcommunity.com/gc/Developer-Tools/apt-get-install-google-cloud-sdk-stopped-working/m-p/710520#M2022) of `google-cloud-sdk`