### PR TITLE
Split extra args into launch and exec

### DIFF
--- a/ReleaseNotes-v4.md
+++ b/ReleaseNotes-v4.md
@@ -722,3 +722,9 @@ V4 changes:
   a "monorepo" containing multiple projects. It must be an absolute path either equal to or a subdirectory of `WORKSPACE_FOLDER_HOST_DIR`.
 - `GEODESIC_TERM_THEME` is normally unset. Set it to "light" or "dark" _before launching Geodesic_ to disable the initial attempt at automatic terminal light/dark theme detection, and use the set value instead.
 - `GEODESIC_TERM_THEME_AUTO` is normally unset. Set it to "enabled" to enable automatic attempts to detect changes in terminal light/dark theme. This feature should be considered experimental and may not work as expected.
+
+Starting with Geodesic version 4.4.0:
+
+- `GEODESIC_DOCKER_EXTRA_ARGS` is deprecated. Geodesic distinguishes between options for launching a container
+  and options for exec’ing into a running one. Use `GEODESIC_DOCKER_EXTRA_LAUNCH_ARGS` for container launch and
+  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container.

--- a/ReleaseNotes-v4.md
+++ b/ReleaseNotes-v4.md
@@ -727,4 +727,6 @@ Starting with Geodesic version 4.4.0:
 
 - `GEODESIC_DOCKER_EXTRA_ARGS` is deprecated. Geodesic distinguishes between options for launching a container
   and options for exec’ing into a running one. Use `GEODESIC_DOCKER_EXTRA_LAUNCH_ARGS` for container launch and
-  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container.
+  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container. As with `GEODESIC_DOCKER_EXTRA_ARGS`,
+  the new variables are placed unquoted on the command line, so they cannot contain arguments with
+  spaces or other special characters, and quoting will not help.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -44,7 +44,9 @@ Starting with Geodesic version 4.4.0:
 
 - `GEODESIC_DOCKER_EXTRA_ARGS` is deprecated. Geodesic distinguishes between options for launching a container
   and options for exec’ing into a running one. Use `GEODESIC_DOCKER_EXTRA_LAUNCH_ARGS` for container launch and
-  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container.
+  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container. As with `GEODESIC_DOCKER_EXTRA_ARGS`,
+  the new variables are placed unquoted on the command line, so they cannot contain arguments with
+  spaces or other special characters, and quoting will not help.
 
 ### Geodesic Version 3 Environment Variables
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -40,6 +40,12 @@ Geodesic version 4 additions and changes:
 - `MAP_FILE_OWNERSHIP` replaces `GEODESIC_HOST_BINDFS_ENABLED`. If set to true, Geodesic will use `bindfs` to map file ownership
   between the host and container. This not normally needed, as it should be handled automatically by Docker.
 
+Starting with Geodesic version 4.4.0:
+
+- `GEODESIC_DOCKER_EXTRA_ARGS` is deprecated. Geodesic distinguishes between options for launching a container
+  and options for exec’ing into a running one. Use `GEODESIC_DOCKER_EXTRA_LAUNCH_ARGS` for container launch and
+  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container.
+
 ### Geodesic Version 3 Environment Variables
 
 Below is a list of environment variables that may be visible in the shell and were present in Geodesic v3.

--- a/rootfs/etc/profile.d/_01-launch-warning.sh
+++ b/rootfs/etc/profile.d/_01-launch-warning.sh
@@ -11,6 +11,11 @@
 # Specifically, this guards against:
 #   docker run -it cloudposse/geodesic:latest-debian  | bash
 
+# It works by outputting a command that will print a warning message to stderr and then exit,
+# which will be evaluated by the shell receiving the output, which will print the message.
+# It also outputs backspaces to erase the message, so the message does not appear
+# on the screen during the normal startup processing if the output is a terminal.
+
 # If the warning message is longer than the terminal width,
 # on some terminals the message may be truncated. In that case,
 # all the erasure characters will not be printed, and the message will not be erased.
