### PR TITLE
Migrate Renovate configuration (base -> recommended) per validator

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,23 @@
 {
   "timezone": "America/Los_Angeles",
   "extends": [
-    "config:base",
+    "config:recommended",
     "docker:disableMajor"
+  ],
+  "ignorePaths": [
+    "os/alpine/**",
+    "rootfs/**"
   ],
   "packageRules": [
     {
-      "packageNames": ["awscli","boto3"],
-      "groupName": ["AWS CLI packages"],
-      "schedule": ["after 4pm on friday"]
+      "matchPackageNames": [
+        "awscli",
+        "boto3"
+      ],
+      "groupName": "AWS CLI packages",
+      "schedule": [
+        "after 4pm on friday"
+      ]
     }
   ],
   "github-actions": {


### PR DESCRIPTION
## what

- Migrate Renovate configuration (from base of `config:base` to `config:recommended`) per **validator**

## why

- Mend Renovate recommended update

## references

- https://docs.renovatebot.com/release-notes-for-major-versions/#breaking-changes-for-36