### PR TITLE
Ignore updates to Alpine

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,8 +5,8 @@
     "docker:disableMajor"
   ],
   "ignorePaths": [
-    "os/alpine/**",
-    "rootfs/**"
+    "**/os/alpine/**",
+    "**/rootfs/**"
   ],
   "packageRules": [
     {
@@ -25,6 +25,8 @@
   },
   "dockerfile": {
     "ignorePaths": [
+      "**/os/alpine/**",
+      "**/rootfs/**",
       "Dockerfile.custom",
       "Dockerfile.options"
     ]


### PR DESCRIPTION
## what

- Configure Renovate to Ignore updates to Alpine version of Geodesic

## why

- No longer supporting Alpine