@@ -59,5 +64,5 @@ function warn_if_piped() {
 	trap - EXIT
 }
 
-warn_if_piped
+[[ -t 0 ]] && warn_if_piped
 unset -f warn_if_piped

--- a/rootfs/etc/profile.d/_60-register-stray-shells.sh
+++ b/rootfs/etc/profile.d/_60-register-stray-shells.sh
@@ -21,3 +21,11 @@ if [[ $$ != 1 ]] && [[ $PPID == 0 ]] && [[ -z $G_HOST_PID ]]; then
 	export G_HOST_PID=0
 	[[ -t 0 ]] && yellow '# Detected shell launched by `docker exec` without wrapper info, tracking as stray shell.'
 fi
+
+if [[ $$ == 1 ]] && ! [[ -t 0 ]] && [[ $# -eq 0 ]]; then
+	echo
+	echo "#  You have launched a login shell without a terminal and without a command."
+	echo "#  This is not supported. Please run a command or attach a terminal."
+	echo
+	exit 1
+fi

--- a/rootfs/etc/profile.d/_60-register-stray-shells.sh
+++ b/rootfs/etc/profile.d/_60-register-stray-shells.sh
@@ -19,13 +19,13 @@
 
 if [[ $$ != 1 ]] && [[ $PPID == 0 ]] && [[ -z $G_HOST_PID ]]; then
 	export G_HOST_PID=0
-	[[ -t 0 ]] && yellow '# Detected shell launched by `docker exec` without wrapper info, tracking as stray shell.'
+	[[ -t 0 ]] && yellow '# Detected shell launched by `docker exec` without wrapper info, tracking as stray shell.' >&2
 fi
 
 if [[ $$ == 1 ]] && ! [[ -t 0 ]] && [[ $# -eq 0 ]]; then
-	echo
-	echo "#  You have launched a login shell without a terminal and without a command."
-	echo "#  This is not supported. Please run a command or attach a terminal."
-	echo
+	echo >&2
+	echo "#  You have launched a login shell without a terminal and without a command." >&2
+	echo "#  This is not supported. Please run a command or attach a terminal." >&2
+	echo >&2
 	exit 1
 fi

--- a/rootfs/usr/local/bin/boot
+++ b/rootfs/usr/local/bin/boot
@@ -20,7 +20,7 @@ else
   color "########################################################################################"
   color "# Attach a terminal (docker run --rm --it ...) if you want to run a shell."
   color "#"
-  color "# Run the following to install the script that runs ${APP_NAME:-$(basename ${DOCKER_IMAGE:-Geodesic})} "
+  color "# Run the following to install the script that runs ${APP_NAME:-$(basename ${DOCKER_IMAGE:-Geodesic})}"
   color "# with all its features (the recommended way to use Geodesic):"
 fi
 

--- a/rootfs/usr/local/bin/boot
+++ b/rootfs/usr/local/bin/boot
@@ -19,6 +19,7 @@ else
   function color() { echo "$*"  >&2; }
   color "########################################################################################"
   color "# Attach a terminal (docker run --rm --it ...) if you want to run a shell."
+  color "#"
   color "# Run the following to install the script that runs ${APP_NAME:-$(basename ${DOCKER_IMAGE:-Geodesic})} "
   color "# with all its features (the recommended way to use Geodesic):"
 fi


### PR DESCRIPTION
## what

- `GEODESIC_DOCKER_EXTRA_ARGS` is deprecated. Geodesic distinguishes between options for launching a container
  and options for exec’ing into a running one. Use `GEODESIC_DOCKER_EXTRA_LAUNCH_ARGS` for container launch and
  `GEODESIC_DOCKER_EXTRA_EXEC_ARGS` for exec’ing into a running container.
- Add additional outputs to `--verbose` mode
- Minor cleanups for non-standard launch attempts

## why

- Some arguments only apply at launch time, while others my vary with each exec into the same container
- More clarity around options being passed to docker
- Catch a few more edge cases
