### PR TITLE
feat: add `geodesic` devcontainer for Codespaces usage

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,62 @@
+{
+  "name": "Geodesic",
+  "security.workspace.trust.emptyWindow": true,
+  "security.workspace.trust.untrustedFiles": "prompt",
+  "security.workspace.trust.domain": {
+    "*.github.com": true,
+    "*.app.github.dev": true,
+    "localhost": true
+  },
+  "build": {
+    "dockerfile": "os/debian/Dockerfile.debian",
+    "context": "."
+  },
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "8gb",
+    "storage": "20gb"
+  },
+  "runArgs": ["-v", "/var/run/docker.sock:/var/run/docker.sock"],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "bierner.github-markdown-preview",
+        "tomasdahlqvist.markdown-admonitions",
+        "HashiCorp.terraform",
+        "redhat.vscode-yaml",
+        "EditorConfig.EditorConfig"
+      ],
+      "settings": {
+        "git.openRepositoryInParentFolders": "always",
+        "git.autofetch": true,
+        "git.showProgress": true,
+        "workbench.startupEditor": "readme",
+        "workbench.editor.autoLockGroups": {
+          "readme": "/README.md"
+        },
+        "workbench.editorAssociations": {
+          "*.md": "vscode.markdown.preview.editor"
+        },
+        "terminal.integrated.tabs.title": "Geodesic (${process})",
+        "terminal.integrated.tabs.description": "${task}${separator}${local}${separator}${cwdFolder}",
+        "terminal.integrated.shell.linux": "/bin/bash",
+        "terminal.integrated.allowWorkspaceConfiguration": true,
+        "terminal.integrated.commandsToSkipShell": [],
+        "yaml.schemaStore.enable": true,
+        "json.schemas": [],
+        "yaml.schemas": {
+          "https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json": [
+            "**/stacks/**/*.yaml",
+            "!**/stacks/workflows/**/*.yaml",
+            "!**/stacks/schemas/**/*.yaml"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -47,12 +47,17 @@ Then share the resulting container with everyone on your team to ensure everyone
 - **Version Control for Tools**: Geodesic facilitates easy versioning of tools for different environments, enabling repeatable setups and minimizing compatibility issues.
 - **Reusable Base Image for Toolboxes**: Empower teams to create and maintain consistent toolbox images, ensuring a standardized development environment across the board.
 
+> [!TIP]
+> ### You can try out `geodesic` directly in your browser using GitHub Codespaces
+>
+> [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=cloudposse/geodesic&skip_quickstart=true)
+>
+> <i>Already start one? Find it [here](https://github.com/codespaces).</i>
+>
+
 ## Screenshots
 
 <img src="docs/demo.gif" alt="Demo" />*<br/>Example of running a shell based on the `cloudposse/geodesic` base docker image.*
-
-
-
 
 ## Introduction
 
@@ -330,3 +335,4 @@ Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/geodesic&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
 
 <img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/geodesic?pixel&cs=github&cm=readme&an=geodesic"/>
+


### PR DESCRIPTION
## what

- Add devcontainer for basic Debian Geodesic build
- Incorporate develeper experience VS Code plugins for easier documentation readability and terminal configurations
- Adds README button for accessing Codespaces and creating devcontainer

### issues

> [!CAUTION]
> This PR is still in active development

- [X] Devcontainer spins up in Geodesic shell but does not display prompt
- Maybe there is a better way of doing this? (Docker in Docker)
## why

- Make it easier for the community to test and kick the tires on Geodesic

## references

- [Codespaces Documentation](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers)
