### PR TITLE
V4 second bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,9 @@ Those package repositories are pre-installed in Geodesic, so
 all you need to do is add the packages you want via
 
 ```Dockerfile
-RUN apt-get update && apt-get install -y` commands in your Dockerfile.
+RUN apt-get update && apt-get install -y <package-name>...
 ```
-
-The package manager will automatically select the correct architecture for the package.
+commands in your Dockerfile. The package manager will automatically select the correct architecture for the package.
 
 #### Pinning package versions in Debian
 

--- a/README.yaml
+++ b/README.yaml
@@ -236,10 +236,9 @@ usage: |-
   all you need to do is add the packages you want via
 
   ```Dockerfile
-  RUN apt-get update && apt-get install -y` commands in your Dockerfile.
+  RUN apt-get update && apt-get install -y <package-name>...
   ```
-
-  The package manager will automatically select the correct architecture for the package.
+  commands in your Dockerfile. The package manager will automatically select the correct architecture for the package.
 
   #### Pinning package versions in Debian
 

--- a/os/alpine/requirements-Alpine-disabled.txt
+++ b/os/alpine/requirements-Alpine-disabled.txt
@@ -1,4 +1,4 @@
-cryptography==43.0.1
+cryptography==44.0.1
 PyYAML==6.0.1
 awscli==1.33.10
 boto3==1.34.128

--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -95,7 +95,7 @@ ENV XDG_CACHE_HOME=/var/cache/xdg_cache_home
 RUN for dir in $XDG_DATA_HOME $XDG_CONFIG_HOME $XDG_CACHE_HOME; do \
 	mkdir -p $dir; chmod 777 $dir; done
 
-ENV BANNER "geodesic"
+ENV BANNER="geodesic"
 
 # Install all packages as root
 USER root

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -50,8 +50,13 @@ function reload() {
 	if [ "${current_screen_size}" != "${SCREEN_SIZE}" ]; then
 		echo "* Screen resized to ${current_screen_size}"
 		export SCREEN_SIZE=${current_screen_size}
+		# Use this opportunity to see if the terminal color mode has changed
+		export GEODESIC_TERM_COLOR_UPDATING="needed"
 		# Instruct shell that window size has changed to ensure lines wrap correctly
 		kill -WINCH $$
+	fi
+	if [[ $GEODESIC_TERM_COLOR_UPDATING == "needed" ]]; then
+		auto-update-terminal-color-mode
 	fi
 }
 

--- a/rootfs/templates/wrapper-body.sh
+++ b/rootfs/templates/wrapper-body.sh
@@ -135,7 +135,19 @@ function parse_args() {
 		--no-motd*)
 			export GEODESIC_MOTD_ENABLED=false
 			;;
+		--workspace)
+			# WORKSPACE_FOLDER_HOST_DIR takes precedence over WORKSPACE, but we allow the command line option to override both
+			# So even thought the option is --workspace, we still set WORKSPACE_FOLDER_HOST_DIR
+			# We unset WORKSPACE to avoid a warning later when they are both set to different values
+			unset WORKSPACE
+			[ -n "$WORKSPACE_FOLDER_HOST_DIR" ] && echo "# Ignoring WORKSPACE_FOLDER_HOST_DIR=$WORKSPACE_FOLDER_HOST_DIR because --workspace is set" >&2
+			WORKSPACE_FOLDER_HOST_DIR="${1}"
+			shift
+			;;
 		--workspace=*)
+			# WORKSPACE_FOLDER_HOST_DIR takes precedence over WORKSPACE, but to save ourselves hassle over parsing the option,
+			# we just unset WORKSPACE_FOLDER_HOST_DIR and let normal option processing set WORKSPACE
+			[ -n "$WORKSPACE_FOLDER_HOST_DIR" ] && echo "# Ignoring WORKSPACE_FOLDER_HOST_DIR=$WORKSPACE_FOLDER_HOST_DIR because --workspace is set" >&2
 			unset WORKSPACE_FOLDER_HOST_DIR
 			# ;& # fall through only introduced in bash 4.0, we want to remain 3.2 compatible
 			options+=("${arg}")


### PR DESCRIPTION
## what

- Move update of terminal color mode from signal handler to prompt command
- Fix typo in README (thanks @petabook)
- Rename `os/alpine/requirements.txt` -> `os/alpine/requirements-Alpine-disabled.txt`
- Allow the `--workspace` command-line option to use `=` or space, e.g. `--workspace=$HOME/dev` or `--workspace $HOME/dev`

## why

- Fixes #967 
- Fixes and supersedes #966 (which did not regenerate README.md)
- The Alpine implementation is obsolete but being kept for reference and historical context, how ever Dependabot keeps trying to update it with security patches. This removes one source of unnecessary updates.
- Better user experience

