### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,10 +30,10 @@ jobs:
         os: ['debian']
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       with:
         role-to-assume: ${{ vars.ECR_AWS_ROLE }}
         aws-region: ${{ env.AWS_REGION }}
@@ -98,7 +98,7 @@ jobs:
         fi
     - name: Prepare Metadata for Docker Images
       id: Metadata
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       env:
         DOCKER_METADATA_PR_HEAD_SHA: true
         DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
@@ -137,18 +137,18 @@ jobs:
 
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     - name: Login to DockerHub
       if: steps.prepare.outputs.publish == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: "Build and push docker image to DockerHub"
       id: docker_build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Drafts your next Release notes as Pull Requests are merged into "main"
-    - uses: release-drafter/release-drafter@v6
+    - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
       with:
         publish: false
         prerelease: false

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: mszostok/codeowners-validator@v0.7.1
       with:
         checks: "syntax,owners,duppatterns"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: mszostok/codeowners-validator@v0.7.1
       with:
         checks: "syntax,owners,duppatterns"

--- a/.github/workflows/vhs.yaml
+++ b/.github/workflows/vhs.yaml
@@ -19,7 +19,7 @@ jobs:
   vhs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
 
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.check.outputs.skip != 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: "Override Env and Define Commands for Geodesic Demo Purposes"
         if: steps.check.outputs.skip != 'true'
@@ -73,7 +73,7 @@ jobs:
           path: demo.tape
           install-fonts: true
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         if: steps.check.outputs.skip != 'true'
         id: auto-commit
         env:


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `actions/labeler@v5` → `@bf12e9b0...` `# v7.0.0`
  * `aws-actions/configure-aws-credentials@v4` → `@e6de0542...` `# v6.2.3`
  * `docker/build-push-action@v5` → `@53b7df96...` `# v7.3.0`
  * `docker/login-action@v3` → `@dbcb8138...` `# v4.6.0`
  * `docker/metadata-action@v5` → `@dc802804...` `# v6.2.0`
  * `docker/setup-buildx-action@v3` → `@bb05f3f5...` `# v4.2.0`
  * `docker/setup-qemu-action@v3` → `@96fe6ef7...` `# v4.2.0`
  * `release-drafter/release-drafter@v6` → `@34d80673...` `# v7.7.0`
  * `stefanzweifel/git-auto-commit-action@v5` → `@4a55954c...` `# v7.2.0`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## still on Node 20

* `charmbracelet/vhs-action@v2` — no Node 24 release exists yet
* `mszostok/codeowners-validator@v0.7.1` — Docker-based action, not affected by the Node runtime deprecation
