### PR TITLE
Fix colorized string in prompt

### DIFF
--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -100,7 +100,7 @@ function export_current_aws_role() {
 		fi
 		echo "* $(red Profile is set to $profile_target but current role does not match:)"
 		echo "*   $(red $current_role)"
-		export ASSUME_ROLE=$(red '!mixed!')
+		export ASSUME_ROLE=$(red-n '!mixed!')
 		return
 	fi
 


### PR DESCRIPTION
## what

- Fix colorized text added to prompt without delimiters for color codes by `aws.sh`

## why

- Bash counts the characters in the prompt to manage viewing and editing command history. Non-printing characters must be delimited so they are not counted in the prompt text length.
