### PR TITLE
Update dependencies and tools

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -2,28 +2,25 @@
 # https://hub.docker.com/_/debian
 # We use codename (bookworm) instead of version number (12) because we want to select
 # the matching Python Docker image, which is named after the codename only.
-# bookworm-20240513 corresponds to Debian 12.5
+# bookworm-20240722 corresponds to Debian 12.6
 ARG DEBIAN_CODENAME=bookworm
 # Debian codenamed images are tagged with date codes rather than minor version numbers.
-ARG DEBAIN_DATECODE=20240513
+ARG DEBAIN_DATECODE=20240722
 # Find the current version of Python at https://www.python.org/downloads/source/
-ARG PYTHON_VERSION=3.12.3
+ARG PYTHON_VERSION=3.12.4
 
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.5
 # https://github.com/jonmosco/kube-ps1/releases
-ARG KUBE_PS1_VERSION=0.8.0
+ARG KUBE_PS1_VERSION=0.9.0
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#plugin-version-history
 ARG SESSION_MANAGER_PLUGIN_VERSION=latest
 
 # Helm plugins:
 # https://github.com/databus23/helm-diff/releases
-ARG HELM_DIFF_VERSION=3.9.4
+ARG HELM_DIFF_VERSION=3.9.9
 # https://github.com/aslafy-z/helm-git/releases
-# We had issues with helm-diff 3.1.3 + helm-git 0.9.0,
-# previous workaround was to pin helm-git to version 0.8.1.
-# We expect this has been fixed now with helm-diff 3.3.2 + helm-git 0.11.1
-ARG HELM_GIT_VERSION=0.15.1
+ARG HELM_GIT_VERSION=1.3.0
 
 
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME} as python

--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -1,6 +1,6 @@
 #!/bin/bash
 export DOCKER_IMAGE="{{getenv "DOCKER_IMAGE" "cloudposse/geodesic"}}"
-export DOCKER_TAG="{{- getenv "DOCKER_TAG" (printf "${1:-%s-%s}" ((index (split (getenv "GEODESIC_VERSION") " ") 0) | default "dev") (getenv "GEODESIC_OS" "alpine")) -}}"
+export DOCKER_TAG="{{- getenv "DOCKER_TAG" (printf "${1:-%s-%s}" ((index (strings.Split (getenv "GEODESIC_VERSION") " ") 0) | default "dev") (getenv "GEODESIC_OS" "alpine")) -}}"
 export APP_NAME=${APP_NAME:-$(basename $DOCKER_IMAGE)}
 export INSTALL_PATH=${INSTALL_PATH:-/usr/local/bin}
 export SAFE_INSTALL_PATH="$HOME/.local/bin" # per XDG recommendations


### PR DESCRIPTION
## what

- Update Debian 12.5 -> 12.6
- Update Python 3.12.3 -> 3.12.4
- Update [kube-ps1](https://github.com/jonmosco/kube-ps1) 0.8.0 -> 0.9.0
- Update [helm-diff](https://github.com/databus23/helm-diff) 3.9.4 -> 3.9.9
- Update [helm-git](https://github.com/aslafy-z/helm-git) 0.15.1 -> 1.3.0
- Update bootstrap `gomplate` template to use `strings.Split` instead of deprecated `split`
- Update all unpinned packages to latest released versions
  - Updates [OpenTofu](https://opentofu.org/) 1.7.1 -> 1.7.3

## why

- Keep current

