### PR TITLE
Fix Excessive CPU usage, fix --solo

### DIFF
--- a/rootfs/templates/wrapper-body.sh
+++ b/rootfs/templates/wrapper-body.sh
@@ -588,6 +588,7 @@ function use() {
 	)
 
 	if [ "$ONE_SHELL" = "true" ]; then
+		[ -t 0 ] && DOCKER_EXEC_ARGS+=(-it)
 		DOCKER_NAME="${DOCKER_NAME}-$(date +%d%H%M%S)"
 		echo "# Starting single shell ${DOCKER_NAME} session from ${DOCKER_IMAGE}"
 		echo "# Exposing port ${GEODESIC_PORT}"

--- a/rootfs/usr/local/sbin/shell-monitor
+++ b/rootfs/usr/local/sbin/shell-monitor
@@ -18,9 +18,6 @@ shells_are_running() {
 shell_has_exited() {
 	local pid
 
-	trap 'set +x' EXIT
-	set -x
-
 	# If there are no shells left, then they have all exited.
 	[[ "${#wrapper_pids[@]}" -eq 0 ]] && return 0
 

--- a/rootfs/usr/local/sbin/shell-monitor
+++ b/rootfs/usr/local/sbin/shell-monitor
@@ -6,15 +6,20 @@ wrapper_pids=()
 
 # Function to count active shell sessions launched by wrapper
 # Expensive, so run sparingly. Only needed to find new shells when they launch.
-count_shells() {
+shells_are_running() {
+	# As a side effect, update the list of running shells
 	wrapper_pids=($(list-wrapper-shells))
-	echo "${#wrapper_pids[@]}"
+	# Return true if there are any shells running
+	[[ "${#wrapper_pids[@]}" -gt 0 ]]
 }
 
 # Function to check if any registered shell has exited.
 # Super efficient, so run as often as needed.
 shell_has_exited() {
 	local pid
+
+	trap 'set +x' EXIT
+	set -x
 
 	# If there are no shells left, then they have all exited.
 	[[ "${#wrapper_pids[@]}" -eq 0 ]] && return 0
@@ -31,25 +36,25 @@ shell_has_exited() {
 # Function to kill all active shell sessions launched by wrapper.
 # This is the shutdown procedure, so we do not care about hogging the CPU.
 kill_shells() {
-	for pid in $(list_wrapper_shells); do
+	for pid in $(list-wrapper-shells); do
 		kill -HUP $pid
 	done
 
 	for i in {1..4}; do
-		[ $(count_shells) -eq 0 ] && return 0
+		shells_are_running || return 0
 		sleep 1
 	done
 
-	for pid in $(list_wrapper_shells); do
+	for pid in $(list-wrapper-shells); do
 		kill -TERM $pid
 	done
 
 	for i in {1..3}; do
-		[ $(count_shells) -eq 0 ] && return 0
+		shells_are_running || return 0
 		sleep 1
 	done
 
-	for pid in $(list_wrapper_shells); do
+	for pid in $(list-wrapper-shells); do
 		kill -KILL $pid
 	done
 
@@ -62,7 +67,7 @@ trap 'kill_shells; exit $?' TERM HUP INT QUIT EXIT
 # Since we are waiting for something to happen, we can afford burn
 # up some CPU in order to be more responsive.
 i=0
-while [ $(count_shells) -eq 0 ]; do
+while ! shells_are_running; do
 	sleep 0.5
 	i=$((i + 1))
 	if [ $i -ge 120 ]; then
@@ -87,7 +92,7 @@ while true; do
 	while ! shell_has_exited; do
 		sleep 0.67
 	done
-	[[ $(count_shells) -eq 0 ]] && break
+	shells_are_running || break
 done
 
 # Clean up and exit


### PR DESCRIPTION
## what

- Fix shell monitoring introduced in v4.1.0 #970 
- Fix `--solo` / `ONE_SHELL=true` option broken in v4.1.0 #970 

## why

- Bug caused shell monitor to burn CPU busy waiting on shell exits rather than sleep and poll
- Oversight in refactoring launch vs exec parameters left out terminal allocation for `--solo` option, causing Geodesic to immediately exit

