### PR TITLE
Fix Role Prompt, bypass buggy secrets check, add lsb_release

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -236,8 +236,7 @@ RUN helm3 plugin install https://github.com/databus23/helm-diff.git --version v$
 # AWS_DATA_PATH is a PATH-like variable for configuring the AWS botocore library to
 # load additional modules. Do not set it.
 ARG GEODESIC_AWS_HOME=${HOME}/.aws
-ENV AWS_CONFIG_FILE=${GEODESIC_AWS_HOME}/config
-ENV AWS_SHARED_CREDENTIALS_FILE=${GEODESIC_AWS_HOME}/credentials
+
 # Region abbreviation types are "fixed" (always 3 chars), "short" (4-5 chars), or "long" (the full AWS string)
 # See https://github.com/cloudposse/terraform-aws-utils#introduction
 ENV AWS_REGION_ABBREVIATION_TYPE=short
@@ -319,6 +318,14 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     -o "/tmp/session-manager-plugin.deb" && \
     sudo dpkg -i /tmp/session-manager-plugin.deb && \
     rm -f /tmp/session-manager-plugin.deb
+
+# This is a workaround for https://github.com/moby/buildkit/issues/5775
+# CHAMBER_KMS_KEY_ALIAS is used by the `chamber` CLI, but it is incorrectly
+# flagged as a secret by the SecretsUsedInArgOrEnv check. This is a false positive.
+# So, as a workaround, we allow you to set `CHAMBER_KMS_ALIAS` instead,
+# and at runtime we copy the value to `CHAMBER_KMS_KEY_ALIAS` for you.
+ENV CHAMBER_KMS_ALIAS=aws/ssm
+
 
 # Install documentation
 COPY docs/ /usr/share/docs/

--- a/packages.txt
+++ b/packages.txt
@@ -40,6 +40,7 @@ kubectl@cloudposse
 kubectx@cloudposse
 kubens@cloudposse
 less
+lsb-release
 make
 man-db
 openssh-client

--- a/rootfs/etc/profile.d/_10-colors.sh
+++ b/rootfs/etc/profile.d/_10-colors.sh
@@ -10,6 +10,28 @@
 # The main change is that it uses the terminal's default colors for foreground and background,
 # whereas the previous version "reset" the color by setting it to black, which fails in dark mode.
 
