### PR TITLE
Fix manual install to use APP_NAME and INSTALL_PATH properly

### DIFF
--- a/rootfs/etc/init.d/bootstrap.sh
+++ b/rootfs/etc/init.d/bootstrap.sh
@@ -1,4 +1,4 @@
-# Otherwise present user with bootstrap script to stdout
+# Otherwise (if not Atlantis) present user with bootstrap script to stdout
 gomplate -f /templates/bootstrap
 
 boot wrapper

--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -1,8 +1,9 @@
 #!/bin/bash
 export DOCKER_IMAGE="{{getenv "DOCKER_IMAGE" "cloudposse/geodesic"}}"
 export DOCKER_TAG="{{- getenv "DOCKER_TAG" (printf "${1:-%s-%s}" ((index (getenv "GEODESIC_VERSION" | strings.Split " ") 0) | default "dev") (getenv "GEODESIC_OS" "debian")) -}}"
-export APP_NAME=${APP_NAME:-${NAMESPACE:-$(basename ${DOCKER_IMAGE:-geodesic})}}
-export INSTALL_PATH=${INSTALL_PATH:-/usr/local/bin}
+# export APP_NAME=${APP_NAME:-${NAMESPACE:-$(basename ${DOCKER_IMAGE:-geodesic})}}
+export APP_NAME="{{- getenv "APP_NAME" (getenv "NAMESPACE" (path.Base (getenv "DOCKER_IMAGE" "geodesic"))) -}}"
+export INSTALL_PATH="{{- getenv "INSTALL_PATH" "/usr/local/bin" -}}"
 export SAFE_INSTALL_PATH="$HOME/.local/bin" # per XDG recommendations
 export INSTALLER_NAME="${APP_NAME}-installer"
 export REQUIRE_PULL=${REQUIRE_PULL:-false}

--- a/rootfs/usr/local/bin/boot
+++ b/rootfs/usr/local/bin/boot
@@ -39,7 +39,7 @@ color "#   docker run --rm ${DOCKER_IMAGE:-cloudposse/geodesic}:${version} init 
 color "#"
 color "# After that, you should be able to launch Geodesic just by typing"
 color "#"
-color "#   $(basename ${DOCKER_IMAGE:-geodesic})"
+color "#   ${APP_NAME:-$(basename ${DOCKER_IMAGE:-Geodesic})}"
 color "#"
 color "########################################################################################"
 echo


### PR DESCRIPTION
## what

- Fix manual install to use `APP_NAME` and `INSTALL_PATH` properly

## why

- When installing without the Makefile, displayed instructions and resulting install did not work 

