### PR TITLE
Fix #964

### DIFF
--- a/rootfs/etc/profile.d/_40-preferences.sh
+++ b/rootfs/etc/profile.d/_40-preferences.sh
@@ -56,7 +56,7 @@ elif [[ -z $(find "${WORKSPACE_MOUNT}" -mindepth 1 -maxdepth 1) ]]; then
 	red "# No files found under $(bold "${WORKSPACE_MOUNT}")." | _term_fold >&2
 	red "# Run Geodesic from your source directory." | _term_fold >&2
 	red "# Change (\`cd\`) to your source directory (in your git repo)" | _term_fold >&2
-	red "# and run ${APP_NAME:-Geodesic} from there." | _term_fold >&2
+	red "# and run ${APP_NAME:-${NAMESPACE:-$(basename ${DOCKER_IMAGE:-geodesic})}} from there." | _term_fold >&2
 	red "################################################################" >&2
 	echo
 fi

--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -1,7 +1,7 @@
 #!/bin/bash
 export DOCKER_IMAGE="{{getenv "DOCKER_IMAGE" "cloudposse/geodesic"}}"
 export DOCKER_TAG="{{- getenv "DOCKER_TAG" (printf "${1:-%s-%s}" ((index (getenv "GEODESIC_VERSION" | strings.Split " ") 0) | default "dev") (getenv "GEODESIC_OS" "debian")) -}}"
-export APP_NAME=${APP_NAME:-$(basename $DOCKER_IMAGE)}
+export APP_NAME=${APP_NAME:-${NAMESPACE:-$(basename ${DOCKER_IMAGE:-geodesic})}}
 export INSTALL_PATH=${INSTALL_PATH:-/usr/local/bin}
 export SAFE_INSTALL_PATH="$HOME/.local/bin" # per XDG recommendations
 export INSTALLER_NAME="${APP_NAME}-installer"
@@ -90,7 +90,7 @@ else
 	exit 1
 fi
 
-command -v hash 2>/dev/null && hash -r  # forget hashed location of $APP_NAME
+command -v hash 2>/dev/null && hash -r # forget hashed location of $APP_NAME
 if [ ! "${INSTALL_PATH}/${APP_NAME}" -ef "$(command -v "${APP_NAME}" 2>/dev/null)" ]; then
 	if [ -x "${INSTALL_PATH}/${APP_NAME}" ]; then
 		if [ -n "$(command -v "${APP_NAME}" 2>/dev/null)" ]; then

--- a/rootfs/templates/wrapper-body.sh
+++ b/rootfs/templates/wrapper-body.sh
@@ -137,7 +137,9 @@ function parse_args() {
 			;;
 		--workspace=*)
 			unset WORKSPACE_FOLDER_HOST_DIR
-			;& # fall through
+			# ;& # fall through only introduced in bash 4.0, we want to remain 3.2 compatible
+			options+=("${arg}")
+			;;
 		--*)
 			options+=("${arg}")
 			;;

--- a/rootfs/templates/wrapper-body.sh
+++ b/rootfs/templates/wrapper-body.sh
@@ -120,7 +120,7 @@ function parse_args() {
 		--solo)
 			export ONE_SHELL=true
 			;;
-		--no-solo|--no-one-shell)
+		--no-solo | --no-one-shell)
 			export ONE_SHELL=false
 			;;
 		--trace)


### PR DESCRIPTION
## what

- Fix wrapper to be compatible with `bash` 3.2
- Prefer `NAMESPACE` (if set) to `basename $DOCKER_IMAGE` as default for `APP_NAME`

## why

- `bash` 3.2 was the last GPL licensed version and is what ships with macOS
- Better reflect common usage

## references

- Fixes #964 