+# These utilities use basic ANSI color codes (0-7) to colorize text in the terminal.
+# Besides being the most widely supported method, it also has the advantage
+# that terminals that support colored text and backgrounds as themes often
+# take responsibility for the ANSI colors being legible regardless of the theme.
+# For example, on a completely red background, the ANSI red color will be changed
+# as part of the theme to a lighter or darker shade of red to ensure it is legible.
+# This would not be the case if we tried to set the color directly using RGB values,
+# or even using extended ANSI colors.
+
+# To test a terminal manually, the following script displays all 256 ANSI colors.
+# Our color functions only use 1 through 6.
+# We indirectly support 0 and 7 (black and white), reversing them in dark mode,
+# but we do not provide direct functions for them.
+# We support a "bold" modifier, which some terminals equate to colors 8 through 15.
+#
+# for i in {0..255}; do
+#    printf "\e[38;5;${i}mcolor%-5i\e[0m" $i
+#    if [ $((($i + 1) % 8)) == 0 ]; then
+#        echo
+#    fi
+# done
+
 function update-terminal-theme() {
 	local new_mode="$1"
 	local quiet=false

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# shellcheck disable=SC2155
+# Above directive suppresses ShellCheck SC2155: Declare and assign separately to avoid masking return values.
+# In this script, we do not care about return values, as problems are detected by the resulting empty value.
 
 export AWS_REGION_ABBREVIATION_TYPE=${AWS_REGION_ABBREVIATION_TYPE:-fixed}
 export AWS_DEFAULT_SHORT_REGION=${AWS_DEFAULT_SHORT_REGION:-$(aws-region --${AWS_REGION_ABBREVIATION_TYPE} ${AWS_DEFAULT_REGION:-us-west-2})}
@@ -252,7 +255,7 @@ function refresh_current_aws_role_if_needed() {
 	local is_exported="^declare -[^ x]*x[^ x]* "
 	local aws_profile=$(declare -p AWS_PROFILE 2>/dev/null)
 	[[ $aws_profile =~ $is_exported ]] || aws_profile=""
-	local credentials_mtime=$(stat -c "%Y" ${AWS_SHARED_CREDENTIALS_FILE:-"~/.aws/credentials"} 2>/dev/null)
+	local credentials_mtime=$(stat -c "%Y" ${AWS_SHARED_CREDENTIALS_FILE:-"${GEODESIC_AWS_HOME}/credentials"} 2>/dev/null)
 	local role_fingerprint="${aws_profile}/${credentials_mtime}/${AWS_ACCESS_KEY_ID}"
 	if [[ $role_fingerprint != $GEODESIC_AWS_ROLE_CACHE ]]; then
 		export_current_aws_role

--- a/rootfs/etc/profile.d/aws.sh
+++ b/rootfs/etc/profile.d/aws.sh
@@ -255,7 +255,7 @@ function refresh_current_aws_role_if_needed() {
 	local is_exported="^declare -[^ x]*x[^ x]* "
 	local aws_profile=$(declare -p AWS_PROFILE 2>/dev/null)
 	[[ $aws_profile =~ $is_exported ]] || aws_profile=""
-	local credentials_mtime=$(stat -c "%Y" ${AWS_SHARED_CREDENTIALS_FILE:-"${GEODESIC_AWS_HOME}/credentials"} 2>/dev/null)
+	local credentials_mtime=$(stat -c "%Y" "${AWS_SHARED_CREDENTIALS_FILE:-${GEODESIC_AWS_HOME}/credentials}" 2>/dev/null)
 	local role_fingerprint="${aws_profile}/${credentials_mtime}/${AWS_ACCESS_KEY_ID}"
 	if [[ $role_fingerprint != $GEODESIC_AWS_ROLE_CACHE ]]; then
 		export_current_aws_role

--- a/rootfs/etc/profile.d/chamber.sh
+++ b/rootfs/etc/profile.d/chamber.sh
@@ -1,0 +1,22 @@
+# This is a workaround for https://github.com/moby/buildkit/issues/5775
+#
+# The `chamber` command (https://github.com/segmentio/chamber) is a CLI for managing secrets.
+# It is installed in Geodesic and referenced in various documentation.
+#
+# Chamber works with AWS SSM Parameter store to save encrypted parameters.
+# By default, in uses a KMS key with the alias `parameter_store_key`
+# to encrypt and decrypt the parameters. Geodesic supports using
+# the AWS default key, with alias `ssm`, or a custom key.
+#
+# However, due to the issue with buildkit mentioned above,
+# setting the required environment variable in the Dockerfile
+# leads to a warning about it being a secret stored in the image.
+#
+# So, as a workaround, we allow you to set `CHAMBER_KMS_ALIAS` instead,
+# and we will set the `CHAMBER_KMS_KEY_ALIAS` environment variable for you here.
+#
+
+if [[ -z $CHAMBER_KMS_KEY_ALIAS ]] && [[ -n $CHAMBER_KMS_ALIAS ]]; then
+	export CHAMBER_KMS_KEY_ALIAS=$CHAMBER_KMS_ALIAS
+	unset CHAMBER_KMS_ALIAS
+fi

--- a/rootfs/etc/profile.d/chamber.sh
+++ b/rootfs/etc/profile.d/chamber.sh
@@ -16,7 +16,7 @@
 # and we will set the `CHAMBER_KMS_KEY_ALIAS` environment variable for you here.
 #
 
-if [[ -z $CHAMBER_KMS_KEY_ALIAS ]] && [[ -n $CHAMBER_KMS_ALIAS ]]; then
-	export CHAMBER_KMS_KEY_ALIAS=$CHAMBER_KMS_ALIAS
+if [[ -z "$CHAMBER_KMS_KEY_ALIAS" ]] && [[ -n "$CHAMBER_KMS_ALIAS" ]]; then
+	export CHAMBER_KMS_KEY_ALIAS="$CHAMBER_KMS_ALIAS"
 	unset CHAMBER_KMS_ALIAS
 fi


### PR DESCRIPTION
## what

- Fix the script for converting the current AWS IAM role to something short and meaningful for the shell command prompt
- Add support for converting Identity Center Permission Sets to profile names in the shell prompt
- Support setting `CHAMBER_KMS_KEY_ALIAS` via `CHAMBER_KMS_ALIAS`
- Add the `lsb-release` package to provide `lsb_release`

## why

- The code was buggy due too piecemeal changes resulting in unreachable code
- Many people are using Identity Center now
- Setting `CHAMBER_KMS_KEY_ALIAS` as is customary in Cloud Posse Dockerfiles triggers the `SecretsUsedInArgOrEnv` warning. While this is arguably a bug in the warning, this change allows concerned users to avoid the issue.
- Some tool installation scripts require `lsb_release` to be already installed

## references

- `chamber` [KMS key alias](https://github.com/segmentio/chamber?tab=readme-ov-file#setting-up-kms)
- https://github.com/moby/buildkit/issues/5775