### PR TITLE
Update Python to 3.12.5, fix init script

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -5,9 +5,9 @@
 # bookworm-20240722 corresponds to Debian 12.6
 ARG DEBIAN_CODENAME=bookworm
 # Debian codenamed images are tagged with date codes rather than minor version numbers.
-ARG DEBAIN_DATECODE=20240722
+ARG DEBAIN_DATECODE=20240812
 # Find the current version of Python at https://www.python.org/downloads/source/
-ARG PYTHON_VERSION=3.12.4
+ARG PYTHON_VERSION=3.12.5
 
 # https://github.com/ahmetb/kubectx/releases
 ARG KUBECTX_COMPLETION_VERSION=0.9.5
@@ -23,7 +23,7 @@ ARG HELM_DIFF_VERSION=3.9.9
 ARG HELM_GIT_VERSION=1.3.0
 
 
-FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME} as python
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME} AS python
 
 # Debian comes with minimal Locale support. See https://github.com/docker-library/docs/pull/703/files
 # Recommended: LC_ALL=C.UTF-8

--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -1,6 +1,6 @@
 #!/bin/bash
 export DOCKER_IMAGE="{{getenv "DOCKER_IMAGE" "cloudposse/geodesic"}}"
-export DOCKER_TAG="{{- getenv "DOCKER_TAG" (printf "${1:-%s-%s}" ((index (strings.Split (getenv "GEODESIC_VERSION") " ") 0) | default "dev") (getenv "GEODESIC_OS" "alpine")) -}}"
+export DOCKER_TAG="{{- getenv "DOCKER_TAG" (printf "${1:-%s-%s}" ((index (getenv "GEODESIC_VERSION" | strings.Split " ") 0) | default "dev") (getenv "GEODESIC_OS" "alpine")) -}}"
 export APP_NAME=${APP_NAME:-$(basename $DOCKER_IMAGE)}
 export INSTALL_PATH=${INSTALL_PATH:-/usr/local/bin}
 export SAFE_INSTALL_PATH="$HOME/.local/bin" # per XDG recommendations


### PR DESCRIPTION
## what

- Update Python 3.12.4 -> 3.12.5
- Update Debian 12.6 from 20240722 to 20240812
- Fix conversion of `gomplate` `split` to `strings.Split` done wrong in #953 

## why

- Stay current
- Fix #954 

