### PR TITLE
fix: correct syntax errors and typos in shell scripts

### DIFF
--- a/os/debian/Dockerfile.debian
+++ b/os/debian/Dockerfile.debian
@@ -5,7 +5,7 @@
 # bookworm-20241016 corresponds to Debian 12.7
 ARG DEBIAN_CODENAME=bookworm
 # Debian codenamed images are tagged with date codes rather than minor version numbers.
-ARG DEBAIN_DATECODE=20241223
+ARG DEBIAN_DATECODE=20241223
 # Find the current version of Python at https://www.python.org/downloads/source/
 ARG PYTHON_VERSION=3.12.8
 
@@ -61,7 +61,7 @@ RUN find / -xdev -name __pycache__ -exec rm -rf {} \; -prune
 #
 # Geodesic base image
 #
-FROM debian:${DEBIAN_CODENAME}-${DEBAIN_DATECODE}-slim
+FROM debian:${DEBIAN_CODENAME}-${DEBIAN_DATECODE}-slim
 
 ARG VERSION
 ENV GEODESIC_VERSION=$VERSION

--- a/rootfs/etc/profile.d/_10-colors.sh
+++ b/rootfs/etc/profile.d/_10-colors.sh
@@ -210,7 +210,7 @@ function _geodesic_tput_cache_init() {
 	done
 
 	# Bold is not a color, handle bold without color change separately
-	if [[ -n "$bold"} ]]; then
+	if [[ -n "$bold" ]]; then
 		_geodesic_tput_cache["bold"]=$(printf "\x01%s\x02" "$bold")
 		_geodesic_tput_cache["bold-off"]=$(printf "\x01%s\x02" "$bold_off")
 	fi

--- a/rootfs/etc/profile.d/_50-workspace.sh
+++ b/rootfs/etc/profile.d/_50-workspace.sh
@@ -14,7 +14,7 @@ function file_on_host() {
 	for path in "${GEODESIC_HOST_PATHS[@]}"; do
 		# Skip paths that are just slashes, or completely empty, which would match everything
 		[[ "$path" =~ ^/*$ ]] && continue
-		if [[ "$path" == "${file}/" || "${file}" == "$path"* ]]; then
+		if [[ "${file}" == "${path}" || "${file}" == "$path"* ]]; then
 			return 0
 		fi
 	done

--- a/rootfs/etc/profile.d/helm.sh
+++ b/rootfs/etc/profile.d/helm.sh
@@ -1,8 +1,8 @@
 if command -v helm >/dev/null; then
 	# Initialize auto-completion for whichever helm version is the installed default
 	# Suppress error message about KUBECONFIG not found or being world readable
-	if [[ -r $KUBECONFIG ]]; then
-		chmod 600 $KUBECONFIG
+	if [[ -r "$KUBECONFIG" ]]; then
+		chmod 600 "$KUBECONFIG"
 		source <(helm completion bash)
 	else
 		touch /tmp/kubecfg

--- a/rootfs/etc/profile.d/prompt.sh
+++ b/rootfs/etc/profile.d/prompt.sh
@@ -168,7 +168,7 @@ function geodesic_prompt() {
 		if [[ -n ${GEODESIC_TF_PROMPT_LINE} ]]; then
 			tf_prompt=" ${tf_mark} ${GEODESIC_TF_PROMPT_LINE}\n"
 		fi
-		if [[ GEODESIC_TF_PROMPT_ENABLED == "true" ]]; then
+		if [[ $GEODESIC_TF_PROMPT_ENABLED == "true" ]]; then
 			KUBE_PS1_PREFIX="$(yellow-n "cluster:")("
 		fi
 	fi


### PR DESCRIPTION
## why

- This includes several minor fixes and improvements to shell scripts and the Debian Dockerfile to address typos and improve code correctness. The changes focus on correcting environment variable usage, fixing typos in argument names, and improving conditional checks.

## what

* Fixed a typo in the `ARG` definition by renaming `DEBAIN_DATECODE` to `DEBIAN_DATECODE` in `os/debian/Dockerfile.debian`.
* Updated the `FROM` line to use the corrected `DEBIAN_DATECODE` argument.
* Corrected the conditional check for bold formatting in `_geodesic_tput_cache_init` by fixing the bracket placement in `rootfs/etc/profile.d/_10-colors.sh`.
* Improved path matching logic in `file_on_host` to correctly compare paths in `rootfs/etc/profile.d/_50-workspace.sh`.
* Fixed quoting and conditional checks for `KUBECONFIG` in the Helm initialization script in `rootfs/etc/profile.d/helm.sh`.
* Corrected the conditional check for `GEODESIC_TF_PROMPT_ENABLED` in `geodesic_prompt` in `rootfs/etc/profile.d/prompt.sh`.